### PR TITLE
refactor to make environments provide a generator over training task lists

### DIFF
--- a/src/approaches/__init__.py
+++ b/src/approaches/__init__.py
@@ -43,36 +43,29 @@ def create_approach(name: str,
                     initial_predicates: Set[Predicate],
                     initial_options: Set[ParameterizedOption],
                     types: Set[Type],
-                    action_space: Box,
-                    train_tasks: List[Task]) -> BaseApproach:
+                    action_space: Box) -> BaseApproach:
     """Create an approach given its name.
     """
     if name == "oracle":
         return OracleApproach(simulator, initial_predicates,
-                              initial_options, types, action_space,
-                              train_tasks)
+                              initial_options, types, action_space)
     if name == "random_actions":
         return RandomActionsApproach(simulator, initial_predicates,
-                                     initial_options, types, action_space,
-                                     train_tasks)
+                                     initial_options, types, action_space)
     if name == "random_options":
         return RandomOptionsApproach(simulator, initial_predicates,
-                                     initial_options, types, action_space,
-                                     train_tasks)
+                                     initial_options, types, action_space)
     if name == "nsrt_learning":
         return NSRTLearningApproach(simulator, initial_predicates,
-                                    initial_options, types, action_space,
-                                    train_tasks)
+                                    initial_options, types, action_space)
     if name == "interactive_learning":
         return InteractiveLearningApproach(simulator, initial_predicates,
-                                           initial_options, types, action_space,
-                                           train_tasks)
+                                           initial_options, types, action_space)
     if name == "iterative_invention":
         return IterativeInventionApproach(simulator, initial_predicates,
-                                          initial_options, types, action_space,
-                                          train_tasks)
+                                          initial_options, types, action_space)
     if name == "grammar_search_invention":
         return GrammarSearchInventionApproach(simulator, initial_predicates,
                                               initial_options, types,
-                                              action_space, train_tasks)
+                                              action_space)
     raise NotImplementedError(f"Unknown env: {name}")

--- a/src/approaches/base_approach.py
+++ b/src/approaches/base_approach.py
@@ -17,8 +17,7 @@ class BaseApproach:
                  initial_predicates: Set[Predicate],
                  initial_options: Set[ParameterizedOption],
                  types: Set[Type],
-                 action_space: Box,
-                 train_tasks: List[Task]) -> None:
+                 action_space: Box) -> None:
         """All approaches are initialized with only the necessary
         information about the environment.
         """
@@ -27,7 +26,6 @@ class BaseApproach:
         self._initial_options = initial_options
         self._types = types
         self._action_space = action_space
-        self._train_tasks = train_tasks
         self._metrics: Metrics = defaultdict(float)
         self.seed(0)
 
@@ -64,8 +62,10 @@ class BaseApproach:
         self._rng = np.random.default_rng(self._seed)
         self._action_space.seed(seed)
 
-    def learn_from_offline_dataset(self, dataset: Dataset) -> None:
-        """Learning-based approaches can use an offline dataset.
+    def learn_from_offline_dataset(self, dataset: Dataset,
+                                   train_tasks: List[Task]) -> None:
+        """For learning-based approaches, learn whatever is needed from
+        the given dataset, which was generated from the given train_tasks.
         Also, should save whatever is necessary to load() later.
 
         Note: this is not an abc.abstractmethod because it does

--- a/src/approaches/grammar_search_invention_approach.py
+++ b/src/approaches/grammar_search_invention_approach.py
@@ -418,8 +418,8 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
         del dataset
         # Generate a candidate set of predicates.
         print("Generating candidate predicates...")
-        grammar = _create_grammar(CFG.grammar_search_grammar_name, self._dataset,
-                                  self._initial_predicates)
+        grammar = _create_grammar(CFG.grammar_search_grammar_name,
+                                  self._dataset, self._initial_predicates)
         candidates = grammar.generate(max_num=CFG.grammar_search_max_predicates)
         print(f"Done: created {len(candidates)} candidates:")
         for predicate in candidates:

--- a/src/approaches/grammar_search_invention_approach.py
+++ b/src/approaches/grammar_search_invention_approach.py
@@ -260,17 +260,17 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
                  initial_predicates: Set[Predicate],
                  initial_options: Set[ParameterizedOption],
                  types: Set[Type],
-                 action_space: Box,
-                 train_tasks: List[Task]) -> None:
+                 action_space: Box) -> None:
         super().__init__(simulator, initial_predicates, initial_options,
-                         types, action_space, train_tasks)
+                         types, action_space)
         self._learned_predicates: Set[Predicate] = set()
         self._num_inventions = 0
 
     def _get_current_predicates(self) -> Set[Predicate]:
         return self._initial_predicates | self._learned_predicates
 
-    def learn_from_offline_dataset(self, dataset: Dataset) -> None:
+    def learn_from_offline_dataset(self, dataset: Dataset,
+                                   train_tasks: List[Task]) -> None:
         # Generate a candidate set of predicates.
         print("Generating candidate predicates...")
         grammar = _create_grammar(CFG.grammar_search_grammar_name, dataset)

--- a/src/approaches/grammar_search_invention_approach.py
+++ b/src/approaches/grammar_search_invention_approach.py
@@ -264,7 +264,6 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
         super().__init__(simulator, initial_predicates, initial_options,
                          types, action_space)
         self._learned_predicates: Set[Predicate] = set()
-        self._dataset: Dataset = []
         self._num_inventions = 0
 
     def _get_current_predicates(self) -> Set[Predicate]:

--- a/src/approaches/interactive_learning_approach.py
+++ b/src/approaches/interactive_learning_approach.py
@@ -31,7 +31,6 @@ class InteractiveLearningApproach(NSRTLearningApproach):
         predicates_to_learn = initial_predicates - self._known_predicates
         self._teacher = _Teacher(initial_predicates, predicates_to_learn)
         # All seen data
-        self._dataset: Dataset = []
         self._dataset_with_atoms: List[GroundAtomTrajectory] = []
         # No cheating!
         self._predicates_to_learn = {strip_predicate(p)

--- a/src/approaches/interactive_learning_approach.py
+++ b/src/approaches/interactive_learning_approach.py
@@ -22,8 +22,7 @@ class InteractiveLearningApproach(NSRTLearningApproach):
                  initial_predicates: Set[Predicate],
                  initial_options: Set[ParameterizedOption],
                  types: Set[Type],
-                 action_space: Box,
-                 train_tasks: List[Task]) -> None:
+                 action_space: Box) -> None:
         # Predicates should not be ablated
         assert not CFG.excluded_predicates
         # Only the teacher is allowed to know about the initial predicates
@@ -39,7 +38,7 @@ class InteractiveLearningApproach(NSRTLearningApproach):
         del initial_predicates
         del predicates_to_learn
         super().__init__(simulator, self._predicates_to_learn, initial_options,
-                         types, action_space, train_tasks)
+                         types, action_space)
 
     def _get_current_predicates(self) -> Set[Predicate]:
         return self._known_predicates | self._predicates_to_learn
@@ -48,7 +47,8 @@ class InteractiveLearningApproach(NSRTLearningApproach):
         """Stores dataset and corresponding ground atom dataset."""
         self._dataset.extend(self._teacher.generate_data(dataset))
 
-    def learn_from_offline_dataset(self, dataset: Dataset) -> None:
+    def learn_from_offline_dataset(self, dataset: Dataset,
+                                   train_tasks: List[Task]) -> None:
         self._load_dataset(dataset)
         # Learn predicates and NSRTs
         self._relearn_predicates_and_nsrts()
@@ -57,8 +57,8 @@ class InteractiveLearningApproach(NSRTLearningApproach):
         for i in range(1, CFG.interactive_num_episodes+1):
             print(f"\nActive learning episode {i}")
             # Sample initial state from train tasks
-            index = self._rng.choice(len(self._train_tasks))
-            state = self._train_tasks[index].init
+            index = self._rng.choice(len(train_tasks))
+            state = train_tasks[index].init
             # Find policy for exploration
             task_list = glib_sample(state, self._get_current_predicates(),
                                     self._dataset)

--- a/src/approaches/interactive_learning_approach.py
+++ b/src/approaches/interactive_learning_approach.py
@@ -31,7 +31,8 @@ class InteractiveLearningApproach(NSRTLearningApproach):
         predicates_to_learn = initial_predicates - self._known_predicates
         self._teacher = _Teacher(initial_predicates, predicates_to_learn)
         # All seen data
-        self._dataset: List[GroundAtomTrajectory] = []
+        self._dataset: Dataset = []
+        self._dataset_with_atoms: List[GroundAtomTrajectory] = []
         # No cheating!
         self._predicates_to_learn = {strip_predicate(p)
                                      for p in predicates_to_learn}
@@ -44,12 +45,15 @@ class InteractiveLearningApproach(NSRTLearningApproach):
         return self._known_predicates | self._predicates_to_learn
 
     def _load_dataset(self, dataset: Dataset) -> None:
-        """Stores dataset and corresponding ground atom dataset."""
-        self._dataset.extend(self._teacher.generate_data(dataset))
+        """Stores dataset and corresponding ground atom dataset.
+        """
+        self._dataset.extend(dataset)
+        self._dataset_with_atoms.extend(self._teacher.generate_data(dataset))
 
     def learn_from_offline_dataset(self, dataset: Dataset,
                                    train_tasks: List[Task]) -> None:
         self._load_dataset(dataset)
+        del dataset
         # Learn predicates and NSRTs
         self._relearn_predicates_and_nsrts()
         # Active learning
@@ -61,7 +65,7 @@ class InteractiveLearningApproach(NSRTLearningApproach):
             state = train_tasks[index].init
             # Find policy for exploration
             task_list = glib_sample(state, self._get_current_predicates(),
-                                    self._dataset)
+                                    self._dataset_with_atoms)
             assert task_list
             task = task_list[0]
             for task in task_list:
@@ -93,7 +97,8 @@ class InteractiveLearningApproach(NSRTLearningApproach):
                     random_atom = ground_atoms[idx]
                     # Add this atom if it's a positive example
                     if self._ask_teacher(s, random_atom):
-                        self._dataset.append(([s], [], [{random_atom}]))
+                        self._dataset_with_atoms.append(
+                            ([s], [], [{random_atom}]))
                     # Still need to implement a way to use negative examples
                 # Relearn predicates and NSRTs
                 self._relearn_predicates_and_nsrts()
@@ -111,7 +116,7 @@ class InteractiveLearningApproach(NSRTLearningApproach):
             positive_examples = []
             negative_examples = []
             # Positive examples
-            for (states, _, ground_atom_sets) in self._dataset:
+            for (states, _, ground_atom_sets) in self._dataset_with_atoms:
                 assert len(states) == len(ground_atom_sets)
                 for (state, ground_atom_set) in zip(states, ground_atom_sets):
                     if len(ground_atom_set) == 0:
@@ -121,7 +126,7 @@ class InteractiveLearningApproach(NSRTLearningApproach):
                                  if ground_atom.predicate == pred]
                     positive_examples.extend(positives)
             # Negative examples - assume unlabeled is negative for now
-            for (states, _, _) in self._dataset:
+            for (states, _, _) in self._dataset_with_atoms:
                 for state in states:
                     possible = [state.vec(choice)
                                 for choice in get_object_combinations(
@@ -153,9 +158,7 @@ class InteractiveLearningApproach(NSRTLearningApproach):
                 (self._predicates_to_learn - {pred}) | {new_pred}
 
         # Learn NSRTs via superclass
-        # Reconstruct Dataset
-        dataset: Dataset = [(s, a) for (s, a, _) in self._dataset]
-        self._learn_nsrts(dataset)
+        self._learn_nsrts()
 
 
     def _get_states_to_ask(self, trajectories: Dataset) -> List[State]:
@@ -164,7 +167,7 @@ class InteractiveLearningApproach(NSRTLearningApproach):
         new_states = []
         for (ss, _) in trajectories:
             new_states.extend(ss)
-        scores = [score_goal(self._dataset,
+        scores = [score_goal(self._dataset_with_atoms,
                              utils.abstract(s, self._get_current_predicates()))
                   for s in new_states]
         if CFG.interactive_ask_strategy == "all_seen_states":

--- a/src/approaches/iterative_invention_approach.py
+++ b/src/approaches/iterative_invention_approach.py
@@ -25,17 +25,17 @@ class IterativeInventionApproach(NSRTLearningApproach):
                  initial_predicates: Set[Predicate],
                  initial_options: Set[ParameterizedOption],
                  types: Set[Type],
-                 action_space: Box,
-                 train_tasks: List[Task]) -> None:
+                 action_space: Box) -> None:
         super().__init__(simulator, initial_predicates, initial_options,
-                         types, action_space, train_tasks)
+                         types, action_space)
         self._learned_predicates: Set[Predicate] = set()
         self._num_inventions = 0
 
     def _get_current_predicates(self) -> Set[Predicate]:
         return self._initial_predicates | self._learned_predicates
 
-    def learn_from_offline_dataset(self, dataset: Dataset) -> None:
+    def learn_from_offline_dataset(self, dataset: Dataset,
+                                   train_tasks: List[Task]) -> None:
         # Use the current predicates to segment dataset.
         predicates = self._get_current_predicates()
         # Apply predicates to dataset.

--- a/src/approaches/iterative_invention_approach.py
+++ b/src/approaches/iterative_invention_approach.py
@@ -29,7 +29,6 @@ class IterativeInventionApproach(NSRTLearningApproach):
         super().__init__(simulator, initial_predicates, initial_options,
                          types, action_space)
         self._learned_predicates: Set[Predicate] = set()
-        self._dataset: Dataset = []
         self._num_inventions = 0
 
     def _get_current_predicates(self) -> Set[Predicate]:

--- a/src/approaches/nsrt_learning_approach.py
+++ b/src/approaches/nsrt_learning_approach.py
@@ -25,6 +25,7 @@ class NSRTLearningApproach(TAMPApproach):
         super().__init__(simulator, initial_predicates, initial_options, types,
                          action_space)
         self._nsrts: Set[NSRT] = set()
+        self._dataset: Dataset = []
 
     @property
     def is_learning_based(self) -> bool:
@@ -39,11 +40,13 @@ class NSRTLearningApproach(TAMPApproach):
         # The only thing we need to do here is learn NSRTs,
         # which we split off into a different function in case
         # subclasses want to make use of it.
-        self._learn_nsrts(dataset)
+        self._dataset.extend(dataset)
+        del dataset
+        self._learn_nsrts()
 
-    def _learn_nsrts(self, dataset: Dataset) -> None:
+    def _learn_nsrts(self) -> None:
         self._nsrts = learn_nsrts_from_data(
-            dataset, self._get_current_predicates(),
+            self._dataset, self._get_current_predicates(),
             do_sampler_learning=CFG.do_sampler_learning)
         save_path = get_save_path()
         with open(f"{save_path}.NSRTs", "wb") as f:

--- a/src/approaches/nsrt_learning_approach.py
+++ b/src/approaches/nsrt_learning_approach.py
@@ -21,10 +21,9 @@ class NSRTLearningApproach(TAMPApproach):
                  initial_predicates: Set[Predicate],
                  initial_options: Set[ParameterizedOption],
                  types: Set[Type],
-                 action_space: Box,
-                 train_tasks: List[Task]) -> None:
+                 action_space: Box) -> None:
         super().__init__(simulator, initial_predicates, initial_options, types,
-                         action_space, train_tasks)
+                         action_space)
         self._nsrts: Set[NSRT] = set()
 
     @property
@@ -35,7 +34,8 @@ class NSRTLearningApproach(TAMPApproach):
         assert self._nsrts, "NSRTs not learned"
         return self._nsrts
 
-    def learn_from_offline_dataset(self, dataset: Dataset) -> None:
+    def learn_from_offline_dataset(self, dataset: Dataset,
+                                   train_tasks: List[Task]) -> None:
         # The only thing we need to do here is learn NSRTs,
         # which we split off into a different function in case
         # subclasses want to make use of it.

--- a/src/approaches/tamp_approach.py
+++ b/src/approaches/tamp_approach.py
@@ -21,10 +21,9 @@ class TAMPApproach(BaseApproach):
                  initial_predicates: Set[Predicate],
                  initial_options: Set[ParameterizedOption],
                  types: Set[Type],
-                 action_space: Box,
-                 train_tasks: List[Task]) -> None:
+                 action_space: Box) -> None:
         super().__init__(simulator, initial_predicates, initial_options, types,
-                         action_space, train_tasks)
+                         action_space)
         self._option_model = create_option_model(
             CFG.option_model_name, self._simulator)
         self._num_calls = 0

--- a/src/approaches/tamp_approach.py
+++ b/src/approaches/tamp_approach.py
@@ -3,7 +3,7 @@ planning strategy: SEarch-and-SAMple planning, then Execution.
 """
 
 import abc
-from typing import Callable, Set, List
+from typing import Callable, Set
 from gym.spaces import Box
 from predicators.src.approaches import BaseApproach, ApproachFailure
 from predicators.src.planning import sesame_plan

--- a/src/datasets/__init__.py
+++ b/src/datasets/__init__.py
@@ -1,18 +1,21 @@
-"""Create offline datasets.
+"""Create offline datasets for training, given a set of training tasks
+for an environment.
 """
 
+from typing import List
 from predicators.src.envs import BaseEnv
-from predicators.src.structs import Dataset
+from predicators.src.structs import Dataset, Task
 from predicators.src.datasets.demo_only import create_demo_data
 from predicators.src.datasets.demo_replay import create_demo_replay_data
 from predicators.src.settings import CFG
 
 
-def create_dataset(env: BaseEnv) -> Dataset:
-    """Create offline datasets.
+def create_dataset(env: BaseEnv, train_tasks: List[Task]) -> Dataset:
+    """Create offline datasets for training, given a set of training tasks
+    for an environment.
     """
     if CFG.offline_data_method == "demo":
-        return create_demo_data(env)
+        return create_demo_data(env, train_tasks)
     if CFG.offline_data_method == "demo+replay":
-        return create_demo_replay_data(env)
+        return create_demo_replay_data(env, train_tasks)
     raise NotImplementedError("Unrecognized dataset method.")

--- a/src/datasets/demo_only.py
+++ b/src/datasets/demo_only.py
@@ -1,20 +1,19 @@
 """Create offline datasets by collecting demonstrations.
 """
 
+from typing import List
 from predicators.src.approaches import create_approach
 from predicators.src.envs import BaseEnv
-from predicators.src.structs import Dataset
+from predicators.src.structs import Dataset, Task
 from predicators.src.settings import CFG
 from predicators.src import utils
 
 
-def create_demo_data(env: BaseEnv) -> Dataset:
+def create_demo_data(env: BaseEnv, train_tasks: List[Task]) -> Dataset:
     """Create offline datasets by collecting demos.
     """
-    train_tasks = env.get_train_tasks()
     oracle_approach = create_approach("oracle", env.simulate,
-        env.predicates, env.options, env.types, env.action_space,
-        train_tasks)
+        env.predicates, env.options, env.types, env.action_space)
     dataset = []
     for task in train_tasks:
         policy = oracle_approach.solve(

--- a/src/datasets/demo_replay.py
+++ b/src/datasets/demo_replay.py
@@ -5,16 +5,16 @@ from typing import List
 import numpy as np
 from predicators.src.approaches.oracle_approach import get_gt_nsrts
 from predicators.src.envs import BaseEnv, EnvironmentFailure
-from predicators.src.structs import Dataset, _GroundNSRT
+from predicators.src.structs import Dataset, _GroundNSRT, Task
 from predicators.src.datasets.demo_only import create_demo_data
 from predicators.src.settings import CFG
 from predicators.src import utils
 
 
-def create_demo_replay_data(env: BaseEnv) -> Dataset:
+def create_demo_replay_data(env: BaseEnv, train_tasks: List[Task]) -> Dataset:
     """Create offline datasets by collecting demos and replaying.
     """
-    demo_dataset = create_demo_data(env)
+    demo_dataset = create_demo_data(env, train_tasks)
     # We will sample from states uniformly at random.
     # The reason for doing it this way, rather than combining
     # all states into one list, is that we want to compute

--- a/src/envs/base_env.py
+++ b/src/envs/base_env.py
@@ -2,7 +2,7 @@
 """
 
 import abc
-from typing import List, Set, Optional
+from typing import List, Set, Optional, Iterator
 import numpy as np
 from gym.spaces import Box
 from predicators.src.structs import State, Task, Predicate, \
@@ -24,8 +24,11 @@ class BaseEnv:
         raise NotImplementedError("Override me!")
 
     @abc.abstractmethod
-    def get_train_tasks(self) -> List[Task]:
-        """Get an ordered list of tasks for training.
+    def train_tasks_generator(self) -> Iterator[List[Task]]:
+        """A generator that produces ordered lists of tasks for training.
+        Useful as an offline mock of the idea of collecting more data
+        through exploration. The generator could, for instance, iterate
+        over various task families.
         """
         raise NotImplementedError("Override me!")
 

--- a/src/envs/behavior.py
+++ b/src/envs/behavior.py
@@ -5,7 +5,7 @@
 import functools
 import itertools
 import os
-from typing import List, Set, Optional, Dict, Callable, Sequence
+from typing import List, Set, Optional, Dict, Callable, Sequence, Iterator
 import numpy as np
 try:
     import bddl
@@ -63,13 +63,11 @@ class BehaviorEnv(BaseEnv):
         next_state = self._current_ig_state_to_state()
         return next_state
 
-    def get_train_tasks(self) -> List[Task]:
-        return self._get_tasks(num=CFG.num_train_tasks,
-                               rng=self._train_rng)
+    def train_tasks_generator(self) -> Iterator[List[Task]]:
+        yield self._get_tasks(num=CFG.num_train_tasks, rng=self._train_rng)
 
     def get_test_tasks(self) -> List[Task]:
-        return self._get_tasks(num=CFG.num_test_tasks,
-                               rng=self._test_rng)
+        return self._get_tasks(num=CFG.num_test_tasks, rng=self._test_rng)
 
     def _get_tasks(self, num: int,
                    rng: np.random.Generator) -> List[Task]:

--- a/src/envs/blocks.py
+++ b/src/envs/blocks.py
@@ -5,7 +5,7 @@ are much less than the table dimensions). The simplicity of this environment
 makes it a good testbed for predicate invention.
 """
 
-from typing import List, Set, Sequence, Dict, Tuple, Optional
+from typing import List, Set, Sequence, Dict, Tuple, Optional, Iterator
 import numpy as np
 from gym.spaces import Box
 from matplotlib import pyplot as plt
@@ -177,10 +177,10 @@ class BlocksEnv(BaseEnv):
         next_state.set(self._robot, "fingers", fingers)
         return next_state
 
-    def get_train_tasks(self) -> List[Task]:
-        return self._get_tasks(num_tasks=CFG.num_train_tasks,
-                               possible_num_blocks=self.num_blocks_train,
-                               rng=self._train_rng)
+    def train_tasks_generator(self) -> Iterator[List[Task]]:
+        yield self._get_tasks(num_tasks=CFG.num_train_tasks,
+                              possible_num_blocks=self.num_blocks_train,
+                              rng=self._train_rng)
 
     def get_test_tasks(self) -> List[Task]:
         return self._get_tasks(num_tasks=CFG.num_test_tasks,

--- a/src/envs/cluttered_table.py
+++ b/src/envs/cluttered_table.py
@@ -2,7 +2,7 @@
 planner's ability to handle failures reported by the environment.
 """
 
-from typing import List, Set, Sequence, Dict, Optional
+from typing import List, Set, Sequence, Dict, Optional, Iterator
 import matplotlib.pyplot as plt
 import numpy as np
 from gym.spaces import Box
@@ -107,13 +107,11 @@ class ClutteredTableEnv(BaseEnv):
         next_state.set(desired_can, "is_grasped", 1.0)
         return next_state
 
-    def get_train_tasks(self) -> List[Task]:
-        return self._get_tasks(num=CFG.num_train_tasks,
-                               train_or_test="train")
+    def train_tasks_generator(self) -> Iterator[List[Task]]:
+        yield self._get_tasks(num=CFG.num_train_tasks, train_or_test="train")
 
     def get_test_tasks(self) -> List[Task]:
-        return self._get_tasks(num=CFG.num_test_tasks,
-                               train_or_test="test")
+        return self._get_tasks(num=CFG.num_test_tasks, train_or_test="test")
 
     @property
     def predicates(self) -> Set[Predicate]:

--- a/src/envs/cover.py
+++ b/src/envs/cover.py
@@ -2,7 +2,7 @@
 won't ever fail), but it still requires backtracking.
 """
 
-from typing import List, Set, Sequence, Dict, Tuple, Optional
+from typing import List, Set, Sequence, Dict, Tuple, Optional, Iterator
 import matplotlib.pyplot as plt
 import numpy as np
 from gym.spaces import Box
@@ -93,13 +93,11 @@ class CoverEnv(BaseEnv):
                 next_state.set(held_block, "grasp", -1)
         return next_state
 
-    def get_train_tasks(self) -> List[Task]:
-        return self._get_tasks(num=CFG.num_train_tasks,
-                               rng=self._train_rng)
+    def train_tasks_generator(self) -> Iterator[List[Task]]:
+        yield self._get_tasks(num=CFG.num_train_tasks, rng=self._train_rng)
 
     def get_test_tasks(self) -> List[Task]:
-        return self._get_tasks(num=CFG.num_test_tasks,
-                               rng=self._test_rng)
+        return self._get_tasks(num=CFG.num_test_tasks, rng=self._test_rng)
 
     @property
     def predicates(self) -> Set[Predicate]:

--- a/src/envs/painting.py
+++ b/src/envs/painting.py
@@ -288,7 +288,7 @@ class PaintingEnv(BaseEnv):
                                       num_objs_lst=self.num_objs_train,
                                       rng=self._train_rng)
             else:
-                raise Exception(f"Unrecognized task family: {family_name}")
+                raise ValueError(f"Unrecognized task family: {family_name}")
 
     def get_test_tasks(self) -> List[Task]:
         return self._get_tasks(num_tasks=CFG.num_test_tasks,

--- a/src/main.py
+++ b/src/main.py
@@ -26,9 +26,9 @@ To run grammar search predicate invention (example):
 
 import time
 from predicators.src.settings import CFG
-from predicators.src.envs import create_env, EnvironmentFailure
+from predicators.src.envs import create_env, EnvironmentFailure, BaseEnv
 from predicators.src.approaches import create_approach, ApproachTimeout, \
-    ApproachFailure
+    ApproachFailure, BaseApproach
 from predicators.src.datasets import create_dataset
 from predicators.src import utils
 
@@ -54,21 +54,35 @@ def main() -> None:
     else:
         preds = env.predicates
     approach = create_approach(CFG.approach, env.simulate, preds,
-                               env.options, env.types, env.action_space,
-                               env.get_train_tasks())
+                               env.options, env.types, env.action_space)
     env.seed(CFG.seed)
     approach.seed(CFG.seed)
     env.action_space.seed(CFG.seed)
     for option in env.options:
         option.params_space.seed(CFG.seed)
-    # If approach is learning-based, get training datasets
+    # If approach is learning-based, get training datasets and do learning,
+    # testing after each learning call. Otherwise, just do testing.
     if approach.is_learning_based:
         if CFG.load:
             approach.load()
+            _run_testing(env, approach)
         else:
-            dataset = create_dataset(env)
-            approach.learn_from_offline_dataset(dataset)
-    # Run approach
+            # Iterate over the train_tasks lists coming from the generator.
+            # Add the data into one large dataset.
+            dataset_idx = 0
+            dataset = []
+            for train_tasks in env.train_tasks_generator():
+                dataset += create_dataset(env, train_tasks)
+                print(f"\n\nDATASET INDEX: {dataset_idx}")
+                dataset_idx += 1
+                approach.learn_from_offline_dataset(dataset, train_tasks)
+                _run_testing(env, approach)
+    else:
+        _run_testing(env, approach)
+    print(f"\n\nMain script terminated in {time.time()-start:.5f} seconds")
+
+
+def _run_testing(env: BaseEnv, approach: BaseApproach) -> None:
     test_tasks = env.get_test_tasks()
     num_solved = 0
     approach.reset_metrics()
@@ -96,7 +110,6 @@ def main() -> None:
         if CFG.make_videos:
             outfile = f"{utils.get_config_path_str()}__task{i}.mp4"
             utils.save_video(outfile, video)
-    print(f"\n\nMain script terminated in {time.time()-start:.5f} seconds")
     print(f"Tasks solved: {num_solved} / {len(test_tasks)}")
     print(f"Approach metrics: {approach.metrics}")
 

--- a/src/main.py
+++ b/src/main.py
@@ -68,11 +68,9 @@ def main() -> None:
             _run_testing(env, approach)
         else:
             # Iterate over the train_tasks lists coming from the generator.
-            # Add the data into one large dataset.
             dataset_idx = 0
-            dataset = []
             for train_tasks in env.train_tasks_generator():
-                dataset += create_dataset(env, train_tasks)
+                dataset = create_dataset(env, train_tasks)
                 print(f"\n\nDATASET INDEX: {dataset_idx}")
                 dataset_idx += 1
                 approach.learn_from_offline_dataset(dataset, train_tasks)

--- a/src/settings.py
+++ b/src/settings.py
@@ -24,6 +24,13 @@ class GlobalSettings:
     cluttered_table_can_radius = 0.01
     cluttered_table_collision_angle_thresh = np.pi / 4
 
+    # painting env parameters
+    painting_train_families = [
+        "box_and_shelf",  # placing into both box and shelf
+        # "box_only",  # just placing into the box
+        # "shelf_only",  # just placing into the shelf
+    ]
+
     # behavior env parameters
     behavior_config_file = os.path.join(  # relative to igibson.root_path
         "examples", "configs",

--- a/tests/approaches/test_base_approach.py
+++ b/tests/approaches/test_base_approach.py
@@ -53,7 +53,7 @@ def test_base_approach():
     options = {ParameterizedOption(
         "Move", [], params_space, _policy, _initiable=None, _terminal=None)}
     approach = BaseApproach(_simulator, predicates, options, types,
-                            action_space, train_tasks=set())
+                            action_space)
     approach.seed(123)
     goal = {pred1([cup, plate1])}
     task = Task(state, goal)
@@ -63,9 +63,9 @@ def test_base_approach():
     with pytest.raises(NotImplementedError):
         approach.solve(task, 500)
     approach = _DummyApproach(_simulator, predicates, options, types,
-                              action_space, train_tasks=set())
+                              action_space)
     assert not approach.is_learning_based
-    assert approach.learn_from_offline_dataset([]) is None
+    assert approach.learn_from_offline_dataset([], []) is None
     # Try solving with dummy approach.
     policy = approach.solve(task, 500)
     for _ in range(10):
@@ -81,12 +81,13 @@ def test_create_approach():
     for name in ["random_actions", "random_options", "oracle",
                  "nsrt_learning", "interactive_learning",
                  "iterative_invention"]:
-        utils.update_config({"env": "cover", "approach": name, "seed": 123})
+        utils.update_config({"env": "cover", "approach": name, "seed": 123,
+                             "excluded_predicates": ""})
         approach = create_approach(
             name, env.simulate, env.predicates, env.options, env.types,
-            env.action_space, env.get_train_tasks())
+            env.action_space)
         assert isinstance(approach, BaseApproach)
     with pytest.raises(NotImplementedError):
         create_approach(
             "Not a real approach", env.simulate, env.predicates,
-            env.options, env.types, env.action_space, env.get_train_tasks())
+            env.options, env.types, env.action_space)

--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -18,7 +18,7 @@ def test_predicate_grammar():
     """
     utils.update_config({"env": "cover"})
     env = CoverEnv()
-    train_task = env.get_train_tasks()[0]
+    train_task = next(env.train_tasks_generator())[0]
     state = train_task.init
     other_state = state.copy()
     robby = [o for o in state if o.type.name == "robot"][0]

--- a/tests/approaches/test_interactive_approach.py
+++ b/tests/approaches/test_interactive_approach.py
@@ -43,7 +43,8 @@ def test_create_teacher_dataset():
         "seed": 123,
     })
     env = CoverEnv()
-    dataset = create_dataset(env)
+    train_tasks = next(env.train_tasks_generator())
+    dataset = create_dataset(env, train_tasks)
     teacher_dataset = create_teacher_dataset(env.predicates, dataset)
     assert len(teacher_dataset) == 10
 
@@ -79,10 +80,11 @@ def test_interactive_learning_approach():
     env = CoverEnv()
     approach = _DummyInteractiveLearningApproach(
         env.simulate, env.predicates, env.options, env.types,
-        env.action_space, env.get_train_tasks())
-    dataset = create_dataset(env)
+        env.action_space)
+    train_tasks = next(env.train_tasks_generator())
+    dataset = create_dataset(env, train_tasks)
     assert approach.is_learning_based
-    approach.learn_from_offline_dataset(dataset)
+    approach.learn_from_offline_dataset(dataset, train_tasks)
     for task in env.get_test_tasks():
         try:
             approach.solve(task, timeout=CFG.timeout)
@@ -109,8 +111,9 @@ def test_interactive_learning_approach_ask_strategies():
     env = CoverEnv()
     approach = _DummyInteractiveLearningApproach(
         env.simulate, env.predicates, env.options, env.types,
-        env.action_space, env.get_train_tasks())
-    dataset = create_dataset(env)
+        env.action_space)
+    train_tasks = next(env.train_tasks_generator())
+    dataset = create_dataset(env, train_tasks)
     assert approach.is_learning_based
     approach.load_dataset(dataset)
 
@@ -159,9 +162,10 @@ def test_interactive_learning_approach_no_ground_atoms():
     env = CoverEnv()
     approach = _DummyInteractiveLearningApproach(
         env.simulate, env.predicates, env.options, env.types,
-        env.action_space, env.get_train_tasks())
-    dataset = create_dataset(env)
+        env.action_space)
+    train_tasks = next(env.train_tasks_generator())
+    dataset = create_dataset(env, train_tasks)
     assert approach.is_learning_based
     # MLP training fails since there are 0 positive examples
     with pytest.raises(RuntimeError):
-        approach.learn_from_offline_dataset(dataset)
+        approach.learn_from_offline_dataset(dataset, train_tasks)

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -33,10 +33,11 @@ def _test_approach(env_name, approach_name, excluded_predicates="",
         preds = env.predicates
     approach = create_approach(approach_name,
         env.simulate, preds, env.options, env.types,
-        env.action_space, env.get_train_tasks())
-    dataset = create_dataset(env)
+        env.action_space)
+    train_tasks = next(env.train_tasks_generator())
+    dataset = create_dataset(env, train_tasks)
     assert approach.is_learning_based
-    approach.learn_from_offline_dataset(dataset)
+    approach.learn_from_offline_dataset(dataset, train_tasks)
     task = env.get_test_tasks()[0]
     if try_solving:
         approach.solve(task, timeout=CFG.timeout)
@@ -45,7 +46,7 @@ def _test_approach(env_name, approach_name, excluded_predicates="",
     # Now test loading NSRTs & predicates.
     approach2 = create_approach(approach_name,
         env.simulate, preds, env.options, env.types,
-        env.action_space, env.get_train_tasks())
+        env.action_space)
     approach2.load()
     if try_solving:
         approach2.solve(task, timeout=CFG.timeout)

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -14,6 +14,8 @@ def _test_approach(env_name, approach_name, excluded_predicates="",
     """
     utils.flush_cache()  # Some extremely nasty bugs arise without this.
     utils.update_config({"env": env_name, "approach": approach_name,
+                         "seed": 12345})
+    utils.update_config({"env": env_name, "approach": approach_name,
                          "timeout": 10, "max_samples_per_step": 10,
                          "seed": 12345, "regressor_max_itr": 200,
                          "classifier_max_itr_sampler": 200,

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -24,7 +24,7 @@ def test_cover_get_gt_nsrts():
     assert pick_nsrt.name == "Pick"
     assert place_nsrt.name == "Place"
     env.seed(123)
-    train_task = env.get_train_tasks()[0]
+    train_task = next(env.train_tasks_generator())[0]
     state = train_task.init
     block0, _, _, target0, _ = list(state)
     assert block0.name == "block0"
@@ -69,11 +69,11 @@ def test_oracle_approach_cover():
     env.seed(123)
     approach = OracleApproach(
         env.simulate, env.predicates, env.options, env.types,
-        env.action_space, env.get_train_tasks())
+        env.action_space)
     assert not approach.is_learning_based
     random_action = Action(env.action_space.sample())
     approach.seed(123)
-    for task in env.get_train_tasks():
+    for task in next(env.train_tasks_generator()):
         policy = approach.solve(task, timeout=500)
         assert utils.policy_solves_task(
             policy, task, env.simulate, env.predicates)
@@ -97,11 +97,11 @@ def test_oracle_approach_cover_typed_options():
     env.seed(123)
     approach = OracleApproach(
         env.simulate, env.predicates, env.options, env.types,
-        env.action_space, env.get_train_tasks())
+        env.action_space)
     assert not approach.is_learning_based
     random_action = Action(env.action_space.sample())
     approach.seed(123)
-    for task in env.get_train_tasks():
+    for task in next(env.train_tasks_generator()):
         policy = approach.solve(task, timeout=500)
         assert utils.policy_solves_task(
             policy, task, env.simulate, env.predicates)
@@ -125,11 +125,11 @@ def test_oracle_approach_cover_hierarchical_types():
     env.seed(123)
     approach = OracleApproach(
         env.simulate, env.predicates, env.options, env.types,
-        env.action_space, env.get_train_tasks())
+        env.action_space)
     assert not approach.is_learning_based
     random_action = Action(env.action_space.sample())
     approach.seed(123)
-    for task in env.get_train_tasks():
+    for task in next(env.train_tasks_generator()):
         policy = approach.solve(task, timeout=500)
         assert utils.policy_solves_task(
             policy, task, env.simulate, env.predicates)
@@ -153,11 +153,11 @@ def test_oracle_approach_cover_multistep_options():
     env.seed(123)
     approach = OracleApproach(
         env.simulate, env.predicates, env.options, env.types,
-        env.action_space, env.get_train_tasks())
+        env.action_space)
     assert not approach.is_learning_based
     random_action = Action(env.action_space.sample())
     approach.seed(123)
-    for task in env.get_train_tasks():
+    for task in next(env.train_tasks_generator()):
         policy = approach.solve(task, timeout=500)
         assert utils.policy_solves_task(
             policy, task, env.simulate, env.predicates)
@@ -185,8 +185,8 @@ def test_cluttered_table_get_gt_nsrts():
     assert dump_nsrt.name == "Dump"
     assert grasp_nsrt.name == "Grasp"
     env.seed(123)
-    for train_task in env.get_train_tasks():
-        state = train_task.init
+    for task in next(env.train_tasks_generator()):
+        state = task.init
         can0, can1, _, can3, _ = list(state)
         assert can0.name == "can0"
         assert can3.name == "can3"
@@ -218,10 +218,10 @@ def test_oracle_approach_cluttered_table():
     env.seed(123)
     approach = OracleApproach(
         env.simulate, env.predicates, env.options, env.types,
-        env.action_space, env.get_train_tasks())
+        env.action_space)
     assert not approach.is_learning_based
     approach.seed(123)
-    train_task = env.get_train_tasks()[0]
+    train_task = next(env.train_tasks_generator())[0]
     policy = approach.solve(train_task, timeout=500)
     assert utils.policy_solves_task(
         policy, train_task, env.simulate, env.predicates)
@@ -239,12 +239,12 @@ def test_oracle_approach_blocks():
     env.seed(123)
     approach = OracleApproach(
         env.simulate, env.predicates, env.options, env.types,
-        env.action_space, env.get_train_tasks())
+        env.action_space)
     assert not approach.is_learning_based
     approach.seed(123)
     # Test a couple of train tasks so that we get at least one which
     # requires resampling placement poses on the table.
-    for train_task in env.get_train_tasks()[:10]:
+    for train_task in next(env.train_tasks_generator())[:10]:
         policy = approach.solve(train_task, timeout=500)
         assert utils.policy_solves_task(
             policy, train_task, env.simulate, env.predicates)
@@ -262,10 +262,10 @@ def test_oracle_approach_painting():
     env.seed(123)
     approach = OracleApproach(
         env.simulate, env.predicates, env.options, env.types,
-        env.action_space, env.get_train_tasks())
+        env.action_space)
     assert not approach.is_learning_based
     approach.seed(123)
-    for train_task in env.get_train_tasks()[:2]:
+    for train_task in next(env.train_tasks_generator())[:2]:
         policy = approach.solve(train_task, timeout=500)
         assert utils.policy_solves_task(
             policy, train_task, env.simulate, env.predicates)

--- a/tests/approaches/test_random_actions_approach.py
+++ b/tests/approaches/test_random_actions_approach.py
@@ -13,11 +13,10 @@ def test_random_actions_approach():
                          "approach": "random_actions",
                          "seed": 123})
     env = CoverEnv()
-    tasks = env.get_train_tasks()
-    task = tasks[0]
+    task = next(env.train_tasks_generator())[0]
     approach = RandomActionsApproach(
         env.simulate, env.predicates, env.options, env.types,
-        env.action_space, env.get_train_tasks())
+        env.action_space)
     approach.seed(123)
     policy = approach.solve(task, 500)
     actions = []

--- a/tests/approaches/test_random_options_approach.py
+++ b/tests/approaches/test_random_options_approach.py
@@ -34,7 +34,7 @@ def test_random_options_approach():
     Solved = Predicate("Solved", [cup_type], _solved_classifier)
     approach = RandomOptionsApproach(
         _simulator, {Solved}, {parameterized_option}, {cup_type},
-        params_space, [])
+        params_space)
     task = Task(state, {Solved([cup])})
     approach.seed(123)
     policy = approach.solve(task, 500)
@@ -61,7 +61,7 @@ def test_random_options_approach():
         _terminal)
     approach = RandomOptionsApproach(
         _simulator, {Solved}, {parameterized_option2}, {cup_type},
-        params_space, [])
+        params_space)
     task = Task(state, {Solved([cup])})
     approach.seed(123)
     policy = approach.solve(task, 500)
@@ -73,7 +73,7 @@ def test_random_options_approach():
         lambda _1, _2, _3, _4: True)
     approach = RandomOptionsApproach(
         _simulator, {Solved}, {parameterized_option3}, {cup_type},
-        params_space, [])
+        params_space)
     task = Task(state, {Solved([cup])})
     approach.seed(123)
     policy = approach.solve(task, 500)

--- a/tests/approaches/test_tamp_approach.py
+++ b/tests/approaches/test_tamp_approach.py
@@ -12,7 +12,7 @@ def test_tamp_approach():
     env = CoverEnv()
     approach = TAMPApproach(
         env.simulate, env.predicates, env.options, env.types,
-        env.action_space, env.get_train_tasks())
-    for task in env.get_train_tasks():
+        env.action_space)
+    for task in next(env.train_tasks_generator()):
         with pytest.raises(NotImplementedError):
             approach.solve(task, timeout=500)

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -25,7 +25,8 @@ def test_demo_dataset():
         "num_train_tasks": 7,
     })
     env = CoverEnv()
-    dataset = create_dataset(env)
+    train_tasks = next(env.train_tasks_generator())
+    dataset = create_dataset(env, train_tasks)
     assert len(dataset) == 7
     assert len(dataset[0]) == 2
     assert len(dataset[0][0]) == 3
@@ -44,7 +45,8 @@ def test_demo_dataset():
         "num_train_tasks": 7,
     })
     env = CoverEnv()
-    dataset = create_dataset(env)
+    train_tasks = next(env.train_tasks_generator())
+    dataset = create_dataset(env, train_tasks)
     assert len(dataset) == 7
     assert len(dataset[0]) == 2
     assert len(dataset[0][0]) == 3
@@ -56,7 +58,7 @@ def test_demo_dataset():
         "offline_data_method": "not a real method",
     })
     with pytest.raises(NotImplementedError):
-        create_dataset(env)
+        create_dataset(env, train_tasks)
 
 
 def test_demo_replay_dataset():
@@ -74,7 +76,8 @@ def test_demo_replay_dataset():
         "num_train_tasks": 5,
     })
     env = CoverEnv()
-    dataset = create_dataset(env)
+    train_tasks = next(env.train_tasks_generator())
+    dataset = create_dataset(env, train_tasks)
     assert len(dataset) == 5 + 3
     assert len(dataset[-1]) == 2
     assert len(dataset[-1][0]) == 2
@@ -94,7 +97,8 @@ def test_demo_replay_dataset():
         "num_train_tasks": 5,
     })
     env = CoverEnv()
-    dataset = create_dataset(env)
+    train_tasks = next(env.train_tasks_generator())
+    dataset = create_dataset(env, train_tasks)
     assert len(dataset) == 5 + 3
     assert len(dataset[-1]) == 2
     assert len(dataset[-1][0]) == 2
@@ -113,7 +117,8 @@ def test_demo_replay_dataset():
         "num_train_tasks": 5,
     })
     env = ClutteredTableEnv()
-    dataset = create_dataset(env)
+    train_tasks = next(env.train_tasks_generator())
+    dataset = create_dataset(env, train_tasks)
     assert len(dataset[-1]) == 2
     assert len(dataset[-1][0]) == 2
     assert len(dataset[-1][1]) == 1

--- a/tests/envs/test_base_env.py
+++ b/tests/envs/test_base_env.py
@@ -21,7 +21,7 @@ def test_base_env():
     with pytest.raises(NotImplementedError):
         env.simulate(state, [1, 2])
     with pytest.raises(NotImplementedError):
-        env.get_train_tasks()
+        env.train_tasks_generator()
     with pytest.raises(NotImplementedError):
         env.get_test_tasks()
     with pytest.raises(NotImplementedError):

--- a/tests/envs/test_blocks.py
+++ b/tests/envs/test_blocks.py
@@ -1,6 +1,7 @@
 """Test cases for the blocks environment.
 """
 
+import pytest
 import numpy as np
 from predicators.src.envs import BlocksEnv
 from predicators.src import utils
@@ -12,9 +13,12 @@ def test_blocks():
     utils.update_config({"env": "blocks"})
     env = BlocksEnv()
     env.seed(123)
-    for task in env.get_train_tasks():
+    train_tasks_gen = env.train_tasks_generator()
+    for task in next(train_tasks_gen):
         for obj in task.init:
             assert len(obj.type.feature_names) == len(task.init[obj])
+    with pytest.raises(StopIteration):
+        next(train_tasks_gen)
     for task in env.get_test_tasks():
         for obj in task.init:
             assert len(obj.type.feature_names) == len(task.init[obj])
@@ -66,7 +70,7 @@ def test_blocks_failure_cases():
     block1 = block_type("block1")
     block2 = block_type("block2")
     robot = robot_type("robot")
-    task = env.get_train_tasks()[0]
+    task = next(env.train_tasks_generator())[0]
     state = task.init
     atoms = utils.abstract(state, env.predicates)
     assert OnTable([block0]) in atoms

--- a/tests/envs/test_cluttered_table.py
+++ b/tests/envs/test_cluttered_table.py
@@ -1,6 +1,7 @@
 """Test cases for the cluttered table environment.
 """
 
+import pytest
 import numpy as np
 from gym.spaces import Box
 from predicators.src.envs import ClutteredTableEnv
@@ -15,9 +16,12 @@ def test_cluttered_table():
     utils.update_config({"env": "cluttered_table"})
     env = ClutteredTableEnv()
     env.seed(123)
-    for task in env.get_train_tasks():
+    train_tasks_gen = env.train_tasks_generator()
+    for task in next(train_tasks_gen):
         for obj in task.init:
             assert len(obj.type.feature_names) == len(task.init[obj])
+    with pytest.raises(StopIteration):
+        next(train_tasks_gen)
     for task in env.get_test_tasks():
         for obj in task.init:
             assert len(obj.type.feature_names) == len(task.init[obj])

--- a/tests/envs/test_cover.py
+++ b/tests/envs/test_cover.py
@@ -1,6 +1,7 @@
 """Test cases for the cover environment.
 """
 
+import pytest
 import numpy as np
 from gym.spaces import Box
 from predicators.src.envs import CoverEnv, CoverEnvTypedOptions, \
@@ -15,9 +16,12 @@ def test_cover():
     utils.update_config({"env": "cover"})
     env = CoverEnv()
     env.seed(123)
-    for task in env.get_train_tasks():
+    train_tasks_gen = env.train_tasks_generator()
+    for task in next(train_tasks_gen):
         for obj in task.init:
             assert len(obj.type.feature_names) == len(task.init[obj])
+    with pytest.raises(StopIteration):
+        next(train_tasks_gen)
     for task in env.get_test_tasks():
         for obj in task.init:
             assert len(obj.type.feature_names) == len(task.init[obj])
@@ -84,9 +88,12 @@ def test_cover_typed_options():
     utils.update_config({"env": "cover"})
     env = CoverEnvTypedOptions()
     env.seed(123)
-    for task in env.get_train_tasks():
+    train_tasks_gen = env.train_tasks_generator()
+    for task in next(train_tasks_gen):
         for obj in task.init:
             assert len(obj.type.feature_names) == len(task.init[obj])
+    with pytest.raises(StopIteration):
+        next(train_tasks_gen)
     for task in env.get_test_tasks():
         for obj in task.init:
             assert len(obj.type.feature_names) == len(task.init[obj])
@@ -152,9 +159,12 @@ def test_cover_multistep_options():
     utils.update_config({"env": "cover_multistep_options"})
     env = CoverMultistepOptions()
     env.seed(123)
-    for task in env.get_train_tasks():
+    train_tasks_gen = env.train_tasks_generator()
+    for task in next(train_tasks_gen):
         for obj in task.init:
             assert len(obj.type.feature_names) == len(task.init[obj])
+    with pytest.raises(StopIteration):
+        next(train_tasks_gen)
     for task in env.get_test_tasks():
         for obj in task.init:
             assert len(obj.type.feature_names) == len(task.init[obj])

--- a/tests/envs/test_playroom.py
+++ b/tests/envs/test_playroom.py
@@ -3,7 +3,6 @@
 
 import pytest
 import numpy as np
-import pytest
 from predicators.src.envs import PlayroomEnv
 from predicators.src import utils
 from predicators.src.structs import Action, State

--- a/tests/envs/test_playroom.py
+++ b/tests/envs/test_playroom.py
@@ -1,6 +1,7 @@
 """Test cases for the boring room vs. playroom environment.
 """
 
+import pytest
 import numpy as np
 import pytest
 from predicators.src.envs import PlayroomEnv
@@ -13,9 +14,12 @@ def test_playroom():
     utils.update_config({"env": "playroom"})
     env = PlayroomEnv()
     env.seed(123)
-    for task in env.get_train_tasks():
+    train_tasks_gen = env.train_tasks_generator()
+    for task in next(train_tasks_gen):
         for obj in task.init:
             assert len(obj.type.feature_names) == len(task.init[obj])
+    with pytest.raises(StopIteration):
+        next(train_tasks_gen)
     for task in env.get_test_tasks():
         for obj in task.init:
             assert len(obj.type.feature_names) == len(task.init[obj])
@@ -47,7 +51,7 @@ def test_playroom_failure_cases():
     block0 = block_type("block0")
     block1 = block_type("block1")
     block2 = block_type("block2")
-    task = env.get_train_tasks()[0]
+    task = next(env.train_tasks_generator())[0]
     state = task.init
     atoms = utils.abstract(state, env.predicates)
     robot = None
@@ -143,7 +147,7 @@ def test_playroom_simulate_blocks():
     robot_type = [t for t in env.types if t.name == "robot"][0]
     block1 = block_type("block1")
     block2 = block_type("block2")
-    task = env.get_train_tasks()[0]
+    task = next(env.train_tasks_generator())[0]
     state = task.init
     robot = None
     for item in state:
@@ -190,7 +194,7 @@ def test_playroom_simulate_doors_and_dial():
     door4 = door_type("door4")
     door5 = door_type("door5")
     door6 = door_type("door6")
-    task = env.get_train_tasks()[0]
+    task = next(env.train_tasks_generator())[0]
     state = task.init
     robot = None
     dial = None
@@ -281,7 +285,7 @@ def test_playroom_options():
     door5 = door_type("door5")
     door6 = door_type("door6")
     dial = dial_type("dial")
-    task = env.get_train_tasks()[0]
+    task = next(env.train_tasks_generator())[0]
     state = task.init
     # Run through a specific plan of options.
     Pick = [o for o in env.options if o.name == "Pick"][0]
@@ -331,7 +335,7 @@ def test_playroom_action_sequence_video():
     env = PlayroomEnv()
     env.seed(123)
     # Run through a specific plan of low-level actions.
-    task = env.get_train_tasks()[0]
+    task = next(env.train_tasks_generator())[0]
     action_arrs = [
         # Pick up a block
         np.array([11.8, 18, 0.45, -0.15, 0]).astype(np.float32),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -62,6 +62,7 @@ def test_main():
     # Try learning (with too low hyperparameters to actually work).
     sys.argv = ["dummy", "--env", "cover", "--approach",
                 "nsrt_learning", "--seed", "123",
+                "--do_sampler_learning", "1",
                 "--classifier_max_itr_sampler", "10",
                 "--regressor_max_itr", "10",
                 "--timeout", "0.01"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -51,6 +51,10 @@ def test_main():
     sys.argv = ["dummy", "--env", "cover", "--approach", "oracle",
                 "--seed", "123", "--timeout", "0.001", "--num_test_tasks", "5"]
     main()
+    # Run actual main approach, but without sampler learning.
+    sys.argv = ["dummy", "--env", "cover", "--approach", "nsrt_learning",
+                "--seed", "123", "--do_sampler_learning", "0"]
+    main()
     # Try loading.
     sys.argv = ["dummy", "--env", "cover", "--approach", "nsrt_learning",
                 "--seed", "123", "--load"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -53,9 +53,8 @@ def test_main():
     main()
     # Try loading.
     sys.argv = ["dummy", "--env", "cover", "--approach", "nsrt_learning",
-                "--seed", "2348393", "--load"]
-    with pytest.raises(FileNotFoundError):
-        main()
+                "--seed", "123", "--load"]
+    main()
     # Try learning (with too low hyperparameters to actually work).
     sys.argv = ["dummy", "--env", "cover", "--approach",
                 "nsrt_learning", "--seed", "123",

--- a/tests/test_option_learning.py
+++ b/tests/test_option_learning.py
@@ -25,7 +25,8 @@ def test_known_options_option_learner():
                          "seed": 123,
                          "num_train_tasks": 3,
                          "do_option_learning": False})
-    dataset = create_demo_replay_data(env)
+    train_tasks = next(env.train_tasks_generator())
+    dataset = create_demo_replay_data(env, train_tasks)
     ground_atom_dataset = utils.create_ground_atom_dataset(
         dataset, env.predicates)
     for _, actions, _ in ground_atom_dataset:
@@ -71,7 +72,8 @@ def test_oracle_option_learner_cover():
                          "num_train_tasks": 3,
                          "do_option_learning": True,
                          "option_learner": "oracle"})
-    dataset = create_demo_replay_data(env)
+    train_tasks = next(env.train_tasks_generator())
+    dataset = create_demo_replay_data(env, train_tasks)
     ground_atom_dataset = utils.create_ground_atom_dataset(
         dataset, env.predicates)
     for _, actions, _ in ground_atom_dataset:
@@ -119,7 +121,8 @@ def test_oracle_option_learner_blocks():
                          "num_train_tasks": 3,
                          "do_option_learning": True,
                          "option_learner": "oracle"})
-    dataset = create_demo_replay_data(env)
+    train_tasks = next(env.train_tasks_generator())
+    dataset = create_demo_replay_data(env, train_tasks)
     ground_atom_dataset = utils.create_ground_atom_dataset(
         dataset, env.predicates)
     for _, actions, _ in ground_atom_dataset:

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -19,7 +19,7 @@ def test_sesame_plan():
     utils.update_config({"env": "cover"})
     env = CoverEnv()
     nsrts = get_gt_nsrts(env.predicates, env.options)
-    task = env.get_train_tasks()[0]
+    task = next(env.train_tasks_generator())[0]
     option_model = create_option_model(CFG.option_model_name, env.simulate)
     plan = sesame_plan(task, option_model, nsrts, env.predicates, 1, 123)
     assert len(plan) == 2
@@ -34,9 +34,9 @@ def test_sesame_plan_failures():
     option_model = create_option_model(CFG.option_model_name, env.simulate)
     approach = OracleApproach(
         env.simulate, env.predicates, env.options, env.types,
-        env.action_space, env.get_train_tasks())
+        env.action_space)
     approach.seed(123)
-    task = env.get_train_tasks()[0]
+    task = next(env.train_tasks_generator())[0]
     trivial_task = Task(task.init, set())
     policy = approach.solve(trivial_task, timeout=500)
     with pytest.raises(ApproachFailure):
@@ -99,7 +99,7 @@ def test_sesame_plan_uninitiable_option():
             nsrt.name+"UNINITIABLE", nsrt.parameters, nsrt.preconditions,
             nsrt.add_effects, nsrt.delete_effects, new_option,
             nsrt.option_vars, nsrt._sampler))
-    task = env.get_train_tasks()[0]
+    task = next(env.train_tasks_generator())[0]
     with pytest.raises(ApproachFailure) as e:
         # Planning should reach max_skeletons_optimized
         sesame_plan(task, option_model, new_nsrts,


### PR DESCRIPTION
Note: this PR touches a bunch of files.

I decided that it doesn't make much sense to have multiple test distributions, but this PR introduces functionality for allowing multiple train distributions. The key change is that `env.get_train_tasks` now becomes `env.train_tasks_generator`, which is a generator over lists of training tasks (e.g., the generator could iterate over different task families). This requires a cascade of changes, such as it no longer making sense for an Approach to take `train_tasks` in the `__init__` method, so I moved that argument into `learn_from_offline_dataset`.

main.py has been updated to loop over the train task lists, and create a dataset for each one. Each approach accumulates the datasets itself, over the multiple calls to `learn_from_offline_dataset`.

Functionality has been verified on the painting env with the change shown in the PR, where we first yield tasks of just placing into the box, and then yield tasks of just placing into the shelf. After training on the first task family, planning fails because we never learned an NSRT that has InShelf as an effect. After training on the second task family as well, planning succeeds.

@amburger66 Including you as a reviewer because I believe your file is the reason we are passing train_tasks to the approaches, hopefully this PR won't change the functionality of all that.

closes #160 