### PR TITLE
Add robot as another parameter to ground truth operators.

### DIFF
--- a/src/approaches/oracle_approach.py
+++ b/src/approaches/oracle_approach.py
@@ -35,7 +35,8 @@ def get_gt_nsrts(predicates: Set[Predicate],
     elif CFG.env == "cover_typed_options":
         nsrts = _get_cover_gt_nsrts(options_are_typed=True)
     elif CFG.env == "cover_multistep_options":
-        nsrts = _get_cover_gt_nsrts(options_are_typed=True, more_params=True,
+        nsrts = _get_cover_gt_nsrts(options_are_typed=True,
+                                    include_robot_in_holding=True,
                                     place_sampler_relative=True)
     elif CFG.env == "cluttered_table":
         nsrts = _get_cluttered_table_gt_nsrts()
@@ -88,7 +89,8 @@ def _get_options_by_names(env_name: str,
     return _get_from_env_by_names(env_name, names, "options")
 
 
-def _get_cover_gt_nsrts(options_are_typed: bool, more_params: bool = False,
+def _get_cover_gt_nsrts(options_are_typed: bool,
+                        include_robot_in_holding: bool = False,
                         place_sampler_relative: bool = False) -> Set[NSRT]:
     """Create ground truth NSRTs for CoverEnv.
     """
@@ -109,7 +111,7 @@ def _get_cover_gt_nsrts(options_are_typed: bool, more_params: bool = False,
     # Pick
     block = Variable("?block", block_type)
     robot = Variable("?robot", robot_type)
-    parameters = [block, robot] if more_params else [block]
+    parameters = [block, robot] if include_robot_in_holding else [block]
     if options_are_typed:
         option_vars = [block]
         option = Pick
@@ -117,14 +119,14 @@ def _get_cover_gt_nsrts(options_are_typed: bool, more_params: bool = False,
         option_vars = []
         option = PickPlace
     preconditions = {LiftedAtom(IsBlock, [block]), LiftedAtom(HandEmpty, [])}
-    if more_params:
+    if include_robot_in_holding:
         add_effects = {LiftedAtom(Holding, [block, robot])}
     else:
         add_effects = {LiftedAtom(Holding, [block])}
     delete_effects = {LiftedAtom(HandEmpty, [])}
     def pick_sampler(state: State, rng: np.random.Generator,
                      objs: Sequence[Object]) -> Array:
-        assert len(objs) == 2 if more_params else len(objs) == 1
+        assert len(objs) == 2 if include_robot_in_holding else len(objs) == 1
         b = objs[0]
         assert b.is_instance(block_type)
         if options_are_typed:
@@ -144,7 +146,8 @@ def _get_cover_gt_nsrts(options_are_typed: bool, more_params: bool = False,
 
     # Place
     target = Variable("?target", target_type)
-    parameters = [block, target, robot] if more_params else [block, target]
+    parameters = [block, target, robot] if include_robot_in_holding \
+        else [block, target]
     if options_are_typed:
         option_vars = [target]
         option = Place
@@ -154,7 +157,7 @@ def _get_cover_gt_nsrts(options_are_typed: bool, more_params: bool = False,
 
     add_effects = {LiftedAtom(HandEmpty, []),
                    LiftedAtom(Covers, [block, target])}
-    if more_params:
+    if include_robot_in_holding:
         preconditions = {LiftedAtom(IsBlock, [block]),
                      LiftedAtom(IsTarget, [target]),
                      LiftedAtom(Holding, [block, robot])}
@@ -166,7 +169,7 @@ def _get_cover_gt_nsrts(options_are_typed: bool, more_params: bool = False,
         delete_effects = {LiftedAtom(Holding, [block])}
     def place_sampler(state: State, rng: np.random.Generator,
                       objs: Sequence[Object]) -> Array:
-        assert len(objs) == 3 if more_params else len(objs) == 2
+        assert len(objs) == 3 if include_robot_in_holding else len(objs) == 2
         t = objs[1]
         assert t.is_instance(target_type)
         if place_sampler_relative:

--- a/src/approaches/oracle_approach.py
+++ b/src/approaches/oracle_approach.py
@@ -138,7 +138,6 @@ def _get_cover_gt_nsrts(options_are_typed: bool,
             ub = float(state.get(b, "pose") + state.get(b, "width")/2)
             ub = min(ub, 1.0)
         return np.array(rng.uniform(lb, ub, size=(1,)), dtype=np.float32)
-
     pick_nsrt = NSRT("Pick", parameters, preconditions,
                      add_effects, delete_effects, option,
                      option_vars, pick_sampler)
@@ -154,13 +153,12 @@ def _get_cover_gt_nsrts(options_are_typed: bool,
     else:
         option_vars = []
         option = PickPlace
-
     add_effects = {LiftedAtom(HandEmpty, []),
                    LiftedAtom(Covers, [block, target])}
     if include_robot_in_holding:
         preconditions = {LiftedAtom(IsBlock, [block]),
-                     LiftedAtom(IsTarget, [target]),
-                     LiftedAtom(Holding, [block, robot])}
+                         LiftedAtom(IsTarget, [target]),
+                         LiftedAtom(Holding, [block, robot])}
         delete_effects = {LiftedAtom(Holding, [block, robot])}
     else:
         preconditions = {LiftedAtom(IsBlock, [block]),

--- a/src/approaches/oracle_approach.py
+++ b/src/approaches/oracle_approach.py
@@ -124,7 +124,7 @@ def _get_cover_gt_nsrts(options_are_typed: bool, more_params: bool = False,
     delete_effects = {LiftedAtom(HandEmpty, [])}
     def pick_sampler(state: State, rng: np.random.Generator,
                      objs: Sequence[Object]) -> Array:
-        assert len(objs) == 2 if more_params else len(obs) == 1
+        assert len(objs) == 2 if more_params else len(objs) == 1
         b = objs[0]
         assert b.is_instance(block_type)
         if options_are_typed:

--- a/src/envs/cover.py
+++ b/src/envs/cover.py
@@ -641,7 +641,7 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
                     break
             # [is_block, is_target, width, x]
             data[target] = np.array([0.0, 1.0, width, x])
-        # [x, y, grip]
+        # [x, y, grip, holding]
         data[self._robot] = np.array([0.0, self.initial_robot_y, 0.0, -1.0])
         return State(data)
 
@@ -689,7 +689,7 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
                        p: Array) -> bool:
         # Pick is done when we're holding the desired object.
         del m, p  # unused
-        block = o[0]
+        block, = o
         return self._Holding_holds(s, [block, self._robot])
 
     def _Place_initiable(self, s: State, m: Dict, o: Sequence[Object],
@@ -751,7 +751,6 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
                 (state.get(targ, "x")-state.get(targ, "width")/10,
                  state.get(targ, "x")+state.get(targ, "width")/10))
         return hand_regions
-
 
     @staticmethod
     def _Holding_holds(state: State, objects: Sequence[Object]) -> bool:


### PR DESCRIPTION
Adds a robot as a parameter to the ground truth operators for multistep-cover and updates the holding predicate to check both the block and the robot state. After this change, the learned operators through nsrt_learning have the robot as one of their parameters. This is important for option learning. Our learned options need to be able to access the robot state, which can only be done if the learned operators have the robot as a parameter. 