### PR TITLE
oracle samplers

### DIFF
--- a/analysis/analyze_supercloud_experiments.py
+++ b/analysis/analyze_supercloud_experiments.py
@@ -2,8 +2,8 @@
 analysis/run_supercloud_experiments.sh.
 """
 
-import pickle as pkl
 import glob
+import dill as pkl
 import pandas as pd
 from predicators.src.settings import CFG
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -32,3 +32,6 @@ ignore_missing_imports = True
 
 [mypy-pandas.*]
 ignore_missing_imports = True
+
+[mypy-dill.*]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pandas
 torch
 scipy
 tabulate
+dill

--- a/src/approaches/nsrt_learning_approach.py
+++ b/src/approaches/nsrt_learning_approach.py
@@ -4,8 +4,8 @@ In contrast to other approaches, this approach does not
 attempt to learn new predicates or options.
 """
 
-import pickle as pkl
 from typing import Callable, Set, List
+import dill as pkl
 from gym.spaces import Box
 from predicators.src.approaches import TAMPApproach
 from predicators.src.structs import Dataset, NSRT, ParameterizedOption, \

--- a/src/main.py
+++ b/src/main.py
@@ -28,8 +28,8 @@ from collections import defaultdict
 import os
 import subprocess
 import time
-import pickle as pkl
 from typing import Dict
+import dill as pkl
 from predicators.src.settings import CFG
 from predicators.src.envs import create_env, EnvironmentFailure, BaseEnv
 from predicators.src.approaches import create_approach, ApproachTimeout, \

--- a/src/sampler_learning.py
+++ b/src/sampler_learning.py
@@ -36,9 +36,10 @@ def learn_samplers(strips_ops: List[STRIPSOperator],
     return samplers
 
 
-def _extract_oracle_samplers(strips_ops: List[STRIPSOperator],
-                             option_specs: List[OptionSpec],
-                             ) -> List[NSRTSampler]:
+def _extract_oracle_samplers(
+    strips_ops: List[STRIPSOperator],
+    option_specs: List[OptionSpec],
+) -> List[NSRTSampler]:
     """Extract the oracle samplers matching the given STRIPSOperator objects
     from the ground truth operators defined in approaches/oracle_approach.py.
 
@@ -49,18 +50,24 @@ def _extract_oracle_samplers(strips_ops: List[STRIPSOperator],
     env = create_env(CFG.env)
     # We don't need to match ground truth NSRTs with no continuous
     # parameters, so we filter them out.
-    gt_nsrts = {nsrt for nsrt in get_gt_nsrts(env.predicates, env.options)
-                if nsrt.option.params_space.shape != (0, )}
+    gt_nsrts = {
+        nsrt
+        for nsrt in get_gt_nsrts(env.predicates, env.options)
+        if nsrt.option.params_space.shape != (0, )
+    }
     assert len(strips_ops) == len(option_specs)
     # Initialize all samplers to random.
-    samplers: List[NSRTSampler] = [_RandomSampler(param_option).sampler
-                                   for param_option, _ in option_specs]
+    samplers: List[NSRTSampler] = [
+        _RandomSampler(param_option).sampler
+        for param_option, _ in option_specs
+    ]
     # Go through the ground truth NSRTs. For each one, if we find a
     # matching to a given operator, extract the NSRT's sampler.
     for nsrt in gt_nsrts:
         # Use unification to find a matching.
-        for idx, (op, (param_option, option_vars)) in enumerate(
-                zip(strips_ops, option_specs)):
+        for idx, (op, (param_option,
+                       option_vars)) in enumerate(zip(strips_ops,
+                                                      option_specs)):
             suc, sub = utils.unify_preconds_effects_options(
                 frozenset(nsrt.preconditions), frozenset(op.preconditions),
                 frozenset(nsrt.add_effects), frozenset(op.add_effects),
@@ -76,10 +83,10 @@ def _extract_oracle_samplers(strips_ops: List[STRIPSOperator],
     return samplers
 
 
-def _make_reordered_sampler(nsrt: NSRT, op: STRIPSOperator, sub: EntToEntSub
-                            ) -> NSRTSampler:
-    """Helper for _extract_oracle_samplers().
-    """
+def _make_reordered_sampler(nsrt: NSRT, op: STRIPSOperator,
+                            sub: EntToEntSub) -> NSRTSampler:
+    """Helper for _extract_oracle_samplers()."""
+
     def _reordered_sampler(state: State, rng: np.random.Generator,
                            objs: Sequence[Object]) -> Array:
         # Use the sub dictionary to correctly order the arguments
@@ -89,6 +96,7 @@ def _make_reordered_sampler(nsrt: NSRT, op: STRIPSOperator, sub: EntToEntSub
             param_idx = op.parameters.index(sub[param])
             reordered_objs.append(objs[param_idx])
         return nsrt.get_sampler()(state, rng, reordered_objs)
+
     return _reordered_sampler
 
 

--- a/src/sampler_learning.py
+++ b/src/sampler_learning.py
@@ -22,16 +22,19 @@ def learn_samplers(strips_ops: List[STRIPSOperator],
         env = create_env(CFG.env)
         # We don't need to match ground truth NSRTs with no
         # continuous parameters, so filter them out.
-        gt_nsrts = {nsrt for nsrt in get_gt_nsrts(env.predicates, env.options)
-                    if nsrt.option.params_space.shape != (0,)}
+        gt_nsrts = {
+            nsrt
+            for nsrt in get_gt_nsrts(env.predicates, env.options)
+            if nsrt.option.params_space.shape != (0, )
+        }
     for i, op in enumerate(strips_ops):
         param_option, option_vars = option_specs[i]
         if sampler_learner == "random" or \
            param_option.params_space.shape == (0,):
             sampler: NSRTSampler = _RandomSampler(param_option).sampler
         elif sampler_learner == "oracle":
-            sampler = _extract_oracle_sampler(
-                op, param_option, option_vars, gt_nsrts)
+            sampler = _extract_oracle_sampler(op, param_option, option_vars,
+                                              gt_nsrts)
         elif sampler_learner == "neural":
             sampler = _learn_neural_sampler(datastores, op.name, op.parameters,
                                             op.preconditions, op.add_effects,
@@ -50,8 +53,9 @@ def _extract_oracle_sampler(op: STRIPSOperator,
                             param_option: ParameterizedOption,
                             option_vars: Sequence[Variable],
                             gt_nsrts: Set[NSRT]) -> NSRTSampler:
-    """Extract the oracle sampler matching the given STRIPSOperator
-    from the ground truth operators defined in approaches/oracle_approach.py.
+    """Extract the oracle sampler matching the given STRIPSOperator from the
+    ground truth operators defined in approaches/oracle_approach.py.
+
     If no ground truth operator can be unified with the given one, just
     returns a random sampler.
     """
@@ -59,15 +63,10 @@ def _extract_oracle_sampler(op: STRIPSOperator,
     matching_sub = None
     for nsrt in gt_nsrts:
         suc, sub = utils.unify_preconds_effects_options(
-            frozenset(op.preconditions),
-            frozenset(nsrt.preconditions),
-            frozenset(op.add_effects),
-            frozenset(nsrt.add_effects),
-            frozenset(op.delete_effects),
-            frozenset(nsrt.delete_effects),
-            param_option,
-            nsrt.option,
-            tuple(option_vars),
+            frozenset(op.preconditions), frozenset(nsrt.preconditions),
+            frozenset(op.add_effects), frozenset(nsrt.add_effects),
+            frozenset(op.delete_effects), frozenset(nsrt.delete_effects),
+            param_option, nsrt.option, tuple(option_vars),
             tuple(nsrt.option_vars))
         if suc:
             matching_nsrt = nsrt
@@ -88,12 +87,12 @@ def _extract_oracle_sampler(op: STRIPSOperator,
             idx = op.parameters.index(rev_sub[param])
             reordered_objs.append(objs[idx])
         return matching_nsrt.get_sampler()(state, rng, reordered_objs)
+
     gt_nsrts.remove(matching_nsrt)  # remove this NSRT from the set
     return _reordered_sampler
 
 
-def _learn_neural_sampler(datastores: List[Datastore],
-                          nsrt_name: str,
+def _learn_neural_sampler(datastores: List[Datastore], nsrt_name: str,
                           variables: Sequence[Variable],
                           preconditions: Set[LiftedAtom],
                           add_effects: Set[LiftedAtom],
@@ -206,8 +205,8 @@ def _create_sampler_data(
 
 @dataclass(frozen=True, eq=False, repr=False)
 class _LearnedSampler:
-    """A convenience class for holding the models underlying a learned sampler.
-    """
+    """A convenience class for holding the models underlying a learned
+    sampler."""
     _classifier: MLPClassifier
     _regressor: NeuralGaussianRegressor
     _variables: Sequence[Variable]
@@ -243,8 +242,7 @@ class _LearnedSampler:
 
 @dataclass(frozen=True, eq=False, repr=False)
 class _RandomSampler:
-    """A convenience class for implementing a random sampler.
-    """
+    """A convenience class for implementing a random sampler."""
     _param_option: ParameterizedOption
 
     def sampler(self, state: State, rng: np.random.Generator,

--- a/src/sampler_learning.py
+++ b/src/sampler_learning.py
@@ -61,8 +61,6 @@ def _extract_oracle_samplers(strips_ops: List[STRIPSOperator],
         # Use unification to find a matching.
         for idx, (op, (param_option, option_vars)) in enumerate(
                 zip(strips_ops, option_specs)):
-            if isinstance(samplers[idx], _RandomSampler):
-                continue
             suc, sub = utils.unify_preconds_effects_options(
                 frozenset(nsrt.preconditions), frozenset(op.preconditions),
                 frozenset(nsrt.add_effects), frozenset(op.add_effects),

--- a/src/sampler_learning.py
+++ b/src/sampler_learning.py
@@ -95,7 +95,7 @@ def _make_reordered_sampler(nsrt: NSRT, op: STRIPSOperator,
         for param in nsrt.parameters:
             param_idx = op.parameters.index(sub[param])
             reordered_objs.append(objs[param_idx])
-        return nsrt.get_sampler()(state, rng, reordered_objs)
+        return nsrt.sampler(state, rng, reordered_objs)
 
     return _reordered_sampler
 

--- a/src/sampler_learning.py
+++ b/src/sampler_learning.py
@@ -21,7 +21,7 @@ def learn_samplers(strips_ops: List[STRIPSOperator],
         return _extract_oracle_samplers(strips_ops, option_specs)
     samplers = []
     for i, op in enumerate(strips_ops):
-        param_option, option_vars = option_specs[i]
+        param_option, _ = option_specs[i]
         if sampler_learner == "random" or \
            param_option.params_space.shape == (0,):
             sampler: NSRTSampler = _RandomSampler(param_option).sampler
@@ -33,6 +33,7 @@ def learn_samplers(strips_ops: List[STRIPSOperator],
             raise NotImplementedError("Unknown sampler_learner: "
                                       f"{CFG.sampler_learner}")
         samplers.append(sampler)
+    return samplers
 
 
 def _extract_oracle_samplers(strips_ops: List[STRIPSOperator],
@@ -52,8 +53,8 @@ def _extract_oracle_samplers(strips_ops: List[STRIPSOperator],
                 if nsrt.option.params_space.shape != (0, )}
     assert len(strips_ops) == len(option_specs)
     # Initialize all samplers to random.
-    samplers = [_RandomSampler(param_option).sampler
-                for param_option, _ in option_specs]
+    samplers: List[NSRTSampler] = [_RandomSampler(param_option).sampler
+                                   for param_option, _ in option_specs]
     # Go through the ground truth NSRTs. For each one, if we find a
     # matching to a given operator, extract the NSRT's sampler.
     for nsrt in gt_nsrts:

--- a/src/sampler_learning.py
+++ b/src/sampler_learning.py
@@ -5,7 +5,7 @@ from typing import Set, Tuple, List, Sequence, Dict, Any
 import numpy as np
 from predicators.src.structs import ParameterizedOption, LiftedAtom, Variable, \
     Object, Array, State, _Option, Datastore, STRIPSOperator, OptionSpec, \
-    NSRTSampler, NSRT
+    NSRTSampler, NSRT, EntToEntSub
 from predicators.src import utils
 from predicators.src.torch_models import MLPClassifier, NeuralGaussianRegressor
 from predicators.src.settings import CFG
@@ -17,24 +17,14 @@ def learn_samplers(strips_ops: List[STRIPSOperator],
                    datastores: List[Datastore], option_specs: List[OptionSpec],
                    sampler_learner: str) -> List[NSRTSampler]:
     """Learn all samplers for each operator's option parameters."""
-    samplers = []
     if sampler_learner == "oracle":
-        env = create_env(CFG.env)
-        # We don't need to match ground truth NSRTs with no
-        # continuous parameters, so filter them out.
-        gt_nsrts = {
-            nsrt
-            for nsrt in get_gt_nsrts(env.predicates, env.options)
-            if nsrt.option.params_space.shape != (0, )
-        }
+        return _extract_oracle_samplers(strips_ops, option_specs)
+    samplers = []
     for i, op in enumerate(strips_ops):
         param_option, option_vars = option_specs[i]
         if sampler_learner == "random" or \
            param_option.params_space.shape == (0,):
             sampler: NSRTSampler = _RandomSampler(param_option).sampler
-        elif sampler_learner == "oracle":
-            sampler = _extract_oracle_sampler(op, param_option, option_vars,
-                                              gt_nsrts)
         elif sampler_learner == "neural":
             sampler = _learn_neural_sampler(datastores, op.name, op.parameters,
                                             op.preconditions, op.add_effects,
@@ -43,52 +33,63 @@ def learn_samplers(strips_ops: List[STRIPSOperator],
             raise NotImplementedError("Unknown sampler_learner: "
                                       f"{CFG.sampler_learner}")
         samplers.append(sampler)
-    if sampler_learner == "oracle":
-        assert not gt_nsrts, f"Can't use oracle samplers, {len(gt_nsrts)} " \
-            "oracle operator(s) were not matched to a learned operator!"
+
+
+def _extract_oracle_samplers(strips_ops: List[STRIPSOperator],
+                             option_specs: List[OptionSpec],
+                             ) -> List[NSRTSampler]:
+    """Extract the oracle samplers matching the given STRIPSOperator objects
+    from the ground truth operators defined in approaches/oracle_approach.py.
+
+    We require every ground truth operator to match one of the given
+    operators, but some of the given operators can match no ground truth
+    operator, in which case such an operator is given a random sampler.
+    """
+    env = create_env(CFG.env)
+    # We don't need to match ground truth NSRTs with no continuous
+    # parameters, so we filter them out.
+    gt_nsrts = {nsrt for nsrt in get_gt_nsrts(env.predicates, env.options)
+                if nsrt.option.params_space.shape != (0, )}
+    assert len(strips_ops) == len(option_specs)
+    # Initialize all samplers to random.
+    samplers = [_RandomSampler(param_option).sampler
+                for param_option, _ in option_specs]
+    # Go through the ground truth NSRTs. For each one, if we find a
+    # matching to a given operator, extract the NSRT's sampler.
+    for nsrt in gt_nsrts:
+        # Use unification to find a matching.
+        for idx, (op, (param_option, option_vars)) in enumerate(
+                zip(strips_ops, option_specs)):
+            if isinstance(samplers[idx], _RandomSampler):
+                continue
+            suc, sub = utils.unify_preconds_effects_options(
+                frozenset(nsrt.preconditions), frozenset(op.preconditions),
+                frozenset(nsrt.add_effects), frozenset(op.add_effects),
+                frozenset(nsrt.delete_effects), frozenset(op.delete_effects),
+                nsrt.option, param_option, tuple(nsrt.option_vars),
+                tuple(option_vars))
+            if suc:  # match found!
+                samplers[idx] = _make_reordered_sampler(nsrt, op, sub)
+                break
+        else:
+            raise Exception("Can't use oracle samplers, no match for "
+                            f"ground truth NSRT: {nsrt}")
     return samplers
 
 
-def _extract_oracle_sampler(op: STRIPSOperator,
-                            param_option: ParameterizedOption,
-                            option_vars: Sequence[Variable],
-                            gt_nsrts: Set[NSRT]) -> NSRTSampler:
-    """Extract the oracle sampler matching the given STRIPSOperator from the
-    ground truth operators defined in approaches/oracle_approach.py.
-
-    If no ground truth operator can be unified with the given one, just
-    returns a random sampler.
+def _make_reordered_sampler(nsrt: NSRT, op: STRIPSOperator, sub: EntToEntSub
+                            ) -> NSRTSampler:
+    """Helper for _extract_oracle_samplers().
     """
-    matching_nsrt = None
-    matching_sub = None
-    for nsrt in gt_nsrts:
-        suc, sub = utils.unify_preconds_effects_options(
-            frozenset(op.preconditions), frozenset(nsrt.preconditions),
-            frozenset(op.add_effects), frozenset(nsrt.add_effects),
-            frozenset(op.delete_effects), frozenset(nsrt.delete_effects),
-            param_option, nsrt.option, tuple(option_vars),
-            tuple(nsrt.option_vars))
-        if suc:
-            matching_nsrt = nsrt
-            matching_sub = sub
-            break
-    if matching_nsrt is None:
-        # Fall back to random sampler.
-        return _RandomSampler(param_option).sampler
-    # We found a matching operator. Use the matching_sub dictionary to
-    # correctly order the arguments to the sampler.
     def _reordered_sampler(state: State, rng: np.random.Generator,
                            objs: Sequence[Object]) -> Array:
-        assert matching_nsrt is not None
-        assert matching_sub is not None
+        # Use the sub dictionary to correctly order the arguments
+        # to the NSRT sampler.
         reordered_objs = []
-        rev_sub = {v: k for k, v in matching_sub.items()}
-        for param in matching_nsrt.parameters:
-            idx = op.parameters.index(rev_sub[param])
-            reordered_objs.append(objs[idx])
-        return matching_nsrt.get_sampler()(state, rng, reordered_objs)
-
-    gt_nsrts.remove(matching_nsrt)  # remove this NSRT from the set
+        for param in nsrt.parameters:
+            param_idx = op.parameters.index(sub[param])
+            reordered_objs.append(objs[param_idx])
+        return nsrt.get_sampler()(state, rng, reordered_objs)
     return _reordered_sampler
 
 

--- a/src/sampler_learning.py
+++ b/src/sampler_learning.py
@@ -247,8 +247,7 @@ class _LearnedSampler:
 
 @dataclass(frozen=True, eq=False, repr=False)
 class _RandomSampler:
-    """A convenience class for implementing a random sampler. Prefer
-    to use this over a lambda function because it is pickleable.
+    """A convenience class for implementing a random sampler.
     """
     _param_option: ParameterizedOption
 

--- a/src/sampler_learning.py
+++ b/src/sampler_learning.py
@@ -88,8 +88,9 @@ def _extract_oracle_sampler(op: STRIPSOperator,
         assert matching_nsrt is not None
         assert matching_sub is not None
         reordered_objs = []
-        for param in op.parameters:
-            idx = matching_nsrt.parameters.index(matching_sub[param])
+        rev_sub = {v: k for k, v in matching_sub.items()}
+        for param in matching_nsrt.parameters:
+            idx = op.parameters.index(rev_sub[param])
             reordered_objs.append(objs[idx])
         return matching_nsrt.get_sampler()(state, rng, reordered_objs)
     gt_nsrts.remove(matching_nsrt)  # remove this NSRT from the set

--- a/src/settings.py
+++ b/src/settings.py
@@ -83,7 +83,7 @@ class GlobalSettings:
     option_learner = "no_learning"  # "no_learning" or "oracle"
 
     # sampler learning parameters
-    sampler_learner = "neural"  # "neural" or "random"
+    sampler_learner = "neural"  # "neural" or "random" or "oracle"
     max_rejection_sampling_tries = 100
     normalization_scale_clip = 1
     classifier_hid_sizes = [32, 32]

--- a/src/structs.py
+++ b/src/structs.py
@@ -678,8 +678,9 @@ class NSRT:
         assert isinstance(other, NSRT)
         return str(self) > str(other)
 
-    def get_sampler(self) -> NSRTSampler:
-        """Get this NSRT's sampler."""
+    @property
+    def sampler(self) -> NSRTSampler:
+        """This NSRT's sampler."""
         return self._sampler
 
     def ground(self, objects: Sequence[Object]) -> _GroundNSRT:

--- a/src/structs.py
+++ b/src/structs.py
@@ -680,6 +680,11 @@ class NSRT:
         assert isinstance(other, NSRT)
         return str(self) > str(other)
 
+    def get_sampler(self) -> NSRTSampler:
+        """Get this NSRT's sampler.
+        """
+        return self._sampler
+
     def ground(self, objects: Sequence[Object]) -> _GroundNSRT:
         """Ground into a _GroundNSRT, given objects.
         """

--- a/src/structs.py
+++ b/src/structs.py
@@ -679,8 +679,7 @@ class NSRT:
         return str(self) > str(other)
 
     def get_sampler(self) -> NSRTSampler:
-        """Get this NSRT's sampler.
-        """
+        """Get this NSRT's sampler."""
         return self._sampler
 
     def ground(self, objects: Sequence[Object]) -> _GroundNSRT:

--- a/src/torch_models.py
+++ b/src/torch_models.py
@@ -284,7 +284,6 @@ class MLPClassifier(nn.Module):
 @dataclass(frozen=True, eq=False, repr=False)
 class LearnedPredicateClassifier:
     """A convenience class for holding the model underlying a learned predicate.
-    Prefer to use this because it is pickleable.
     """
     _model: MLPClassifier
 

--- a/src/torch_models.py
+++ b/src/torch_models.py
@@ -288,8 +288,8 @@ class MLPClassifier(nn.Module):
 
 @dataclass(frozen=True, eq=False, repr=False)
 class LearnedPredicateClassifier:
-    """A convenience class for holding the model underlying a learned predicate.
-    """
+    """A convenience class for holding the model underlying a learned
+    predicate."""
     _model: MLPClassifier
 
     def classifier(self, state: State, objects: Sequence[Object]) -> bool:

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -104,14 +104,14 @@ def test_oracle_samplers():
                    approach_name="nsrt_learning",
                    sampler_learner="oracle",
                    check_solution=True)
-    with pytest.raises(AssertionError) as e:
+    with pytest.raises(Exception) as e:
         # In painting, we learn operators that are different from the
         # oracle ones, so oracle sampler learning is not possible.
         _test_approach(env_name="painting",
                        approach_name="nsrt_learning",
                        sampler_learner="oracle",
                        check_solution=True)
-    assert "were not matched to a learned operator" in str(e)
+    assert "no match for ground truth NSRT" in str(e)
 
 
 def test_iterative_invention_approach():

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -57,8 +57,8 @@ def _test_approach(env_name,
     if try_solving:
         policy = approach.solve(task, timeout=CFG.timeout)
         if check_solution:
-            assert utils.policy_solves_task(
-                policy, task, env.simulate, env.predicates)
+            assert utils.policy_solves_task(policy, task, env.simulate,
+                                            env.predicates)
     # We won't check the policy here because we don't want unit tests to
     # have to train very good models, since that would be slow.
     # Now test loading NSRTs & predicates.
@@ -68,8 +68,8 @@ def _test_approach(env_name,
     if try_solving:
         policy = approach2.solve(task, timeout=CFG.timeout)
         if check_solution:
-            assert utils.policy_solves_task(
-                policy, task, env.simulate, env.predicates)
+            assert utils.policy_solves_task(policy, task, env.simulate,
+                                            env.predicates)
 
 
 def test_nsrt_learning_approach():
@@ -93,19 +93,24 @@ def test_nsrt_learning_approach():
 
 
 def test_oracle_samplers():
-    """Test NSRTLearningApproach with oracle samplers.
-    """
+    """Test NSRTLearningApproach with oracle samplers."""
     # Oracle sampler learning should work (and be fast) in cover and blocks.
     # We can even check that the policy succeeds!
-    _test_approach(env_name="cover", approach_name="nsrt_learning",
-                   sampler_learner="oracle", check_solution=True)
-    _test_approach(env_name="blocks", approach_name="nsrt_learning",
-                   sampler_learner="oracle", check_solution=True)
+    _test_approach(env_name="cover",
+                   approach_name="nsrt_learning",
+                   sampler_learner="oracle",
+                   check_solution=True)
+    _test_approach(env_name="blocks",
+                   approach_name="nsrt_learning",
+                   sampler_learner="oracle",
+                   check_solution=True)
     with pytest.raises(AssertionError) as e:
         # In painting, we learn operators that are different from the
         # oracle ones, so oracle sampler learning is not possible.
-        _test_approach(env_name="painting", approach_name="nsrt_learning",
-                       sampler_learner="oracle", check_solution=True)
+        _test_approach(env_name="painting",
+                       approach_name="nsrt_learning",
+                       sampler_learner="oracle",
+                       check_solution=True)
     assert "were not matched to a learned operator" in str(e)
 
 

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -480,6 +480,7 @@ def test_nsrts():
     assert nsrt == nsrt2
     nsrt3 = strips_operator.make_nsrt(parameterized_option, [], sampler)
     assert nsrt == nsrt3
+    assert nsrt.get_sampler() is sampler
     # _GroundNSRT
     ground_nsrt = nsrt.ground([cup, plate])
     assert isinstance(ground_nsrt, _GroundNSRT)

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -505,7 +505,7 @@ def test_nsrts():
     assert nsrt == nsrt2
     nsrt3 = strips_operator.make_nsrt(parameterized_option, [], sampler)
     assert nsrt == nsrt3
-    assert nsrt.get_sampler() is sampler
+    assert nsrt.sampler is sampler
     # _GroundNSRT
     ground_nsrt = nsrt.ground([cup, plate])
     assert isinstance(ground_nsrt, _GroundNSRT)


### PR DESCRIPTION
Implement oracle samplers for nsrt_learning pipeline by matching to
ground truth NSRTs in oracle_approach.py. We assert that every ground
truth NSRT must match a learned operator (but not the other way around,
since the pipeline could easily learn extra operators that are unimportant).

Works for cover and blocks, but not for painting because learned operators
don't exactly match ground truth ones.

Switched from pickle to dill because samplers defined in
oracle_approach.py are local functions, which cannot be pickled.
Verified that saving/loading work properly in all cases.

closes #246 