### PR TITLE
fix to nsrt learning unify

### DIFF
--- a/src/nsrt_learning.py
+++ b/src/nsrt_learning.py
@@ -129,8 +129,8 @@ def learn_strips_operators(segments: Sequence[Segment], verbose: bool = True,
     """
     # Partition the segments according to common effects.
     params: List[Sequence[Variable]] = []
-    option_vars: List[Tuple[Variable, ...]] = []
     parameterized_options: List[ParameterizedOption] = []
+    option_vars: List[Tuple[Variable, ...]] = []
     add_effects: List[Set[LiftedAtom]] = []
     delete_effects: List[Set[LiftedAtom]] = []
     partitions: List[Partition] = []
@@ -253,6 +253,9 @@ def unify_effects_and_options(
     differently by utils.unify().
     """
     # Can't unify if the parameterized options are different.
+    # Note, of course, we could directly check this in the loop above. But we
+    # want to keep all the unification logic in one place, even if it's trivial
+    # in this case.
     if ground_param_option != lifted_param_option:
         return False, {}
     ground_opt_arg_pred = Predicate("OPT-ARGS",

--- a/src/nsrt_learning.py
+++ b/src/nsrt_learning.py
@@ -245,8 +245,8 @@ def unify_effects_and_options(
         lifted_delete_effects: FrozenSet[LiftedAtom],
         ground_param_option: ParameterizedOption,
         lifted_param_option: ParameterizedOption,
-        ground_option_args: Tuple[Object,...],
-        lifted_option_args: Tuple[Variable,...]
+        ground_option_args: Tuple[Object, ...],
+        lifted_option_args: Tuple[Variable, ...]
 ) -> Tuple[bool, ObjToVarSub]:
     """Wrapper around utils.unify() that handles option arguments, add effects,
     and delete effects. Changes predicate names so that all are treated

--- a/tests/test_nsrt_learning.py
+++ b/tests/test_nsrt_learning.py
@@ -331,6 +331,19 @@ def test_unify_effects_and_options():
     # The following test is for an edge case where everything is identical
     # except for the name of the parameterized option. We do not want to
     # unify in this case.
+    # First, a unify that should succeed.
+    suc, sub = unify_effects_and_options(
+        frozenset(),
+        frozenset(),
+        frozenset(),
+        frozenset(),
+        param_option0,
+        param_option0,
+        (cup0, cup1),
+        (cup0, cup1))
+    assert suc
+    assert sub == {cup0: cup0, cup1: cup1}
+    # Now, a unify that should fail because of different parameterized options.
     param_option1 = ParameterizedOption(
         "dummy1", [cup_type], Box(0.1, 1, (1,)), lambda s, m, o, p: Action(p),
         lambda s, m, o, p: False, lambda s, m, o, p: False)

--- a/tests/test_nsrt_learning.py
+++ b/tests/test_nsrt_learning.py
@@ -304,6 +304,9 @@ def test_unify_effects_and_options():
     y = cup_type("?y")
     z = cup_type("?z")
     pred0 = Predicate("Pred0", [cup_type, cup_type], lambda s, o: False)
+    param_option0 = ParameterizedOption(
+        "dummy0", [cup_type], Box(0.1, 1, (1,)), lambda s, m, o, p: Action(p),
+        lambda s, m, o, p: False, lambda s, m, o, p: False)
     # Option0(cup0, cup1)
     ground_option_args = (cup0, cup1)
     # Pred0(cup1, cup2) true
@@ -319,7 +322,26 @@ def test_unify_effects_and_options():
         lifted_add_effects,
         ground_delete_effects,
         lifted_delete_effects,
+        param_option0,
+        param_option0,
         ground_option_args,
         lifted_option_args)
+    assert not suc
+    assert not sub
+    # The following test is for an edge case where everything is identical
+    # except for the name of the parameterized option. We do not want to
+    # unify in this case.
+    param_option1 = ParameterizedOption(
+        "dummy1", [cup_type], Box(0.1, 1, (1,)), lambda s, m, o, p: Action(p),
+        lambda s, m, o, p: False, lambda s, m, o, p: False)
+    suc, sub = unify_effects_and_options(
+        frozenset(),
+        frozenset(),
+        frozenset(),
+        frozenset(),
+        param_option0,
+        param_option1,
+        (cup0, cup1),
+        (cup0, cup1))
     assert not suc
     assert not sub


### PR DESCRIPTION
in the case where options are known, we should use the parameterizedoption (and not just the option vars) when unifying in nsrt learning.