### PR TITLE
repeated NextTo env

### DIFF
--- a/src/approaches/oracle_approach.py
+++ b/src/approaches/oracle_approach.py
@@ -43,6 +43,8 @@ def get_gt_nsrts(predicates: Set[Predicate],
         nsrts = _get_blocks_gt_nsrts()
     elif CFG.env == "painting":
         nsrts = _get_painting_gt_nsrts()
+    elif CFG.env == "repeated_nextto":
+        nsrts = _get_repeated_nextto_gt_nsrts()
     else:
         raise NotImplementedError("Ground truth NSRTs not implemented")
     # Filter out excluded predicates/options
@@ -535,5 +537,64 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         "OpenLid", parameters, preconditions, add_effects,
         delete_effects, option, option_vars, openlid_sampler)
     nsrts.add(openlid_nsrt)
+
+    return nsrts
+
+
+def _get_repeated_nextto_gt_nsrts() -> Set[NSRT]:
+    """Create ground truth NSRTs for RepeatedNextToEnv.
+    """
+    robot_type, dot_type = _get_types_by_names(CFG.env, ["robot", "dot"])
+
+    NextTo, NextToNothing, Grasped = _get_predicates_by_names(
+        CFG.env, ["NextTo", "NextToNothing", "Grasped"])
+
+    Move, Grasp = _get_options_by_names(CFG.env, ["Move", "Grasp"])
+
+    nsrts = set()
+
+    # Move from next to nothing
+    robot = Variable("?robot", robot_type)
+    targetdot = Variable("?targetdot", dot_type)
+    parameters = [robot, targetdot]
+    option_vars = [robot, targetdot]
+    option = Move
+    preconditions = {LiftedAtom(NextToNothing, [robot])}
+    add_effects = {LiftedAtom(NextTo, [robot, targetdot])}
+    delete_effects = {LiftedAtom(NextToNothing, [robot])}
+    move_nsrt1 = NSRT("MoveFromNextToNothing", parameters, preconditions,
+                      add_effects, delete_effects, option, option_vars,
+                      lambda s, rng, o: np.zeros(1, dtype=np.float32))
+    nsrts.add(move_nsrt1)
+
+    # Move from next to something
+    robot = Variable("?robot", robot_type)
+    targetdot = Variable("?targetdot", dot_type)
+    curdot = Variable("?curdot", dot_type)
+    parameters = [robot, targetdot, curdot]
+    option_vars = [robot, targetdot]
+    option = Move
+    preconditions = {LiftedAtom(NextTo, [robot, curdot])}
+    add_effects = {LiftedAtom(NextTo, [robot, targetdot])}
+    delete_effects = {LiftedAtom(NextTo, [robot, curdot])}
+    move_nsrt2 = NSRT("MoveFromNextToSomething", parameters, preconditions,
+                      add_effects, delete_effects, option, option_vars,
+                      lambda s, rng, o: np.zeros(1, dtype=np.float32))
+    nsrts.add(move_nsrt2)
+
+    # Grasp and end up next to nothing
+    robot = Variable("?robot", robot_type)
+    targetdot = Variable("?targetdot", dot_type)
+    parameters = [robot, targetdot]
+    option_vars = [robot, targetdot]
+    option = Grasp
+    preconditions = {LiftedAtom(NextTo, [robot, targetdot])}
+    add_effects = {LiftedAtom(Grasped, [robot, targetdot]),
+                   LiftedAtom(NextToNothing, [robot])}
+    delete_effects = {LiftedAtom(NextTo, [robot, targetdot])}
+    grasp_nsrt1 = NSRT("GraspEndUpNextToNothing", parameters, preconditions,
+                       add_effects, delete_effects, option, option_vars,
+                       lambda s, rng, o: np.zeros(0, dtype=np.float32))
+    nsrts.add(grasp_nsrt1)
 
     return nsrts

--- a/src/envs/__init__.py
+++ b/src/envs/__init__.py
@@ -9,6 +9,7 @@ from predicators.src.envs.cluttered_table import ClutteredTableEnv
 from predicators.src.envs.blocks import BlocksEnv
 from predicators.src.envs.painting import PaintingEnv
 from predicators.src.envs.playroom import PlayroomEnv
+from predicators.src.envs.repeated_nextto import RepeatedNextToEnv
 
 __all__ = [
     "BaseEnv",
@@ -22,6 +23,7 @@ __all__ = [
     "PaintingEnv",
     "PlayroomEnv",
     "BehaviorEnv",
+    "RepeatedNextToEnv",
 ]
 
 
@@ -46,4 +48,6 @@ def create_env(name: str) -> BaseEnv:
         return PlayroomEnv()
     if name == "behavior":
         return BehaviorEnv()  # pragma: no cover
+    if name == "repeated_nextto":
+        return RepeatedNextToEnv()
     raise NotImplementedError(f"Unknown env: {name}")

--- a/src/envs/repeated_nextto.py
+++ b/src/envs/repeated_nextto.py
@@ -1,0 +1,163 @@
+"""Toy environment for isolating and testing the issue of multiple
+instances of a predicate being in the effects of options. Here,
+the move option can turn on any number of NextTo predicates.
+"""
+
+from typing import List, Set, Sequence, Dict, Tuple, Optional, Iterator
+import numpy as np
+from gym.spaces import Box
+from predicators.src.envs import BaseEnv
+from predicators.src.structs import Type, Predicate, State, Task, \
+    ParameterizedOption, Object, Action, GroundAtom, Image, Array
+from predicators.src.settings import CFG
+from predicators.src import utils
+
+
+class RepeatedNextToEnv(BaseEnv):
+    """RepeatedNextToEnv environment definition. Simple 1D problem.
+    """
+    env_lb = 0.0
+    env_ub = 100.0
+    grasped_thresh = 0.5
+    # nextto_thresh = 10.0
+    nextto_thresh = 0.02  # TODO: remove
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Types
+        self._robot_type = Type("robot", ["x"])
+        self._dot_type = Type("dot", ["x", "grasped"])
+        # Predicates
+        self._NextTo = Predicate(
+            "NextTo", [self._robot_type, self._dot_type], self._NextTo_holds)
+        self._NextToNothing = Predicate(
+            "NextToNothing", [self._robot_type], self._NextToNothing_holds)
+        self._Grasped = Predicate(
+            "Grasped", [self._robot_type, self._dot_type], self._Grasped_holds)
+        # Options
+        self._Move = ParameterizedOption(
+            "Move", types=[self._robot_type, self._dot_type],
+            params_space=Box(-1, 1, (1,)),
+            _policy=self._Move_policy,
+            _initiable=utils.always_initiable,
+            _terminal=utils.onestep_terminal)
+        self._Grasp = ParameterizedOption(
+            "Grasp", types=[self._robot_type, self._dot_type],
+            params_space=Box(0, 1, (0,)),
+            _policy=self._Grasp_policy,
+            _initiable=utils.always_initiable,
+            _terminal=utils.onestep_terminal)
+        # Objects
+        self._dots = []
+        for i in range(CFG.repeated_nextto_num_dots):
+            self._dots.append(Object(f"dot{i}", self._dot_type))
+        self._robot = Object("robby", self._robot_type)
+
+    def simulate(self, state: State, action: Action) -> State:
+        assert self.action_space.contains(action.arr)
+        move_or_grasp, norm_robot_x, norm_dot_x = action.arr
+        next_state = state.copy()
+        if move_or_grasp < 0.5:
+            # move action
+            robot_x = norm_robot_x * (self.env_ub - self.env_lb) + self.env_lb
+            next_state.set(self._robot, "x", robot_x)
+        else:
+            # grasp action
+            dot_x = norm_dot_x * (self.env_ub - self.env_lb) + self.env_lb
+            dot_to_grasp = None
+            for dot in self._dots:
+                if abs(state.get(dot, "x") - dot_x) < 1e-4:
+                    assert dot_to_grasp is None
+                    dot_to_grasp = dot
+                    # don't break here, just to check the asserts fully
+            assert dot_to_grasp is not None
+            next_state.set(dot_to_grasp, "grasped", 1.0)
+        return next_state
+
+    def train_tasks_generator(self) -> Iterator[List[Task]]:
+        yield self._get_tasks(num=CFG.num_train_tasks, rng=self._train_rng)
+
+    def get_test_tasks(self) -> List[Task]:
+        return self._get_tasks(num=CFG.num_test_tasks, rng=self._test_rng)
+
+    @property
+    def predicates(self) -> Set[Predicate]:
+        return {self._NextTo, self._NextToNothing, self._Grasped}
+
+    @property
+    def goal_predicates(self) -> Set[Predicate]:
+        return {self._Grasped}
+
+    @property
+    def types(self) -> Set[Type]:
+        return {self._robot_type, self._dot_type}
+
+    @property
+    def options(self) -> Set[ParameterizedOption]:
+        return {self._Move, self._Grasp}
+
+    @property
+    def action_space(self) -> Box:
+        # First dimension is move (less than 0.5) or grasp (greater than 0.5).
+        # Second dimension is normalized new robot x (if first dim is move).
+        # Third dimension is normalized location of dot to grasp (if second
+        # dim is grasp). Normalization is [self.env_lb, self.env_ub] -> [0, 1].
+        return Box(0, 1, (3,))
+
+    def render(self, state: State, task: Task,
+               action: Optional[Action] = None) -> List[Image]:
+        import ipdb; ipdb.set_trace()
+
+    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[Task]:
+        tasks = []
+        goal1 = {GroundAtom(self._Grasped, [self._robot, self._dots[0]])}
+        goal2 = {GroundAtom(self._Grasped, [self._robot, self._dots[1]])}
+        goal3 = {GroundAtom(self._Grasped, [self._robot, self._dots[0]]),
+                 GroundAtom(self._Grasped, [self._robot, self._dots[1]])}
+        goals = [goal1, goal2, goal3]
+        for i in range(num):
+            data: Dict[Object, Array] = {}
+            for dot in self._dots:
+                dot_x = rng.uniform(self.env_lb, self.env_ub)
+                data[dot] = np.array([dot_x, 0.0])
+            robot_x = rng.uniform(self.env_lb, self.env_ub)
+            data[self._robot] = np.array([robot_x])
+            tasks.append(Task(State(data), goals[i%len(goals)]))
+        return tasks
+
+    def _Move_policy(self, state: State, memory: Dict,
+                     objects: Sequence[Object], params: Array) -> Action:
+        del memory  # unused
+        _, dot = objects
+        dot_x = state.get(dot, "x")
+        delta, = params
+        robot_x = max(min(self.env_ub, dot_x + delta), self.env_lb)
+        norm_robot_x = (robot_x - self.env_lb) / (self.env_ub - self.env_lb)
+        return Action(np.array([0, norm_robot_x, 0], dtype=np.float32))
+
+    def _Grasp_policy(self, state: State, memory: Dict,
+                      objects: Sequence[Object], params: Array) -> Action:
+        del memory, params  # unused
+        _, dot = objects
+        dot_x = state.get(dot, "x")
+        norm_dot_x = (dot_x - self.env_lb) / (self.env_ub - self.env_lb)
+        return Action(np.array([1, 0, norm_dot_x], dtype=np.float32))
+
+    def _NextTo_holds(self, state: State, objects: Sequence[Object]) -> bool:
+        robot, dot = objects
+        return (state.get(dot, "grasped") < self.grasped_thresh and
+                abs(state.get(robot, "x") -
+                    state.get(dot, "x")) < self.nextto_thresh)
+
+    def _NextToNothing_holds(self, state: State,
+                             objects: Sequence[Object]) -> bool:
+        robot, = objects
+        for obj in state:
+            if obj.type == self._dot_type and \
+               self._NextTo_holds(state, [robot, obj]):
+                return False
+        return True
+
+    def _Grasped_holds(self, state: State, objects: Sequence[Object]) -> bool:
+        _, dot = objects
+        return state.get(dot, "grasped") > self.grasped_thresh

--- a/src/settings.py
+++ b/src/settings.py
@@ -24,6 +24,9 @@ class GlobalSettings:
     cluttered_table_can_radius = 0.01
     cluttered_table_collision_angle_thresh = np.pi / 4
 
+    # repeated nextto env parameters
+    repeated_nextto_num_dots = 25
+
     # painting env parameters
     painting_train_families = [
         "box_and_shelf",  # placing into both box and shelf
@@ -130,6 +133,7 @@ class GlobalSettings:
                 "cluttered_table": 50,
                 "blocks": 50,
                 "painting": 50,
+                "repeated_nextto": 50,
                 "playroom": 50,
                 "behavior": 10,
             })[args["env"]],
@@ -143,6 +147,7 @@ class GlobalSettings:
                 "cluttered_table": 50,
                 "blocks": 50,
                 "painting": 50,
+                "repeated_nextto": 50,
                 "playroom": 50,
                 "behavior": 10,
             })[args["env"]],
@@ -157,6 +162,7 @@ class GlobalSettings:
                 "cluttered_table": 25,
                 "blocks": 25,
                 "painting": 100,
+                "repeated_nextto": 10,
                 "playroom": 25,
                 "behavior": 100,
             })[args["env"]],
@@ -170,6 +176,7 @@ class GlobalSettings:
                 "cluttered_table": "default",
                 "blocks": "default",
                 "painting": "default",
+                "repeated_nextto": "default",
             })[args["env"]],
 
             max_samples_per_step=defaultdict(int, {
@@ -180,6 +187,7 @@ class GlobalSettings:
                 "cluttered_table": 10,
                 "blocks": 10,
                 "painting": 1,
+                "repeated_nextto": 10,
                 "playroom": 10,
                 "behavior": 10,
             })[args["env"]],

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -7,7 +7,7 @@ from predicators.src.approaches import OracleApproach
 from predicators.src.approaches.oracle_approach import get_gt_nsrts
 from predicators.src.envs import CoverEnv, CoverEnvTypedOptions, \
     CoverEnvHierarchicalTypes, ClutteredTableEnv, EnvironmentFailure, \
-    BlocksEnv, PaintingEnv, CoverMultistepOptions
+    BlocksEnv, PaintingEnv, CoverMultistepOptions, RepeatedNextToEnv
 from predicators.src.structs import Action
 from predicators.src import utils
 
@@ -270,6 +270,27 @@ def test_oracle_approach_painting():
         assert utils.policy_solves_task(
             policy, train_task, env.simulate, env.predicates)
     for test_task in env.get_test_tasks()[:2]:
+        policy = approach.solve(test_task, timeout=500)
+        assert utils.policy_solves_task(
+            policy, test_task, env.simulate, env.predicates)
+
+
+def test_oracle_approach_repeated_nextto():
+    """Tests for OracleApproach class with RepeatedNextToEnv.
+    """
+    utils.update_config({"env": "repeated_nextto"})
+    env = RepeatedNextToEnv()
+    env.seed(123)
+    approach = OracleApproach(
+        env.simulate, env.predicates, env.options, env.types,
+        env.action_space)
+    assert not approach.is_learning_based
+    approach.seed(123)
+    for train_task in next(env.train_tasks_generator())[:3]:
+        policy = approach.solve(train_task, timeout=500)
+        assert utils.policy_solves_task(
+            policy, train_task, env.simulate, env.predicates)
+    for test_task in env.get_test_tasks()[:3]:
         policy = approach.solve(test_task, timeout=500)
         assert utils.policy_solves_task(
             policy, test_task, env.simulate, env.predicates)

--- a/tests/envs/test_base_env.py
+++ b/tests/envs/test_base_env.py
@@ -42,7 +42,8 @@ def test_create_env():
     """Tests for create_env.
     """
     for name in ["cover", "cover_typed_options", "cover_hierarchical_types",
-                 "cluttered_table", "blocks", "playroom", "painting"]:
+                 "cluttered_table", "blocks", "playroom", "painting",
+                 "repeated_nextto"]:
         env = create_env(name)
         assert isinstance(env, BaseEnv)
     with pytest.raises(NotImplementedError):

--- a/tests/envs/test_repeated_nextto.py
+++ b/tests/envs/test_repeated_nextto.py
@@ -1,0 +1,113 @@
+"""Test cases for the repeated NextTo environment.
+"""
+
+import pytest
+import numpy as np
+from predicators.src.envs import RepeatedNextToEnv
+from predicators.src.structs import Action
+from predicators.src import utils
+
+
+def test_repeated_nextto():
+    """Tests for RepeatedNextTo class.
+    """
+    env = RepeatedNextToEnv()
+    env.seed(123)
+    utils.update_config({"env": "repeated_nextto"})
+    train_tasks_gen = env.train_tasks_generator()
+    for task in next(train_tasks_gen):
+        for obj in task.init:
+            assert len(obj.type.feature_names) == len(task.init[obj])
+    with pytest.raises(StopIteration):
+        next(train_tasks_gen)
+    for task in env.get_test_tasks():
+        for obj in task.init:
+            assert len(obj.type.feature_names) == len(task.init[obj])
+    assert {pred.name for pred in env.predicates} == \
+        {"NextTo", "NextToNothing", "Grasped"}
+    assert {pred.name for pred in env.goal_predicates} == {"Grasped"}
+    assert len(env.options) == 2
+    assert len(env.types) == 2
+    dot_type = [t for t in env.types if t.name == "dot"][0]
+    robot_type = [t for t in env.types if t.name == "robot"][0]
+    assert env.action_space.shape == (3,)
+    for i, task in enumerate(env.get_test_tasks()):
+        state = task.init
+        for item in state:
+            x = state.get(item, "x")
+            assert env.env_lb <= x <= env.env_ub
+            if item.type == robot_type:
+                continue
+            assert 0 <= state.get(item, "grasped") <= 1
+        if i == 0:
+            # Test rendering by setting up a state that has
+            # a grasped dot and a dot next to the robot
+            dot0 = dot_type("dot0")
+            dot1 = dot_type("dot1")
+            robot = robot_type("robby")
+            state.set(robot, "x", state.get(dot0, "x"))
+            state.set(dot1, "grasped", 1.0)
+            env.render(state, task)
+
+def test_repeated_nextto_simulate():
+    """Tests for the simulate() function
+    """
+    utils.update_config({"env": "repeated_nextto",
+                         "approach": "nsrt_learning",
+                         "seed": 123})
+    env = RepeatedNextToEnv()
+    env.seed(123)
+    Move = [o for o in env.options if o.name == "Move"][0]
+    Grasp = [o for o in env.options if o.name == "Grasp"][0]
+    Grasped = [o for o in env.predicates if o.name == "Grasped"][0]
+    dot_type = [t for t in env.types if t.name == "dot"][0]
+    robot_type = [t for t in env.types if t.name == "robot"][0]
+    dot0 = dot_type("dot0")
+    dot1 = dot_type("dot1")
+    robby = robot_type("robby")
+    task = next(env.train_tasks_generator())[0]
+    state = task.init
+    atoms = utils.abstract(state, env.predicates)
+    for item in state:
+        if item != robby:
+            assert Grasped([robby, item]) not in atoms
+    # Move always succeeds, and clips back into bounds
+    midpt = (env.env_lb + env.env_ub) / 2
+    state.set(dot0, "x", midpt)
+    act = Move.ground([robby, dot0], np.array(
+        [1], dtype=np.float32)).policy(state)
+    next_state = env.simulate(state, act)
+    assert not state.allclose(next_state)
+    assert abs(next_state.get(robby, "x") - (midpt + 1)) < 1e-4
+    state.set(dot0, "x", env.env_lb)
+    act = Move.ground([robby, dot0], np.array(
+        [-1], dtype=np.float32)).policy(state)
+    next_state = env.simulate(state, act)
+    assert not state.allclose(next_state)
+    assert abs(next_state.get(robby, "x") - env.env_lb) < 1e-4
+    state.set(dot0, "x", env.env_ub)
+    act = Move.ground([robby, dot0], np.array(
+        [1], dtype=np.float32)).policy(state)
+    next_state = env.simulate(state, act)
+    assert not state.allclose(next_state)
+    assert abs(next_state.get(robby, "x") - env.env_ub) < 1e-4
+    # Move to dot1 and change the state
+    act = Move.ground([robby, dot1], np.array(
+        [0], dtype=np.float32)).policy(state)
+    next_state = env.simulate(state, act)
+    assert not state.allclose(next_state)
+    state = next_state
+    # Grasp success
+    act = Grasp.ground([robby, dot1], np.array(
+        [], dtype=np.float32)).policy(state)
+    next_state = env.simulate(state, act)
+    assert not state.allclose(next_state)
+    # Grasp fails if not at the argument dot
+    act = Grasp.ground([robby, dot0], np.array(
+        [], dtype=np.float32)).policy(state)
+    next_state = env.simulate(state, act)
+    assert state.allclose(next_state)
+    # Use Action directly for final failure mode: no dot at desired x
+    act = Action(np.array([1, 0, 0], dtype=np.float32))
+    next_state = env.simulate(state, act)
+    assert state.allclose(next_state)


### PR DESCRIPTION
Toy environment for isolating the problem of a robot being next to potentially differing numbers of things as it moves around an environment. Currently, both planning and learning work only because we have set the threshold for being next to an object to be very low, such that whp the robot is only next to one object at any given time. Increasing this `nextto_thresh = 0.02` threshold would quickly break planning (and learning).

closes #141 