### PR TITLE
terminate option execution immediately if it's stuck

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -275,6 +275,7 @@ def option_to_trajectory(init: State, simulator: Callable[[State, Action],
     actions = []
     assert option.initiable(init)
     state = init
+    last_state = state
     states = [state]
     for _ in range(max_num_steps):
         act = option.policy(state)
@@ -283,6 +284,10 @@ def option_to_trajectory(init: State, simulator: Callable[[State, Action],
         states.append(state)
         if option.terminal(state):
             break
+        # Detect loops and skip potentially expensive simulation.
+        if state.allclose(last_state):
+            break
+        last_state = state
     return LowLevelTrajectory(states, actions)
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -284,7 +284,7 @@ def option_to_trajectory(init: State, simulator: Callable[[State, Action],
         states.append(state)
         if option.terminal(state):
             break
-        # Detect loops and skip potentially expensive simulation.
+        # Detect if the option is stuck; skip potentially expensive simulation.
         if state.allclose(last_state):
             break
         last_state = state

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -118,6 +118,7 @@ def test_option_to_trajectory():
 
     # Test that option terminates early if it's stuck in a loop.
     def _simulator(s, a):
+        del a  # unused
         return s.copy()
 
     traj = utils.option_to_trajectory(state,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -116,6 +116,16 @@ def test_option_to_trajectory():
                                       max_num_steps=10)
     assert len(traj.actions) == len(traj.states) - 1 == 10
 
+    # Test that option terminates early if it's stuck in a loop.
+    def _simulator(s, a):
+        return s.copy()
+
+    traj = utils.option_to_trajectory(state,
+                                      _simulator,
+                                      option,
+                                      max_num_steps=100)
+    assert len(traj.actions) == len(traj.states) - 1 == 1
+
 
 def test_option_plan_to_policy():
     """Tests for option_plan_to_policy()."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -116,7 +116,7 @@ def test_option_to_trajectory():
                                       max_num_steps=10)
     assert len(traj.actions) == len(traj.states) - 1 == 10
 
-    # Test that option terminates early if it's stuck in a loop.
+    # Test that option terminates early if it's stuck.
     def _simulator(s, a):
         del a  # unused
         return s.copy()


### PR DESCRIPTION
because both env.simulate and option policies are deterministic