### PR TITLE
rename DefaultOption -> DummyOption

### DIFF
--- a/src/approaches/random_options_approach.py
+++ b/src/approaches/random_options_approach.py
@@ -3,7 +3,7 @@
 
 from typing import Callable
 from predicators.src.approaches import BaseApproach
-from predicators.src.structs import State, Task, Action, DefaultOption
+from predicators.src.structs import State, Task, Action, DummyOption
 from predicators.src.settings import CFG
 from predicators.src import utils
 
@@ -17,11 +17,11 @@ class RandomOptionsApproach(BaseApproach):
 
     def _solve(self, task: Task, timeout: int) -> Callable[[State], Action]:
         options = sorted(self._initial_options, key=lambda o: o.name)
-        cur_option = DefaultOption
+        cur_option = DummyOption
         cur_option_ind = 0
         def _policy(state: State) -> Action:
             nonlocal cur_option, cur_option_ind
-            if cur_option is DefaultOption or cur_option.terminal(state):
+            if cur_option is DummyOption or cur_option.terminal(state):
                 for _ in range(CFG.random_options_max_tries):
                     param_opt = options[self._rng.choice(len(options))]
                     objs = utils.get_random_object_combination(

--- a/src/nsrt_learning.py
+++ b/src/nsrt_learning.py
@@ -6,7 +6,7 @@ from typing import Set, Tuple, List, Sequence, FrozenSet
 from predicators.src.structs import Dataset, STRIPSOperator, NSRT, \
     GroundAtom, LiftedAtom, Variable, Predicate, ObjToVarSub, \
     LowLevelTrajectory, Segment, Partition, Object, GroundAtomTrajectory, \
-    DefaultOption, ParameterizedOption, State, Action
+    DummyOption, ParameterizedOption, State, Action
 from predicators.src import utils
 from predicators.src.settings import CFG
 from predicators.src.sampler_learning import learn_samplers
@@ -163,7 +163,7 @@ def learn_strips_operators(segments: Sequence[Segment], verbose: bool = True,
             segment_param_option = segment_option.parent
             segment_option_objs = tuple(segment_option.objects)
         else:
-            segment_param_option = DefaultOption.parent
+            segment_param_option = DummyOption.parent
             segment_option_objs = tuple()
         for i in range(len(partitions)):
             # Try to unify this transition with existing effects.

--- a/src/planning.py
+++ b/src/planning.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field
 import numpy as np
 from predicators.src.approaches import ApproachFailure, ApproachTimeout
 from predicators.src.structs import State, Task, NSRT, Predicate, \
-    GroundAtom, _GroundNSRT, DefaultOption, DefaultState, _Option, \
+    GroundAtom, _GroundNSRT, DummyOption, DefaultState, _Option, \
     PyperplanFacts, Metrics
 from predicators.src import utils
 from predicators.src.envs import EnvironmentFailure
@@ -184,7 +184,7 @@ def _run_low_level_search(
         {"after_exhaust", "immediately", "never"}
     cur_idx = 0
     num_tries = [0 for _ in skeleton]
-    plan: List[_Option] = [DefaultOption for _ in skeleton]
+    plan: List[_Option] = [DummyOption for _ in skeleton]
     traj: List[State] = [task.init]+[DefaultState for _ in skeleton]
     # We'll use a maximum of one discovered failure per step, since
     # resampling can render old discovered failures obsolete.
@@ -243,7 +243,7 @@ def _run_low_level_search(
             assert cur_idx >= 0
             while num_tries[cur_idx] == CFG.max_samples_per_step:
                 num_tries[cur_idx] = 0
-                plan[cur_idx] = DefaultOption
+                plan[cur_idx] = DummyOption
                 traj[cur_idx+1] = DefaultState
                 cur_idx -= 1
                 if cur_idx < 0:

--- a/src/structs.py
+++ b/src/structs.py
@@ -439,11 +439,11 @@ class _Option:
         action.set_option(self)
         return action
 
-DefaultOption: _Option = ParameterizedOption(
+DummyOption: _Option = ParameterizedOption(
     "", [], Box(0, 1, (1,)), lambda s, m, o, p: Action(np.array([0.0])),
     lambda s, m, o, p: False, lambda s, m, o, p: False).ground(
         [], np.array([0.0]))
-DefaultOption.parent.params_space.seed(0)  # for reproducibility
+DummyOption.parent.params_space.seed(0)  # for reproducibility
 
 
 @dataclass(frozen=True, repr=False, eq=False)
@@ -709,7 +709,7 @@ class Action:
     float array that can optionally store the option which produced it.
     """
     _arr: Array
-    _option: _Option = field(repr=False, default=DefaultOption)
+    _option: _Option = field(repr=False, default=DummyOption)
 
     @property
     def arr(self) -> Array:
@@ -720,7 +720,7 @@ class Action:
     def has_option(self) -> bool:
         """Whether this action has a non-default option attached.
         """
-        return self._option is not DefaultOption
+        return self._option is not DummyOption
 
     def get_option(self) -> _Option:
         """Get the option that produced this action.
@@ -736,7 +736,7 @@ class Action:
     def unset_option(self) -> None:
         """Unset the option that produced this action.
         """
-        self._option = DefaultOption
+        self._option = DummyOption
         assert not self.has_option()
 
 
@@ -802,7 +802,7 @@ class Segment:
     trajectory: LowLevelTrajectory
     init_atoms: Set[GroundAtom]
     final_atoms: Set[GroundAtom]
-    _option: _Option = field(repr=False, default=DefaultOption)
+    _option: _Option = field(repr=False, default=DummyOption)
 
     def __post_init__(self) -> None:
         assert len(self.states) == len(self.actions) + 1
@@ -838,7 +838,7 @@ class Segment:
     def has_option(self) -> bool:
         """Whether this segment has a non-default option attached.
         """
-        return self._option is not DefaultOption
+        return self._option is not DummyOption
 
     def get_option(self) -> _Option:
         """Get the option that produced this segment.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,7 @@ import pytest
 import numpy as np
 from gym.spaces import Box
 from predicators.src.structs import State, Type, ParameterizedOption, \
-    Predicate, NSRT, Action, GroundAtom, DefaultOption, STRIPSOperator, \
+    Predicate, NSRT, Action, GroundAtom, DummyOption, STRIPSOperator, \
     LowLevelTrajectory
 from predicators.src.settings import CFG
 from predicators.src import utils
@@ -723,7 +723,7 @@ def test_create_ground_atom_dataset():
         State({cup1: [0.5], cup2: [0.1], plate1: [1.0], plate2: [1.2]}),
         State({cup1: [1.1], cup2: [0.1], plate1: [1.0], plate2: [1.2]})
     ]
-    actions = [DefaultOption]
+    actions = [DummyOption]
     dataset = [LowLevelTrajectory(states, actions)]
     ground_atom_dataset = utils.create_ground_atom_dataset(dataset, {on})
     assert len(ground_atom_dataset) == 1


### PR DESCRIPTION
It's a bit strange that DefaultOption and DefaultOptionModel were separate conceptual ideas. So, doing a simple renaming to make DummyOption sound more similar to DummyOptionModel, which are the same conceptual idea.