### PR TITLE
always allow duplicates

### DIFF
--- a/src/approaches/grammar_search_invention_approach.py
+++ b/src/approaches/grammar_search_invention_approach.py
@@ -90,8 +90,7 @@ class _ForallClassifier(_NullaryClassifier):
     body: Predicate
 
     def _classify_state(self, s: State) -> bool:
-        for o in utils.get_object_combinations(set(s), self.body.types,
-                                               allow_duplicates=True):
+        for o in utils.get_object_combinations(set(s), self.body.types):
             if not self.body.holds(s, o):
                 return False
         return True

--- a/src/approaches/interactive_learning_approach.py
+++ b/src/approaches/interactive_learning_approach.py
@@ -126,8 +126,7 @@ class InteractiveLearningApproach(NSRTLearningApproach):
                     possible = [state.vec(choice)
                                 for choice in get_object_combinations(
                                                   list(state),
-                                                  pred.types,
-                                                  allow_duplicates=False)]
+                                                  pred.types)]
                     negatives = []
                     for ex in possible:
                         for pos in positive_examples:

--- a/src/sampler_learning.py
+++ b/src/sampler_learning.py
@@ -114,8 +114,7 @@ def _create_sampler_data(
                 continue
             var_types = [var.type for var in variables]
             objects = list(state)
-            for grounding in utils.get_object_combinations(
-                    objects, var_types, allow_duplicates=False):
+            for grounding in utils.get_object_combinations(objects, var_types):
                 # If we are currently at the partition that we're learning a
                 # sampler for, and this datapoint matches the actual grounding,
                 # add it to the positive data and continue.

--- a/src/utils.py
+++ b/src/utils.py
@@ -296,28 +296,16 @@ def get_all_groundings(atoms: FrozenSet[LiftedAtom],
     types = [var.type for var in sorted_variables]
     # NOTE: We WON'T use a generator here because that breaks lru_cache.
     result = []
-    # Allow duplicate arguments here because this is across all atoms.
-    # We'll handle within-atom duplicates below.
-    for choice in get_object_combinations(
-            objects, types, allow_duplicates=True):
+    for choice in get_object_combinations(objects, types):
         sub: VarToObjSub = dict(zip(sorted_variables, choice))
-        ground_atoms = set()
-        do_filter = False
-        for atom in atoms:
-            sub_for_atom = [sub[v] for v in atom.variables]
-            if len(sub_for_atom) != len(set(sub_for_atom)):
-                # Any individual atom can't have duplicate arguments.
-                do_filter = True
-            ground_atoms.add(atom.ground(sub))
-        if do_filter:
-            continue
+        ground_atoms = {atom.ground(sub) for atom in atoms}
         result.append((frozenset(ground_atoms), sub))
     return result
 
 
 def get_object_combinations(
-        objects: Collection[Object], types: Sequence[Type],
-        allow_duplicates: bool) -> Iterator[List[Object]]:
+        objects: Collection[Object], types: Sequence[Type]
+        ) -> Iterator[List[Object]]:
     """Get all combinations of objects satisfying the given types sequence.
     """
     sorted_objects = sorted(objects)
@@ -329,8 +317,6 @@ def get_object_combinations(
                 this_choices.append(obj)
         choices.append(this_choices)
     for choice in itertools.product(*choices):
-        if not allow_duplicates and len(set(choice)) != len(choice):
-            continue
         yield list(choice)
 
 
@@ -562,8 +548,7 @@ def abstract(state: State, preds: Collection[Predicate]) -> Set[GroundAtom]:
     """
     atoms = set()
     for pred in preds:
-        for choice in get_object_combinations(list(state), pred.types,
-                                              allow_duplicates=False):
+        for choice in get_object_combinations(list(state), pred.types):
             if pred.holds(state, choice):
                 atoms.add(GroundAtom(pred, choice))
     return atoms
@@ -573,13 +558,10 @@ def all_ground_operators(operator: STRIPSOperator,
                          objects: Collection[Object]
                          ) -> Set[_GroundSTRIPSOperator]:
     """Get all possible groundings of the given operator with the given objects.
-
-    NOTE: Duplicate arguments in ground operators are ALLOWED.
     """
     types = [p.type for p in operator.parameters]
     ground_operators = set()
-    for choice in get_object_combinations(objects, types,
-                                          allow_duplicates=True):
+    for choice in get_object_combinations(objects, types):
         ground_operators.add(operator.ground(tuple(choice)))
     return ground_operators
 
@@ -587,13 +569,10 @@ def all_ground_operators(operator: STRIPSOperator,
 def all_ground_nsrts(
         nsrt: NSRT, objects: Collection[Object]) -> Set[_GroundNSRT]:
     """Get all possible groundings of the given NSRT with the given objects.
-
-    NOTE: Duplicate arguments in ground NSRTs are ALLOWED.
     """
     types = [p.type for p in nsrt.parameters]
     ground_nsrts = set()
-    for choice in get_object_combinations(objects, types,
-                                          allow_duplicates=True):
+    for choice in get_object_combinations(objects, types):
         ground_nsrts.add(nsrt.ground(choice))
     return ground_nsrts
 
@@ -606,8 +585,7 @@ def all_ground_predicates(pred: Predicate,
     NOTE: Duplicate arguments in predicates are DISALLOWED.
     """
     return {GroundAtom(pred, choice)
-            for choice in get_object_combinations(objects, pred.types,
-                                                  allow_duplicates=False)}
+            for choice in get_object_combinations(objects, pred.types)}
 
 
 def all_possible_ground_atoms(state: State, preds: Set[Predicate]) \

--- a/tests/test_nsrt_learning.py
+++ b/tests/test_nsrt_learning.py
@@ -88,9 +88,9 @@ def test_learn_strips_operators():
     assert len(unknown_option_ops) == 1
     assert str(unknown_option_ops[0]) == """STRIPS-Op0:
     Parameters: [?x0:cup_type, ?x1:cup_type, ?x2:cup_type]
-    Preconditions: [Pred0(?x1:cup_type), Pred1(?x1:cup_type, ?x0:cup_type), Pred1(?x1:cup_type, ?x2:cup_type), Pred2(?x1:cup_type)]
-    Add Effects: [Pred0(?x0:cup_type), Pred0(?x2:cup_type), Pred1(?x0:cup_type, ?x1:cup_type), Pred1(?x0:cup_type, ?x2:cup_type), Pred1(?x2:cup_type, ?x0:cup_type), Pred1(?x2:cup_type, ?x1:cup_type), Pred2(?x0:cup_type), Pred2(?x2:cup_type)]
-    Delete Effects: [Pred0(?x1:cup_type), Pred1(?x1:cup_type, ?x0:cup_type), Pred1(?x1:cup_type, ?x2:cup_type), Pred2(?x1:cup_type)]"""  # pylint: disable=line-too-long
+    Preconditions: [Pred0(?x1:cup_type), Pred1(?x1:cup_type, ?x0:cup_type), Pred1(?x1:cup_type, ?x1:cup_type), Pred1(?x1:cup_type, ?x2:cup_type), Pred2(?x1:cup_type)]
+    Add Effects: [Pred0(?x0:cup_type), Pred0(?x2:cup_type), Pred1(?x0:cup_type, ?x0:cup_type), Pred1(?x0:cup_type, ?x1:cup_type), Pred1(?x0:cup_type, ?x2:cup_type), Pred1(?x2:cup_type, ?x0:cup_type), Pred1(?x2:cup_type, ?x1:cup_type), Pred1(?x2:cup_type, ?x2:cup_type), Pred2(?x0:cup_type), Pred2(?x2:cup_type)]
+    Delete Effects: [Pred0(?x1:cup_type), Pred1(?x1:cup_type, ?x0:cup_type), Pred1(?x1:cup_type, ?x1:cup_type), Pred1(?x1:cup_type, ?x2:cup_type), Pred2(?x1:cup_type)]"""  # pylint: disable=line-too-long
 
 
 def test_nsrt_learning_specific_nsrts():
@@ -127,9 +127,9 @@ def test_nsrt_learning_specific_nsrts():
     nsrt = nsrts.pop()
     assert str(nsrt) == """NSRT-Op0:
     Parameters: [?x0:cup_type, ?x1:cup_type, ?x2:cup_type]
-    Preconditions: [Pred0(?x1:cup_type), Pred1(?x1:cup_type, ?x0:cup_type), Pred1(?x1:cup_type, ?x2:cup_type), Pred2(?x1:cup_type)]
-    Add Effects: [Pred0(?x0:cup_type), Pred0(?x2:cup_type), Pred1(?x0:cup_type, ?x1:cup_type), Pred1(?x0:cup_type, ?x2:cup_type), Pred1(?x2:cup_type, ?x0:cup_type), Pred1(?x2:cup_type, ?x1:cup_type), Pred2(?x0:cup_type), Pred2(?x2:cup_type)]
-    Delete Effects: [Pred0(?x1:cup_type), Pred1(?x1:cup_type, ?x0:cup_type), Pred1(?x1:cup_type, ?x2:cup_type), Pred2(?x1:cup_type)]
+    Preconditions: [Pred0(?x1:cup_type), Pred1(?x1:cup_type, ?x0:cup_type), Pred1(?x1:cup_type, ?x1:cup_type), Pred1(?x1:cup_type, ?x2:cup_type), Pred2(?x1:cup_type)]
+    Add Effects: [Pred0(?x0:cup_type), Pred0(?x2:cup_type), Pred1(?x0:cup_type, ?x0:cup_type), Pred1(?x0:cup_type, ?x1:cup_type), Pred1(?x0:cup_type, ?x2:cup_type), Pred1(?x2:cup_type, ?x0:cup_type), Pred1(?x2:cup_type, ?x1:cup_type), Pred1(?x2:cup_type, ?x2:cup_type), Pred2(?x0:cup_type), Pred2(?x2:cup_type)]
+    Delete Effects: [Pred0(?x1:cup_type), Pred1(?x1:cup_type, ?x0:cup_type), Pred1(?x1:cup_type, ?x1:cup_type), Pred1(?x1:cup_type, ?x2:cup_type), Pred2(?x1:cup_type)]
     Option: ParameterizedOption(name='dummy', types=[])
     Option Variables: []"""
     # Test the learned samplers
@@ -159,9 +159,9 @@ def test_nsrt_learning_specific_nsrts():
     nsrt = nsrts.pop()
     assert str(nsrt) == """NSRT-Op0:
     Parameters: [?x0:cup_type, ?x1:cup_type, ?x2:cup_type]
-    Preconditions: [Pred0(?x1:cup_type), Pred1(?x1:cup_type, ?x0:cup_type), Pred1(?x1:cup_type, ?x2:cup_type), Pred2(?x1:cup_type)]
-    Add Effects: [Pred0(?x0:cup_type), Pred0(?x2:cup_type), Pred1(?x0:cup_type, ?x1:cup_type), Pred1(?x0:cup_type, ?x2:cup_type), Pred1(?x2:cup_type, ?x0:cup_type), Pred1(?x2:cup_type, ?x1:cup_type), Pred2(?x0:cup_type), Pred2(?x2:cup_type)]
-    Delete Effects: [Pred0(?x1:cup_type), Pred1(?x1:cup_type, ?x0:cup_type), Pred1(?x1:cup_type, ?x2:cup_type), Pred2(?x1:cup_type)]
+    Preconditions: [Pred0(?x1:cup_type), Pred1(?x1:cup_type, ?x0:cup_type), Pred1(?x1:cup_type, ?x1:cup_type), Pred1(?x1:cup_type, ?x2:cup_type), Pred2(?x1:cup_type)]
+    Add Effects: [Pred0(?x0:cup_type), Pred0(?x2:cup_type), Pred1(?x0:cup_type, ?x0:cup_type), Pred1(?x0:cup_type, ?x1:cup_type), Pred1(?x0:cup_type, ?x2:cup_type), Pred1(?x2:cup_type, ?x0:cup_type), Pred1(?x2:cup_type, ?x1:cup_type), Pred1(?x2:cup_type, ?x2:cup_type), Pred2(?x0:cup_type), Pred2(?x2:cup_type)]
+    Delete Effects: [Pred0(?x1:cup_type), Pred1(?x1:cup_type, ?x0:cup_type), Pred1(?x1:cup_type, ?x1:cup_type), Pred1(?x1:cup_type, ?x2:cup_type), Pred2(?x1:cup_type)]
     Option: ParameterizedOption(name='dummy', types=[])
     Option Variables: []"""
     # The following two tests check edge cases of unification with respect to

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -258,11 +258,11 @@ def test_abstract():
     assert len(wrapped) == len(lifted_atoms)
     for atom in wrapped:
         assert atom.predicate.name.startswith("TEST-PREFIX-L-")
-    assert len(atoms) == 3
+    assert len(atoms) == 4
     assert atoms == {pred1([cup, plate1]),
                      pred1([cup, plate2]),
-                     # predicates with duplicate arguments are filtered out
-                     pred2([cup, plate1, plate2])}
+                     pred2([cup, plate1, plate2]),
+                     pred2([cup, plate2, plate2])}
 
 
 def test_powerset():
@@ -417,9 +417,8 @@ def test_get_all_groundings():
         all_groundings = list(utils.get_all_groundings(lifted_atoms, objs))
     assert time.time()-start_time < 1, "Should be fast due to caching"
     # For pred1, there are 12 groundings (3 cups * 4 plates).
-    # Pred2 adds on 3 options for plate_var2 (it can't be the same as
-    # plate_var1), bringing the total to 36.
-    assert len(all_groundings) == 36
+    # Pred2 adds on 4 options for plate_var2, bringing the total to 48.
+    assert len(all_groundings) == 48
     for grounding, sub in all_groundings:
         assert len(grounding) == len(lifted_atoms)
         assert len(sub) == 3  # three variables
@@ -431,9 +430,8 @@ def test_get_all_groundings():
         all_groundings = list(utils.get_all_groundings(lifted_atoms, objs))
     assert time.time()-start_time < 1, "Should be fast due to caching"
     # For pred1, there are 12 groundings (3 cups * 4 plates).
-    # Pred2 adds on 4*3 options (plate_var2 and plate_var3 can't be the same),
-    # bringing the total to 12*12.
-    assert len(all_groundings) == 12*12
+    # Pred2 adds on 4*4 options, bringing the total to 12*16.
+    assert len(all_groundings) == 12*16
     for grounding, sub in all_groundings:
         assert len(grounding) == len(lifted_atoms)
         assert len(sub) == 4  # four variables


### PR DESCRIPTION
it's confusing to allow duplicates in operator/nsrt parameters but not within predicates. I want to purge `allow_duplicates=False`.

what led me down this path was a weird binary predicate being learned by the grammar approach in blocks. after digging for a long time, I realized that the predicate was basically acting as `neq` to enforce that operator parameters were different. I want to avoid similar misadventures in the future.

`allow_duplicates=True` is also consistent with standard first-order logic semantics. and we can always capture the same behavior by introducing an explicit `neq` predicate.

I verified that oracle and nsrt_learning still work as expected for cover, blocks, and painting.