### PR TITLE
change score function to hff_lookahead_depth0

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -121,7 +121,7 @@ class GlobalSettings:
     grammar_search_pred_complexity_weight = 1
     grammar_search_max_predicates = 50
     grammar_search_predicate_cost_upper_bound = 6
-    grammar_search_score_function = "hff_lookahead_depth1"
+    grammar_search_score_function = "hff_lookahead_depth0"
     grammar_search_heuristic_based_weight = 10.
     grammar_search_heuristic_based_max_demos = 5
     grammar_search_lookahead_based_temperature = 10.


### PR DESCRIPTION
Significantly better empirical results on painting. Across 13 seeds on painting with all ablations, `hff_lookahead_depth1` scores an average of 22.7/50, while `hff_lookahead_depth0` scores an average of 34/50. More results on 5 different seeds:

with depth1:
```
                                                             TEST_TASKS_SOLVED TEST_TASKS_TOTAL  TOTAL_TEST_TIME       TOTAL_TIME  NUM_SEEDS
ENV             APPROACH                 EXCLUDED_PREDICATES
blocks          grammar_search_invention all                     34.40 (17.87)     50.00 (0.00)  179.71 (174.36)  375.01 (181.59)          5
                                         none                     43.80 (8.41)     50.00 (0.00)    72.65 (76.55)   212.09 (91.40)          5
cover           grammar_search_invention all                      48.80 (1.64)     50.00 (0.00)    13.07 (16.01)   226.89 (52.53)          5
                                         none                     48.80 (1.64)     50.00 (0.00)    13.06 (15.98)   225.19 (47.87)          5
painting        grammar_search_invention all                     10.00 (20.72)     50.00 (0.00)  401.17 (202.73)  760.53 (225.12)          5
                                         none                     46.80 (2.59)     50.00 (0.00)    45.85 (27.50)   307.04 (39.89)          5
```

with depth0:
```
                                                      TEST_TASKS_SOLVED TEST_TASKS_TOTAL  TOTAL_TEST_TIME       TOTAL_TIME  NUM_SEEDS
ENV      APPROACH                 EXCLUDED_PREDICATES
blocks   grammar_search_invention all                     21.60 (16.62)     50.00 (0.00)  277.68 (165.33)  465.12 (153.16)          5
                                  none                     42.40 (8.38)     50.00 (0.00)   100.64 (99.27)  275.20 (141.75)          5
cover    grammar_search_invention all                      48.80 (1.64)     50.00 (0.00)    13.07 (16.00)   229.99 (47.29)          5
                                  none                     48.80 (1.64)     50.00 (0.00)    13.08 (15.96)   229.84 (48.72)          5
painting grammar_search_invention all                      45.40 (3.97)     50.00 (0.00)    59.56 (40.14)   393.91 (62.62)          5
                                  none                     46.00 (3.74)     50.00 (0.00)    62.76 (48.78)   355.33 (79.24)          5
```