### PR TITLE
add support for other pyperplan heuristics

### DIFF
--- a/src/approaches/grammar_search_invention_approach.py
+++ b/src/approaches/grammar_search_invention_approach.py
@@ -469,7 +469,7 @@ def _create_score_function(
             initial_predicates, atom_dataset, train_tasks, candidates, "hadd")
     match = re.match(r"(\w+)_lookahead_depth(\d+)", score_function_name)
     if match is not None:
-        # heuristic_name can be any of {"hadd", "hmax", "hff"}
+        # heuristic_name can be any of {"hadd", "hmax", "hff", "lmcut"}
         # depth can be any non-negative integer
         heuristic_name, depth = match.groups()
         depth = int(depth)

--- a/src/approaches/grammar_search_invention_approach.py
+++ b/src/approaches/grammar_search_invention_approach.py
@@ -469,7 +469,7 @@ def _create_score_function(
             initial_predicates, atom_dataset, train_tasks, candidates, "hadd")
     match = re.match(r"(\w+)_lookahead_depth(\d+)", score_function_name)
     if match is not None:
-        # heuristic_name can be any of {"hadd", "hmax", "hff", "lmcut"}
+        # heuristic_name can be any of {"hadd", "hmax", "hff", "hsa", "lmcut"}
         # depth can be any non-negative integer
         heuristic_name, depth = match.groups()
         depth = int(depth)

--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -187,6 +187,12 @@ def test_create_score_function():
                       _RelaxationHeuristicLookaheadBasedScoreFunction)
     assert score_func.lookahead_depth == 0
     assert score_func.heuristic_name == "hmax"
+    score_func = _create_score_function("hsa_lookahead_depth0", set(), [], [],
+                                        {})
+    assert isinstance(score_func,
+                      _RelaxationHeuristicLookaheadBasedScoreFunction)
+    assert score_func.lookahead_depth == 0
+    assert score_func.heuristic_name == "hsa"
     score_func = _create_score_function("lmcut_lookahead_depth0", set(), [],
                                         [], {})
     assert isinstance(score_func,
@@ -396,7 +402,7 @@ def test_relaxation_lookahead_score_function():
                                                  option_specs)
 
     candidates = {p: 1.0 for p in name_to_pred.values()}
-    for heuristic_name in ["hadd", "hmax", "hff", "lmcut"]:
+    for heuristic_name in ["hadd", "hmax", "hff", "hsa", "lmcut"]:
         # Reuse dataset from above.
         score_function = _MockLookahead(initial_predicates, atom_dataset,
                                         train_tasks, candidates,

--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -187,6 +187,12 @@ def test_create_score_function():
                       _RelaxationHeuristicLookaheadBasedScoreFunction)
     assert score_func.lookahead_depth == 0
     assert score_func.heuristic_name == "hmax"
+    score_func = _create_score_function("lmcut_lookahead_depth0", set(), [],
+                                        [], {})
+    assert isinstance(score_func,
+                      _RelaxationHeuristicLookaheadBasedScoreFunction)
+    assert score_func.lookahead_depth == 0
+    assert score_func.heuristic_name == "lmcut"
     score_func = _create_score_function("hadd_lookahead_depth1", set(), [], [],
                                         {})
     assert score_func.lookahead_depth == 1
@@ -390,7 +396,7 @@ def test_relaxation_lookahead_score_function():
                                                  option_specs)
 
     candidates = {p: 1.0 for p in name_to_pred.values()}
-    for heuristic_name in ["hadd", "hmax", "hff"]:
+    for heuristic_name in ["hadd", "hmax", "hff", "lmcut"]:
         # Reuse dataset from above.
         score_function = _MockLookahead(initial_predicates, atom_dataset,
                                         train_tasks, candidates,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1157,6 +1157,10 @@ def test_create_task_planning_heuristic():
         "hff", set(), set(), set(), set(), set())
     assert isinstance(hff_heuristic, _PyperplanHeuristicWrapper)
     assert hff_heuristic.name == "hff"
+    hsa_heuristic = utils.create_task_planning_heuristic(
+        "hsa", set(), set(), set(), set(), set())
+    assert hsa_heuristic.name == "hsa"
+    assert isinstance(hsa_heuristic, _PyperplanHeuristicWrapper)
     lmcut_heuristic = utils.create_task_planning_heuristic(
         "lmcut", set(), set(), set(), set(), set())
     assert isinstance(lmcut_heuristic, _PyperplanHeuristicWrapper)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1157,6 +1157,10 @@ def test_create_task_planning_heuristic():
         "hff", set(), set(), set(), set(), set())
     assert isinstance(hff_heuristic, _PyperplanHeuristicWrapper)
     assert hff_heuristic.name == "hff"
+    lmcut_heuristic = utils.create_task_planning_heuristic(
+        "lmcut", set(), set(), set(), set(), set())
+    assert isinstance(lmcut_heuristic, _PyperplanHeuristicWrapper)
+    assert lmcut_heuristic.name == "lmcut"
     with pytest.raises(ValueError):
         utils.create_task_planning_heuristic("not a real heuristic", set(),
                                              set(), set(), set(), set())


### PR DESCRIPTION
realized that pyperplan facts are actually strings, not tuples. this wasn't an issue for hmax/hadd/hff but led to an error for lmcut.