### PR TITLE
fix subtle bug in grammar approach

### DIFF
--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -9,6 +9,7 @@ from predicators.src.approaches.grammar_search_invention_approach import \
 from predicators.src.envs import CoverEnv
 from predicators.src.structs import Type, Predicate, STRIPSOperator, State, \
     Action
+from predicators.src.nsrt_learning import segment_trajectory
 from predicators.src import utils
 
 
@@ -76,8 +77,10 @@ def test_count_positives_for_ops():
         # Test false positive.
         (states, actions, [{not_on([cup, plate])}, set()]),
     ]
+    segments = [seg for traj in pruned_atom_data
+                for seg in segment_trajectory(traj)]
 
-    num_true, num_false = _count_positives_for_ops(strips_ops, pruned_atom_data)
+    num_true, num_false = _count_positives_for_ops(strips_ops, segments)
     assert num_true == 1
     assert num_false == 1
 


### PR DESCRIPTION
I found this bug in investigating for Painting why `IsWet,IsDry` weren't getting selected when they are manually proposed (after ablation). After this fix, they are selected as expected.

When counting true positives and false positives, we should be looking at segments, not individual transitions within segments. The way that this issue was manifesting was that transitions within segments that had no change at the symbolic level were being counted as "true positives" for an operator that has empty effects. That operator was only arising for the empty candidate predicate set, so that empty set was getting a better score than the set containing `IsWet,IsDry`.