### PR TITLE
don't require coverage for abstract methods

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,13 @@
 [run]
 omit = src/envs/behavior.py
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    # per https://coverage.readthedocs.io/en/latest/config.html#syntax
+    pragma: no cover
+
+    # Don't complain about abstract methods, they aren't run
+    @abstractmethod
+    @abc.abstractmethod


### PR DESCRIPTION
it's fine to test that abstract methods are in fact abstract (so we can leave our current tests), but we should not require this.