### PR TITLE
do not modify frozen groundnsrts with notcausesfailure

### DIFF
--- a/src/planning.py
+++ b/src/planning.py
@@ -304,7 +304,7 @@ def _update_nsrts_with_failure(
             if ground_nsrt == discovered_failure.failing_nsrt:
                 new_ground_nsrt = ground_nsrt.copy_with(
                     preconditions=ground_nsrt.preconditions | {atom})
-            # Update the effects of all nsrts that use this object.
+            # Update the effects of all NSRTs that use this object.
             # Note that this is an elif rather than an if, because it would
             # never be possible to use the failing NSRT's effects to set
             # the _NOT_CAUSES_FAILURE precondition.

--- a/src/structs.py
+++ b/src/structs.py
@@ -783,6 +783,27 @@ class _GroundNSRT:
         params = self._sampler(state, rng, self.objects)
         return self.option.ground(self.option_objs, params)
 
+    def copy_with(self, **kwargs: Any) -> _GroundNSRT:
+        """Create a copy of the ground NSRT, optionally while replacing
+        any of the arguments.
+        """
+        default_kwargs = dict(
+            nsrt=self.nsrt,
+            objects=self.objects,
+            preconditions=self.preconditions,
+            add_effects=self.add_effects,
+            delete_effects=self.delete_effects,
+            option=self.option,
+            option_objs=self.option_objs,
+            _sampler=self._sampler
+        )
+        assert set(kwargs.keys()).issubset(default_kwargs.keys())
+        default_kwargs.update(kwargs)
+        # mypy is known to have issues with this pattern:
+        # https://github.com/python/mypy/issues/5382
+        # This still seems like the least bad option.
+        return _GroundNSRT(**default_kwargs)  # type: ignore
+
 
 @dataclass(eq=False)
 class Action:

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -514,6 +514,29 @@ def test_nsrts():
     assert len(filtered_nsrt.preconditions) == 1
     assert len(filtered_nsrt.add_effects) == 0
     assert len(filtered_nsrt.delete_effects) == 1
+    # Test copy_with().
+    ground_nsrt_copy1 = ground_nsrt.copy_with()
+    assert ground_nsrt == ground_nsrt_copy1
+    ground_nsrt_copy2 = ground_nsrt.copy_with(
+        preconditions=set())
+    assert str(ground_nsrt_copy2) == """GroundNSRT-Pick:
+    Parameters: [cup:cup_type, plate:plate_type]
+    Preconditions: []
+    Add Effects: [On(cup:cup_type, plate:plate_type)]
+    Delete Effects: [NotOn(cup:cup_type, plate:plate_type)]
+    Side Predicates: [On]
+    Option: ParameterizedOption(name='Pick', types=[])
+    Option Objects: []"""
+    ground_nsrt_copy3 = ground_nsrt.copy_with(
+        add_effects=set())
+    assert str(ground_nsrt_copy3) == """GroundNSRT-Pick:
+    Parameters: [cup:cup_type, plate:plate_type]
+    Preconditions: [NotOn(cup:cup_type, plate:plate_type)]
+    Add Effects: []
+    Delete Effects: [NotOn(cup:cup_type, plate:plate_type)]
+    Side Predicates: [On]
+    Option: ParameterizedOption(name='Pick', types=[])
+    Option Objects: []"""
 
 
 def test_datasets():


### PR DESCRIPTION
currently we modify ground NSRTs in-place in the failure discovery part of planning, even though ground NSRTs are frozen. @czeng6 has started encountering issues with this, so this PR is meant to fix the hack.