### PR TITLE
small update to painting env

### DIFF
--- a/src/envs/painting.py
+++ b/src/envs/painting.py
@@ -22,7 +22,7 @@ class PaintingEnv(BaseEnv):
     """
     # Parameters that aren't important enough to need to clog up settings.py
     table_lb = -10.1
-    table_ub = -0.2
+    table_ub = -0.35
     table_height = 0.2
     shelf_l = 2.0 # shelf length
     shelf_lb = 1.

--- a/src/envs/painting.py
+++ b/src/envs/painting.py
@@ -22,7 +22,7 @@ class PaintingEnv(BaseEnv):
     """
     # Parameters that aren't important enough to need to clog up settings.py
     table_lb = -10.1
-    table_ub = -0.35
+    table_ub = -1.0
     table_height = 0.2
     shelf_l = 2.0 # shelf length
     shelf_lb = 1.


### PR DESCRIPTION
This change allows 0.75 coming from the halving_constant_generator to work as a correct implementation of the OnTable predicate. Reasoning:
pose_y is in the range [-10.1, 2.95] which is the table_lb and the shelf_ub respectively. With a constant of 0.75, we get (2.95+10.1)*0.75-10.1 = -0.3125, so with this change, using `obj.pose_y <= -0.3125` as a predicate would represent OnTable.