### PR TITLE
move type check for Atom construction

### DIFF
--- a/src/nsrt_learning.py
+++ b/src/nsrt_learning.py
@@ -241,6 +241,12 @@ def unify_effects_and_options(
     and delete effects. Changes predicate names so that all are treated
     differently by utils.unify().
     """
+    if ([a.type for a in ground_option_args] !=
+        [a.type for a in lifted_option_args]):
+        # First, check if the option arguments match in number and type.
+        # If not, fail immediately.
+        return False, {}
+
     opt_arg_pred = Predicate("OPT-ARGS",
                              [a.type for a in ground_option_args],
                              _classifier=lambda s, o: False)  # dummy

--- a/src/nsrt_learning.py
+++ b/src/nsrt_learning.py
@@ -241,16 +241,10 @@ def unify_effects_and_options(
     and delete effects. Changes predicate names so that all are treated
     differently by utils.unify().
     """
-    if ([a.type for a in ground_option_args] !=
-        [a.type for a in lifted_option_args]):
-        # First, check if the option arguments match in number and type.
-        # If not, fail immediately.
-        return False, {}
-
-    opt_arg_pred = Predicate("OPT-ARGS",
-                             [a.type for a in ground_option_args],
-                             _classifier=lambda s, o: False)  # dummy
-    f_ground_option_args = frozenset({GroundAtom(opt_arg_pred,
+    ground_opt_arg_pred = Predicate("OPT-ARGS",
+                                    [a.type for a in ground_option_args],
+                                    _classifier=lambda s, o: False)  # dummy
+    f_ground_option_args = frozenset({GroundAtom(ground_opt_arg_pred,
                                                  ground_option_args)})
     new_ground_add_effects = utils.wrap_atom_predicates_ground(
         ground_add_effects, "ADD-")
@@ -259,7 +253,10 @@ def unify_effects_and_options(
         ground_delete_effects, "DEL-")
     f_new_ground_delete_effects = frozenset(new_ground_delete_effects)
 
-    f_lifted_option_args = frozenset({LiftedAtom(opt_arg_pred,
+    lifted_opt_arg_pred = Predicate("OPT-ARGS",
+                                    [a.type for a in lifted_option_args],
+                                    _classifier=lambda s, o: False)  # dummy
+    f_lifted_option_args = frozenset({LiftedAtom(lifted_opt_arg_pred,
                                                  lifted_option_args)})
     new_lifted_add_effects = utils.wrap_atom_predicates_lifted(
         lifted_add_effects, "ADD-")

--- a/src/structs.py
+++ b/src/structs.py
@@ -190,9 +190,6 @@ class Predicate:
     def __call__(self, entities: Sequence[_TypedEntity]) -> _Atom:
         """Convenience method for generating Atoms.
         """
-        assert len(entities) == self.arity
-        for ent, pred_type in zip(entities, self.types):
-            assert ent.is_instance(pred_type)
         if all(isinstance(ent, Variable) for ent in entities):
             return LiftedAtom(self, entities)
         if all(isinstance(ent, Object) for ent in entities):
@@ -247,6 +244,11 @@ class _Atom:
     """
     predicate: Predicate
     entities: Sequence[_TypedEntity]
+
+    def __post_init__(self):
+        assert len(self.entities) == self.predicate.arity
+        for ent, pred_type in zip(self.entities, self.predicate.types):
+            assert ent.is_instance(pred_type)
 
     @property
     def _str(self) -> str:

--- a/src/structs.py
+++ b/src/structs.py
@@ -245,7 +245,7 @@ class _Atom:
     predicate: Predicate
     entities: Sequence[_TypedEntity]
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         assert len(self.entities) == self.predicate.arity
         for ent, pred_type in zip(self.entities, self.predicate.types):
             assert ent.is_instance(pred_type)


### PR DESCRIPTION
This change allows the type checking to occur with both usages of Atom construction:
`pred([obj1])`
`Lifted/GroundAtom(pred, [obj1])`
whereas previously it was only occurring with the former.