### PR TITLE
Clip cover_multistep_options's option policies with limits of action space. 

### DIFF
--- a/src/envs/cover.py
+++ b/src/envs/cover.py
@@ -417,7 +417,7 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         # last dimension controls the gripper "magnet" or "vacuum".
         # Note that the bounds are relatively low, which necessitates
         # multi-step options.
-        lb, ub = CFG.action_space_limits
+        lb, ub = CFG.cover_multistep_action_limits
         return Box(lb, ub, (3,))
 
     def simulate(self, state: State, action: Action) -> State:
@@ -656,7 +656,7 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         y = s.get(self._robot, "y")
         desired_y = s.get(obj, "y")
         at_desired_y = abs(desired_y - y) < 1e-5
-        lb, ub = CFG.action_space_limits
+        lb, ub = CFG.cover_multistep_action_limits
         # If we're already above the object and prepared to pick,
         # then execute the pick (turn up the magnet).
         if at_desired_x and at_desired_y:
@@ -705,7 +705,7 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         y = s.get(self._robot, "y")
         desired_y = self.block_height + 1e-2
         at_desired_y = abs(desired_y - y) < 1e-5
-        lb, ub = CFG.action_space_limits
+        lb, ub = CFG.cover_multistep_action_limits
         # If we're already above the object and prepared to place,
         # then execute the place (turn down the magnet).
         if at_desired_x and at_desired_y:

--- a/src/envs/cover.py
+++ b/src/envs/cover.py
@@ -417,7 +417,8 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         # last dimension controls the gripper "magnet" or "vacuum".
         # Note that the bounds are relatively low, which necessitates
         # multi-step options.
-        return Box(-0.1, 0.1, (3,))
+        lb, ub = CFG.action_space_limits
+        return Box(lb, ub, (3,))
 
     def simulate(self, state: State, action: Action) -> State:
         # Since the action space is lower level, we need to write
@@ -655,22 +656,23 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         y = s.get(self._robot, "y")
         desired_y = s.get(obj, "y")
         at_desired_y = abs(desired_y - y) < 1e-5
+        lb, ub = CFG.action_space_limits
         # If we're already above the object and prepared to pick,
         # then execute the pick (turn up the magnet).
         if at_desired_x and at_desired_y:
             return Action(np.array([0., 0., 0.1], dtype=np.float32))
         # If we're above the object but not yet close enough, move down.
         if at_desired_x:
-            delta_y = np.clip(desired_y - y, -0.1, 0.1)
+            delta_y = np.clip(desired_y - y, lb, ub)
             return Action(np.array([0., delta_y, 0.], dtype=np.float32))
         # If we're not above the object, but we're at a safe height,
         # then move left/right.
         if y >= self.initial_robot_y:
-            delta_x = np.clip(desired_x - x, -0.1, 0.1)
+            delta_x = np.clip(desired_x - x, lb, ub)
             return Action(np.array([delta_x, 0., 0.], dtype=np.float32))
         # If we're not above the object, and we're not at a safe height,
         # then move up.
-        delta_y = np.clip(self.initial_robot_y+1e-2 - y, -0.1, 0.1)
+        delta_y = np.clip(self.initial_robot_y+1e-2 - y, lb, ub)
         return Action(np.array([0., delta_y, 0.], dtype=np.float32))
 
     def _Pick_terminal(self, s: State, m: Dict, o: Sequence[Object],
@@ -703,22 +705,23 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         y = s.get(self._robot, "y")
         desired_y = self.block_height + 1e-2
         at_desired_y = abs(desired_y - y) < 1e-5
+        lb, ub = CFG.action_space_limits
         # If we're already above the object and prepared to place,
         # then execute the place (turn down the magnet).
         if at_desired_x and at_desired_y:
             return Action(np.array([0., 0., -0.1], dtype=np.float32))
         # If we're above the object but not yet close enough, move down.
         if at_desired_x:
-            delta_y = np.clip(desired_y - y, -0.1, 0.1)
+            delta_y = np.clip(desired_y - y, lb, ub)
             return Action(np.array([0., delta_y, 0.1], dtype=np.float32))
         # If we're not above the object, but we're at a safe height,
         # then move left/right.
         if y >= self.initial_robot_y:
-            delta_x = np.clip(desired_x - x, -0.1, 0.1)
+            delta_x = np.clip(desired_x - x, lb, ub)
             return Action(np.array([delta_x, 0., 0.1], dtype=np.float32))
         # If we're not above the object, and we're not at a safe height,
         # then move up.
-        delta_y = np.clip(self.initial_robot_y+1e-2 - y, -0.1, 0.1)
+        delta_y = np.clip(self.initial_robot_y+1e-2 - y, lb, ub)
         return Action(np.array([0., delta_y, 0.1], dtype=np.float32))
 
     def _Place_terminal(self, s: State, m: Dict, o: Sequence[Object],

--- a/src/settings.py
+++ b/src/settings.py
@@ -18,6 +18,9 @@ class GlobalSettings:
     cover_block_widths = [0.1, 0.07]
     cover_target_widths = [0.05, 0.03]
 
+    # cover_multistep_options parameters
+    action_space_limits = [-np.inf, np.inf]
+
     # cluttered table env parameters
     cluttered_table_num_cans_train = 5
     cluttered_table_num_cans_test = 10

--- a/src/settings.py
+++ b/src/settings.py
@@ -19,7 +19,7 @@ class GlobalSettings:
     cover_target_widths = [0.05, 0.03]
 
     # cover_multistep_options parameters
-    action_space_limits = [-np.inf, np.inf]
+    cover_multistep_action_limits = [-np.inf, np.inf]
 
     # cluttered table env parameters
     cluttered_table_num_cans_train = 5

--- a/tests/envs/test_cover.py
+++ b/tests/envs/test_cover.py
@@ -175,7 +175,7 @@ def test_cover_multistep_options():
     # Types should be {block, target, robot}
     assert len(env.types) == 3
     # Action space should be 3-dimensional.
-    assert env.action_space == Box(-0.1, 0.1, (3,))
+    assert len(env.action_space.low) == 3
     # Run through a specific plan of low-level actions.
     task = env.get_test_tasks()[0]
     action_arrs = [


### PR DESCRIPTION
This allows for flexibility in defining variable step policies in cover_multistep_options because the Pick() and Place() ground truth option policies now clip the low-level-action by the bounds of the action space. If we want policies that take more steps to go from point to point, we can reduce the limits of the action space. 