### PR TITLE
Playroom nsrt learning

### DIFF
--- a/src/approaches/oracle_approach.py
+++ b/src/approaches/oracle_approach.py
@@ -575,9 +575,9 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
             "Connects", "IsBoringRoom", "IsPlayroom", "IsBoringRoomDoor",
             "IsPlayroomDoor", "DoorOpen", "DoorClosed", "LightOn", "LightOff"])
 
-    Pick, Stack, PutOnTable, Move, OpenDoor, CloseDoor, TurnOnDial, \
+    Pick, Stack, PutOnTable, MoveFromRegion, MoveFromDoor, OpenDoor, CloseDoor, TurnOnDial, \
         TurnOffDial = _get_options_by_names("playroom",
-        ["Pick", "Stack", "PutOnTable", "Move", "OpenDoor", "CloseDoor",
+        ["Pick", "Stack", "PutOnTable", "MoveFromRegion", "MoveFromDoor", "OpenDoor", "CloseDoor",
          "TurnOnDial", "TurnOffDial"])
 
     nsrts = set()
@@ -716,8 +716,8 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     from_region = Variable("?from", region_type)
     to_region = Variable("?to", region_type)
     parameters = [robot, door, from_region, to_region]
-    option_vars = [robot, door, to_region]
-    option = Move
+    option_vars = [robot, door]
+    option = MoveFromDoor  # just needs door
     preconditions = {LiftedAtom(InRegion, [robot, from_region]),
                      LiftedAtom(Connects, [door, from_region, to_region]),
                      LiftedAtom(DoorOpen, [door]),
@@ -746,8 +746,8 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     door = Variable("?door", door_type)
     region = Variable("?region", region_type)
     parameters = [robot, door, region]
-    option_vars = [robot, door, region]
-    option = Move
+    option_vars = [robot, region]
+    option = MoveFromRegion  # needs region
     preconditions = {LiftedAtom(IsBoringRoom, [region]),
                      LiftedAtom(InRegion, [robot, region]),
                      LiftedAtom(NextToTable, [robot]),
@@ -772,8 +772,8 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     door = Variable("?door", door_type)
     region = Variable("?region", region_type)
     parameters = [robot, door, region]
-    option_vars = [robot, door, region]
-    option = Move
+    option_vars = [robot, region]
+    option = MoveFromRegion  # needs region
     preconditions = {LiftedAtom(IsBoringRoom, [region]),
                      LiftedAtom(InRegion, [robot, region]),
                      LiftedAtom(NextToDoor, [robot, door]),
@@ -796,8 +796,8 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     todoor = Variable("?todoor", door_type)
     region = Variable("?region", region_type)
     parameters = [robot, fromdoor, todoor, region]
-    option_vars = [robot, todoor, region]
-    option = Move
+    option_vars = [robot, region]
+    option = MoveFromRegion  # needs region
     preconditions = {LiftedAtom(Borders, [fromdoor, region, todoor]),
                      LiftedAtom(InRegion, [robot, region]),
                      LiftedAtom(NextToDoor, [robot, fromdoor])}
@@ -826,8 +826,8 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     dial = Variable("?dial", dial_type)
     region = Variable("?region", region_type)
     parameters = [robot, door, dial, region]
-    option_vars = [robot, door, region]
-    option = Move
+    option_vars = [robot, region]
+    option = MoveFromRegion  # needs region
     preconditions = {LiftedAtom(IsPlayroom, [region]),
                      LiftedAtom(InRegion, [robot, region]),
                      LiftedAtom(IsPlayroomDoor, [door]),
@@ -853,8 +853,8 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     door = Variable("?door", door_type)
     region = Variable("?region", region_type)
     parameters = [robot, dial, door, region]
-    option_vars = [robot, door, region]
-    option = Move
+    option_vars = [robot, region]
+    option = MoveFromRegion  # needs region
     preconditions = {LiftedAtom(IsPlayroom, [region]),
                      LiftedAtom(InRegion, [robot, region]),
                      LiftedAtom(IsPlayroomDoor, [door]),

--- a/src/approaches/oracle_approach.py
+++ b/src/approaches/oracle_approach.py
@@ -704,9 +704,11 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
             "Connects", "IsBoringRoom", "IsPlayroom", "IsBoringRoomDoor",
             "IsPlayroomDoor", "DoorOpen", "DoorClosed", "LightOn", "LightOff"])
 
-    Pick, Stack, PutOnTable, MoveFromRegion, MoveFromDoor, OpenDoor, CloseDoor, TurnOnDial, \
+    Pick, Stack, PutOnTable, AdvanceThroughDoor, MoveToDoor, MoveDoorToTable, \
+        MoveDoorToDial, OpenDoor, CloseDoor, TurnOnDial, \
         TurnOffDial = _get_options_by_names("playroom",
-        ["Pick", "Stack", "PutOnTable", "MoveFromRegion", "MoveFromDoor", "OpenDoor", "CloseDoor",
+        ["Pick", "Stack", "PutOnTable", "AdvanceThroughDoor", "MoveToDoor",
+         "MoveDoorToTable", "MoveDoorToDial", "OpenDoor", "CloseDoor",
          "TurnOnDial", "TurnOffDial"])
 
     nsrts = set()
@@ -874,7 +876,7 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     to_region = Variable("?to", region_type)
     parameters = [robot, door, from_region, to_region]
     option_vars = [robot, door]
-    option = MoveFromDoor
+    option = AdvanceThroughDoor
     preconditions = {LiftedAtom(InRegion, [robot, from_region]),
                      LiftedAtom(Connects, [door, from_region, to_region]),
                      LiftedAtom(DoorOpen, [door]),
@@ -889,11 +891,9 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
         robot, door, _, _ = objs
         assert robot.is_instance(robot_type)
         assert door.is_instance(door_type)
-        x = state.get(robot, "pose_x")
-        door_x, door_y = state.get(door, "pose_x"), state.get(door, "pose_y")
-        final_x = door_x + 0.2 if x < door_x else door_x - 0.2
-        rotation = 0.0 if x < door_x else -1.0
-        return np.array([final_x, door_y, rotation], dtype=np.float32)
+        if state.get(robot, "pose_x") < state.get(door, "pose_x"):
+            return np.array([0.2, 0.0, 0.0], dtype=np.float32)
+        return np.array([-0.2, 0.0, -1.0], dtype=np.float32)
 
     advancethroughdoor_nsrt = NSRT("AdvanceThroughDoor", parameters,
                                    preconditions, add_effects, delete_effects,
@@ -906,8 +906,8 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     door = Variable("?door", door_type)
     region = Variable("?region", region_type)
     parameters = [robot, door, region]
-    option_vars = [robot, region]
-    option = MoveFromRegion
+    option_vars = [robot, region, door]
+    option = MoveToDoor
     preconditions = {LiftedAtom(IsBoringRoom, [region]),
                      LiftedAtom(InRegion, [robot, region]),
                      LiftedAtom(NextToTable, [robot]),
@@ -917,12 +917,8 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
 
     def movetabletodoor_sampler(state: State, rng: np.random.Generator,
                                 objs: Sequence[Object]) -> Array:
-        del rng  # unused
-        assert len(objs) == 3
-        _, door, _ = objs
-        assert door.is_instance(door_type)
-        x, y = state.get(door, "pose_x") - 0.2, state.get(door, "pose_y")
-        return np.array([x, y, 0.0], dtype=np.float32)
+        del state, rng, objs  # unused
+        return np.array([-0.2, 0.0, 0.0], dtype=np.float32)
 
     movetabletodoor_nsrt = NSRT("MoveTableToDoor", parameters,
                                 preconditions, add_effects, delete_effects,
@@ -936,7 +932,7 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     region = Variable("?region", region_type)
     parameters = [robot, door, region]
     option_vars = [robot, region]
-    option = MoveFromRegion
+    option = MoveDoorToTable
     preconditions = {LiftedAtom(IsBoringRoom, [region]),
                      LiftedAtom(InRegion, [robot, region]),
                      LiftedAtom(NextToDoor, [robot, door]),
@@ -947,8 +943,7 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     def movedoortotable_sampler(state: State, rng: np.random.Generator,
                                 objs: Sequence[Object]) -> Array:
         del state, rng, objs  # unused
-        x, y = PlayroomEnv.table_x_ub, PlayroomEnv.table_y_ub
-        return np.array([x, y, -0.75], dtype=np.float32)
+        return np.array([0.0, 0.0, 0.0], dtype=np.float32)
 
     movedoortotable_nsrt = NSRT("MoveDoorToTable", parameters,
                                 preconditions, add_effects, delete_effects,
@@ -962,8 +957,8 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     todoor = Variable("?todoor", door_type)
     region = Variable("?region", region_type)
     parameters = [robot, fromdoor, todoor, region]
-    option_vars = [robot, region]
-    option = MoveFromRegion
+    option_vars = [robot, region, todoor]
+    option = MoveToDoor
     preconditions = {LiftedAtom(Borders, [fromdoor, region, todoor]),
                      LiftedAtom(InRegion, [robot, region]),
                      LiftedAtom(NextToDoor, [robot, fromdoor])}
@@ -977,11 +972,9 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
         _, fromdoor, todoor, _ = objs
         assert fromdoor.is_instance(door_type)
         assert todoor.is_instance(door_type)
-        to_x, to_y = state.get(todoor, "pose_x"), state.get(todoor, "pose_y")
-        from_x = state.get(fromdoor, "pose_x")
-        rotation = 0.0 if from_x < to_x else -1.0
-        x = to_x - 0.1 if from_x < to_x else to_x + 0.1
-        return np.array([x, to_y, rotation], dtype=np.float32)
+        if state.get(fromdoor, "pose_x") < state.get(todoor, "pose_x"):
+            return np.array([-0.1, 0.0, 0.0], dtype=np.float32)
+        return np.array([0.1, 0.0, -1.0], dtype=np.float32)
 
     movedoortodoor_nsrt = NSRT("MoveDoorToDoor", parameters, preconditions,
                                add_effects, delete_effects, set(), option,
@@ -994,8 +987,8 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     dial = Variable("?dial", dial_type)
     region = Variable("?region", region_type)
     parameters = [robot, door, dial, region]
-    option_vars = [robot, region]
-    option = MoveFromRegion
+    option_vars = [robot, region, dial]
+    option = MoveDoorToDial
     preconditions = {LiftedAtom(IsPlayroom, [region]),
                      LiftedAtom(InRegion, [robot, region]),
                      LiftedAtom(IsPlayroomDoor, [door]),
@@ -1005,12 +998,8 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
 
     def movedoortodial_sampler(state: State, rng: np.random.Generator,
                                objs: Sequence[Object]) -> Array:
-        del rng  # unused
-        assert len(objs) == 4
-        _, _, dial, _ = objs
-        assert dial.is_instance(dial_type)
-        dial_x, dial_y = state.get(dial, "pose_x"), state.get(dial, "pose_y")
-        return np.array([dial_x - 0.2, dial_y, -1.0], dtype=np.float32)
+        del state, rng, objs  # unused
+        return np.array([0.0, 0.0, 0.0], dtype=np.float32)
 
     movedoortodial_nsrt = NSRT("MoveDoorToDial", parameters, preconditions,
                                add_effects, delete_effects, set(), option,
@@ -1023,8 +1012,8 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     door = Variable("?door", door_type)
     region = Variable("?region", region_type)
     parameters = [robot, dial, door, region]
-    option_vars = [robot, region]
-    option = MoveFromRegion
+    option_vars = [robot, region, door]
+    option = MoveToDoor
     preconditions = {LiftedAtom(IsPlayroom, [region]),
                      LiftedAtom(InRegion, [robot, region]),
                      LiftedAtom(IsPlayroomDoor, [door]),
@@ -1034,12 +1023,8 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
 
     def movedialtodoor_sampler(state: State, rng: np.random.Generator,
                                objs: Sequence[Object]) -> Array:
-        del rng  # unused
-        assert len(objs) == 4
-        _, _, door, _ = objs
-        assert door.is_instance(door_type)
-        x, y = state.get(door, "pose_x"), state.get(door, "pose_y")
-        return np.array([x + 0.1, y, -1.0], dtype=np.float32)
+        del state, rng, objs  # unused
+        return np.array([0.1, 0.0, -1.0], dtype=np.float32)
 
     movedialtodoor_nsrt = NSRT("MoveDialToDoor", parameters, preconditions,
                                add_effects, delete_effects, set(), option,

--- a/src/approaches/oracle_approach.py
+++ b/src/approaches/oracle_approach.py
@@ -877,10 +877,12 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     parameters = [robot, door, from_region, to_region]
     option_vars = [robot, from_region, door]
     option = MoveToDoor
-    preconditions = {LiftedAtom(InRegion, [robot, from_region]),
-                     LiftedAtom(Connects, [door, from_region, to_region]),
-                     LiftedAtom(DoorOpen, [door]),
-                     LiftedAtom(NextToDoor, [robot, door])}
+    preconditions = {
+        LiftedAtom(InRegion, [robot, from_region]),
+        LiftedAtom(Connects, [door, from_region, to_region]),
+        LiftedAtom(DoorOpen, [door]),
+        LiftedAtom(NextToDoor, [robot, door])
+    }
     add_effects = {LiftedAtom(InRegion, [robot, to_region])}
     delete_effects = {LiftedAtom(InRegion, [robot, from_region])}
 
@@ -908,10 +910,12 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     parameters = [robot, door, region]
     option_vars = [robot, region, door]
     option = MoveToDoor
-    preconditions = {LiftedAtom(IsBoringRoom, [region]),
-                     LiftedAtom(InRegion, [robot, region]),
-                     LiftedAtom(NextToTable, [robot]),
-                     LiftedAtom(IsBoringRoomDoor, [door])}
+    preconditions = {
+        LiftedAtom(IsBoringRoom, [region]),
+        LiftedAtom(InRegion, [robot, region]),
+        LiftedAtom(NextToTable, [robot]),
+        LiftedAtom(IsBoringRoomDoor, [door])
+    }
     add_effects = {LiftedAtom(NextToDoor, [robot, door])}
     delete_effects = {LiftedAtom(NextToTable, [robot])}
 
@@ -933,10 +937,12 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     parameters = [robot, door, region]
     option_vars = [robot, region]
     option = MoveDoorToTable
-    preconditions = {LiftedAtom(IsBoringRoom, [region]),
-                     LiftedAtom(InRegion, [robot, region]),
-                     LiftedAtom(NextToDoor, [robot, door]),
-                     LiftedAtom(IsBoringRoomDoor, [door])}
+    preconditions = {
+        LiftedAtom(IsBoringRoom, [region]),
+        LiftedAtom(InRegion, [robot, region]),
+        LiftedAtom(NextToDoor, [robot, door]),
+        LiftedAtom(IsBoringRoomDoor, [door])
+    }
     add_effects = {LiftedAtom(NextToTable, [robot])}
     delete_effects = {LiftedAtom(NextToDoor, [robot, door])}
 
@@ -959,9 +965,11 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     parameters = [robot, fromdoor, todoor, region]
     option_vars = [robot, region, todoor]
     option = MoveToDoor
-    preconditions = {LiftedAtom(Borders, [fromdoor, region, todoor]),
-                     LiftedAtom(InRegion, [robot, region]),
-                     LiftedAtom(NextToDoor, [robot, fromdoor])}
+    preconditions = {
+        LiftedAtom(Borders, [fromdoor, region, todoor]),
+        LiftedAtom(InRegion, [robot, region]),
+        LiftedAtom(NextToDoor, [robot, fromdoor])
+    }
     add_effects = {LiftedAtom(NextToDoor, [robot, todoor])}
     delete_effects = {LiftedAtom(NextToDoor, [robot, fromdoor])}
 
@@ -989,10 +997,12 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     parameters = [robot, door, dial, region]
     option_vars = [robot, region, dial]
     option = MoveDoorToDial
-    preconditions = {LiftedAtom(IsPlayroom, [region]),
-                     LiftedAtom(InRegion, [robot, region]),
-                     LiftedAtom(IsPlayroomDoor, [door]),
-                     LiftedAtom(NextToDoor, [robot, door])}
+    preconditions = {
+        LiftedAtom(IsPlayroom, [region]),
+        LiftedAtom(InRegion, [robot, region]),
+        LiftedAtom(IsPlayroomDoor, [door]),
+        LiftedAtom(NextToDoor, [robot, door])
+    }
     add_effects = {LiftedAtom(NextToDial, [robot, dial])}
     delete_effects = {LiftedAtom(NextToDoor, [robot, door])}
 
@@ -1014,10 +1024,12 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     parameters = [robot, dial, door, region]
     option_vars = [robot, region, door]
     option = MoveToDoor
-    preconditions = {LiftedAtom(IsPlayroom, [region]),
-                     LiftedAtom(InRegion, [robot, region]),
-                     LiftedAtom(IsPlayroomDoor, [door]),
-                     LiftedAtom(NextToDial, [robot, dial])}
+    preconditions = {
+        LiftedAtom(IsPlayroom, [region]),
+        LiftedAtom(InRegion, [robot, region]),
+        LiftedAtom(IsPlayroomDoor, [door]),
+        LiftedAtom(NextToDial, [robot, dial])
+    }
     add_effects = {LiftedAtom(NextToDoor, [robot, door])}
     delete_effects = {LiftedAtom(NextToDial, [robot, dial])}
 

--- a/src/approaches/oracle_approach.py
+++ b/src/approaches/oracle_approach.py
@@ -704,10 +704,10 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
             "Connects", "IsBoringRoom", "IsPlayroom", "IsBoringRoomDoor",
             "IsPlayroomDoor", "DoorOpen", "DoorClosed", "LightOn", "LightOff"])
 
-    Pick, Stack, PutOnTable, AdvanceThroughDoor, MoveToDoor, MoveDoorToTable, \
+    Pick, Stack, PutOnTable, MoveToDoor, MoveDoorToTable, \
         MoveDoorToDial, OpenDoor, CloseDoor, TurnOnDial, \
         TurnOffDial = _get_options_by_names("playroom",
-        ["Pick", "Stack", "PutOnTable", "AdvanceThroughDoor", "MoveToDoor",
+        ["Pick", "Stack", "PutOnTable", "MoveToDoor",
          "MoveDoorToTable", "MoveDoorToDial", "OpenDoor", "CloseDoor",
          "TurnOnDial", "TurnOffDial"])
 
@@ -875,8 +875,8 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     from_region = Variable("?from", region_type)
     to_region = Variable("?to", region_type)
     parameters = [robot, door, from_region, to_region]
-    option_vars = [robot, door]
-    option = AdvanceThroughDoor
+    option_vars = [robot, from_region, door]
+    option = MoveToDoor
     preconditions = {LiftedAtom(InRegion, [robot, from_region]),
                      LiftedAtom(Connects, [door, from_region, to_region]),
                      LiftedAtom(DoorOpen, [door]),

--- a/src/approaches/oracle_approach.py
+++ b/src/approaches/oracle_approach.py
@@ -717,7 +717,7 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     to_region = Variable("?to", region_type)
     parameters = [robot, door, from_region, to_region]
     option_vars = [robot, door]
-    option = MoveFromDoor  # just needs door
+    option = MoveFromDoor
     preconditions = {LiftedAtom(InRegion, [robot, from_region]),
                      LiftedAtom(Connects, [door, from_region, to_region]),
                      LiftedAtom(DoorOpen, [door]),
@@ -747,7 +747,7 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     region = Variable("?region", region_type)
     parameters = [robot, door, region]
     option_vars = [robot, region]
-    option = MoveFromRegion  # needs region
+    option = MoveFromRegion
     preconditions = {LiftedAtom(IsBoringRoom, [region]),
                      LiftedAtom(InRegion, [robot, region]),
                      LiftedAtom(NextToTable, [robot]),
@@ -773,7 +773,7 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     region = Variable("?region", region_type)
     parameters = [robot, door, region]
     option_vars = [robot, region]
-    option = MoveFromRegion  # needs region
+    option = MoveFromRegion
     preconditions = {LiftedAtom(IsBoringRoom, [region]),
                      LiftedAtom(InRegion, [robot, region]),
                      LiftedAtom(NextToDoor, [robot, door]),
@@ -797,7 +797,7 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     region = Variable("?region", region_type)
     parameters = [robot, fromdoor, todoor, region]
     option_vars = [robot, region]
-    option = MoveFromRegion  # needs region
+    option = MoveFromRegion
     preconditions = {LiftedAtom(Borders, [fromdoor, region, todoor]),
                      LiftedAtom(InRegion, [robot, region]),
                      LiftedAtom(NextToDoor, [robot, fromdoor])}
@@ -827,7 +827,7 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     region = Variable("?region", region_type)
     parameters = [robot, door, dial, region]
     option_vars = [robot, region]
-    option = MoveFromRegion  # needs region
+    option = MoveFromRegion
     preconditions = {LiftedAtom(IsPlayroom, [region]),
                      LiftedAtom(InRegion, [robot, region]),
                      LiftedAtom(IsPlayroomDoor, [door]),
@@ -854,7 +854,7 @@ def _get_playroom_gt_nsrts() -> Set[NSRT]:
     region = Variable("?region", region_type)
     parameters = [robot, dial, door, region]
     option_vars = [robot, region]
-    option = MoveFromRegion  # needs region
+    option = MoveFromRegion
     preconditions = {LiftedAtom(IsPlayroom, [region]),
                      LiftedAtom(InRegion, [robot, region]),
                      LiftedAtom(IsPlayroomDoor, [door]),

--- a/src/envs/playroom.py
+++ b/src/envs/playroom.py
@@ -765,15 +765,6 @@ class PlayroomEnv(BlocksEnv):
         robot = objects[0]
         return PlayroomEnv._NextToTable_holds(state, (robot,))
 
-    def _Move_policy(self, state: State, memory: Dict,
-                     objects: Sequence[Object], params: Array) -> Action:
-        del memory  # unused
-        robot = objects[0]
-        fingers = state.get(robot, "fingers")
-        arr = np.r_[params[:-1], 1.0, params[-1], fingers].astype(np.float32)
-        arr = np.clip(arr, self.action_space.low, self.action_space.high)
-        return Action(arr)
-
     @staticmethod
     def _MoveFromRegion_initiable(state: State, memory: Dict,
                                   objects: Sequence[Object], params: Array
@@ -781,14 +772,6 @@ class PlayroomEnv(BlocksEnv):
         del memory, params  # unused
         # objects: robot, region, ...
         return PlayroomEnv._InRegion_holds(state, objects[:2])
-
-    @staticmethod
-    def _MoveFromDoor_initiable(state: State, memory: Dict,
-                                objects: Sequence[Object], params: Array
-                                ) -> bool:
-        del memory, params  # unused
-        # objects: (robot, door)
-        return PlayroomEnv._NextToDoor_holds(state, objects)
     
     def _MoveToDoor_policy(self, state: State, memory: Dict,
                              objects: Sequence[Object], params: Array) -> Action:

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -349,25 +349,41 @@ def test_oracle_approach_playroom():
     train_task = next(env.train_tasks_generator())[0]
     state = train_task.init
     objs = list(state)
-    robot, dial, door, region = objs[17], objs[3], objs[9], objs[16]
+    robot, dial, door5, door6, region6, region7 = objs[17], objs[3], objs[8], objs[9], objs[15], objs[16]
     assert robot.name == "robby"
     assert dial.name == "dial"
-    assert door.name == "door6"
-    assert region.name == "region7"
-    movedialtodoor_nsrt = movedialtodoor.ground([robot, dial, door, region])
+    assert door5.name == "door5"
+    assert door6.name == "door6"
+    assert region6.name == "region6"
+    assert region7.name == "region7"
+    movedialtodoor_nsrt = movedialtodoor.ground([robot, dial, door6, region7])
     rng = np.random.default_rng(123)
-    move_option = movedialtodoor_nsrt.sample_option(state, rng)
-    move_action = move_option.policy(state)
-    assert env.action_space.contains(move_action.arr)
+    movetodoor_option = movedialtodoor_nsrt.sample_option(state, rng)
+    movetodoor_action = movetodoor_option.policy(state)
+    assert env.action_space.contains(movetodoor_action.arr)
     assert np.all(
-        move_action.arr == np.array([110.1, 15, 1, -1, 1], dtype=np.float32))
+        movetodoor_action.arr == np.array([110.1, 15, 1, -1, 1], dtype=np.float32))
     # Test MoveDoorToTable for coverage.
     movedoortotable = [nsrt for nsrt in nsrts \
                       if nsrt.name == "MoveDoorToTable"][0]
-    movedoortotable_nsrt = movedoortotable.ground([robot, door, region])
-    move_option2 = movedoortotable_nsrt.sample_option(state, rng)
-    move_action2 = move_option2.policy(state)
-    assert env.action_space.contains(move_action2.arr)
+    movedoortotable_nsrt = movedoortotable.ground([robot, door6, region7])
+    movedoortotable_option = movedoortotable_nsrt.sample_option(state, rng)
+    movedoortotable_action = movedoortotable_option.policy(state)
+    assert env.action_space.contains(movedoortotable_action.arr)
+    # Test AdvanceThroughDoor (moving left) for coverage.
+    advancethroughdoor = [nsrt for nsrt in nsrts \
+                      if nsrt.name == "AdvanceThroughDoor"][0]
+    advancethroughdoor_nsrt = advancethroughdoor.ground([robot, door6, region7, region6])
+    movetodoor_option2 = advancethroughdoor_nsrt.sample_option(state, rng)
+    movetodoor_action2 = movetodoor_option2.policy(state)
+    assert env.action_space.contains(movetodoor_action2.arr)
+    # Test MoveDoorToDoor (moving left) for coverage.
+    movedoortodoor = [nsrt for nsrt in nsrts \
+                      if nsrt.name == "MoveDoorToDoor"][0]
+    movedoortodoor_nsrt = movedoortodoor.ground([robot, door6, door5, region6])
+    movedoortodoor_option = movedoortodoor_nsrt.sample_option(state, rng)
+    movedoortodoor_action = movedoortodoor_option.policy(state)
+    assert env.action_space.contains(movedoortodoor_action.arr)
 
 
 def test_oracle_approach_repeated_nextto():

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -349,7 +349,8 @@ def test_oracle_approach_playroom():
     train_task = next(env.train_tasks_generator())[0]
     state = train_task.init
     objs = list(state)
-    robot, dial, door5, door6, region6, region7 = objs[17], objs[3], objs[8], objs[9], objs[15], objs[16]
+    robot, dial, door5, door6, region6, region7 = objs[17], objs[3], objs[
+        8], objs[9], objs[15], objs[16]
     assert robot.name == "robby"
     assert dial.name == "dial"
     assert door5.name == "door5"
@@ -361,8 +362,8 @@ def test_oracle_approach_playroom():
     movetodoor_option = movedialtodoor_nsrt.sample_option(state, rng)
     movetodoor_action = movetodoor_option.policy(state)
     assert env.action_space.contains(movetodoor_action.arr)
-    assert np.all(
-        movetodoor_action.arr == np.array([110.1, 15, 1, -1, 1], dtype=np.float32))
+    assert np.all(movetodoor_action.arr == np.array([110.1, 15, 1, -1, 1],
+                                                    dtype=np.float32))
     # Test MoveDoorToTable for coverage.
     movedoortotable = [nsrt for nsrt in nsrts \
                       if nsrt.name == "MoveDoorToTable"][0]
@@ -371,9 +372,11 @@ def test_oracle_approach_playroom():
     movedoortotable_action = movedoortotable_option.policy(state)
     assert env.action_space.contains(movedoortotable_action.arr)
     # Test AdvanceThroughDoor (moving left) for coverage.
+    state.set(robot, "pose_x", 110.3)
     advancethroughdoor = [nsrt for nsrt in nsrts \
                       if nsrt.name == "AdvanceThroughDoor"][0]
-    advancethroughdoor_nsrt = advancethroughdoor.ground([robot, door6, region7, region6])
+    advancethroughdoor_nsrt = advancethroughdoor.ground(
+        [robot, door6, region7, region6])
     movetodoor_option2 = advancethroughdoor_nsrt.sample_option(state, rng)
     movetodoor_action2 = movetodoor_option2.policy(state)
     assert env.action_space.contains(movetodoor_action2.arr)

--- a/tests/envs/test_playroom.py
+++ b/tests/envs/test_playroom.py
@@ -74,29 +74,29 @@ def test_playroom_failure_cases():
     next_state = env.simulate(state, act)
     for o in state:
         if o.type != robot_type:
-            assert np.all(state[o] == next_state[o])
+            assert np.allclose(state[o], next_state[o])
     # Object not clear, pick fails
     act = Action(np.array([12.2, 11.8, 0.45, 0.35, 0]).astype(np.float32))
     next_state = env.simulate(state, act)
     for o in state:
         if o.type != robot_type:
-            assert np.all(state[o] == next_state[o])
+            assert np.allclose(state[o], next_state[o])
     # Cannot putontable or stack without picking first
     act = Action(np.array([12.2, 11.8, 5, 0.35, 0.7]).astype(np.float32))
     next_state = env.simulate(state, act)
     for o in state:
         if o.type != robot_type:
-            assert np.all(state[o] == next_state[o])
+            assert np.allclose(state[o], next_state[o])
     act = Action(np.array([19, 14, 0.45, 0.95, 0.8]).astype(np.float32))
     next_state = env.simulate(state, act)
     for o in state:
         if o.type != robot_type:
-            assert np.all(state[o] == next_state[o])
+            assert np.allclose(state[o], next_state[o])
     # Perform valid pick
     act = Action(np.array([11.8, 18, 0.45, -0.15, 0]).astype(np.float32))
     next_state = env.simulate(state, act)
-    assert np.any(state[robot] != next_state[robot])
-    assert np.any(state[block2] != next_state[block2])
+    assert not np.allclose(state[robot], next_state[robot])
+    assert not np.allclose(state[block2], next_state[block2])
     state = next_state
     atoms = utils.abstract(state, env.predicates)
     assert OnTable([block2]) not in atoms
@@ -109,13 +109,13 @@ def test_playroom_failure_cases():
     next_state = env.simulate(state, act)
     for o in state:
         if o.type != robot_type:
-            assert np.all(state[o] == next_state[o])
+            assert np.allclose(state[o], next_state[o])
     # Cannot stack onto no block
     act = Action(np.array([15, 16, 0.8, -0.5, 0.7]).astype(np.float32))
     next_state = env.simulate(state, act)
     for o in state:
         if o.type != robot_type:
-            assert np.all(state[o] == next_state[o])
+            assert np.allclose(state[o], next_state[o])
     # Cannot stack onto yourself
     act = Action(np.array([11.8, 18, 1.5, -0.15, 0.7]).astype(np.float32))
     next_state = env.simulate(state, act)
@@ -125,7 +125,7 @@ def test_playroom_failure_cases():
     next_state = env.simulate(state, act)
     for o in state:
         if o.type != robot_type:
-            assert np.all(state[o] == next_state[o])
+            assert np.allclose(state[o], next_state[o])
     # Cannot move to invalid location
     act = Action(np.array([40, 5, 0, 0, 0]).astype(np.float32))
     next_state = env.simulate(state, act)
@@ -157,35 +157,35 @@ def test_playroom_simulate_blocks():
     # Move to boring room door
     act = Action(np.array([29.6, 15, 1, 1, 0]).astype(np.float32))
     next_state = env.simulate(state, act)
-    assert np.any(state[robot] != next_state[robot])
+    assert not np.allclose(state[robot], next_state[robot])
     state = next_state
     # Move to table but do not pick block 1
     act = Action(np.array([12, 11.8, 0.95, 0.35, 0]).astype(np.float32))
     next_state = env.simulate(state, act)
-    assert np.any(state[robot] != next_state[robot])
+    assert not np.allclose(state[robot], next_state[robot])
     assert np.allclose(state[block1], next_state[block1])
     state = next_state
     # Perform valid pick of block 1 (do not have to face the block)
     act = Action(np.array([12, 11.8, 0.95, -0.35, 0]).astype(np.float32))
     next_state = env.simulate(state, act)
-    assert np.any(state[robot] != next_state[robot])
-    assert np.any(state[block1] != next_state[block1])
+    assert not np.allclose(state[robot], next_state[robot])
+    assert not np.allclose(state[block1], next_state[block1])
     state = next_state
     # Perform valid put on table
     act = Action(np.array([19, 14, 0.45, 0.95, 0.8]).astype(np.float32))
     next_state = env.simulate(state, act)
-    assert np.any(state[block1] != next_state[block1])
+    assert not np.allclose(state[block1], next_state[block1])
     state = next_state
     # Perform valid pick of block 2
     act = Action(np.array([11.8, 18, 0.45, -0.15, 0]).astype(np.float32))
     next_state = env.simulate(state, act)
-    assert np.any(state[robot] != next_state[robot])
-    assert np.any(state[block2] != next_state[block2])
+    assert not np.allclose(state[robot], next_state[robot])
+    assert not np.allclose(state[block2], next_state[block2])
     state = next_state
     # Perform valid stack
     act = Action(np.array([12.2, 11.8, 5, 0.35, 0.7]).astype(np.float32))
     next_state = env.simulate(state, act)
-    assert np.any(state[block2] != next_state[block2])
+    assert not np.allclose(state[block2], next_state[block2])
     state = next_state
 
 
@@ -214,15 +214,15 @@ def test_playroom_simulate_doors_and_dial():
     # Move to boring room door but do not open it
     act = Action(np.array([29.8, 15, 3, 0, 1]).astype(np.float32))
     next_state = env.simulate(state, act)
-    assert np.any(state[robot] != next_state[robot])
+    assert not np.allclose(state[robot], next_state[robot])
     for o in state:
         if o.type != robot_type:
-            assert np.all(state[o] == next_state[o])
+            assert np.allclose(state[o], next_state[o])
     state = next_state
     # Open boring room door
     act = Action(np.array([29.8, 15, 3, 0, 1]).astype(np.float32))
     next_state = env.simulate(state, act)
-    assert np.any(state[door1] != next_state[door1])
+    assert not np.allclose(state[door1], next_state[door1])
     state = next_state
     # Cannot move directly to playroom even though doors are all open
     act = Action(np.array([125, 15, 1, 0, 1]).astype(np.float32))
@@ -244,7 +244,7 @@ def test_playroom_simulate_doors_and_dial():
     for arr in actions:
         act = Action(arr)
         next_state = env.simulate(state, act)
-        assert np.any(state[robot] != next_state[robot])
+        assert not np.allclose(state[robot], next_state[robot])
         for o in state:
             if o.type != robot_type:
                 assert np.allclose(state[o], next_state[o]), f"obj {o} in state {state} and \nnext state {next_state}"
@@ -256,7 +256,7 @@ def test_playroom_simulate_doors_and_dial():
     # Advance through door6
     act = Action(np.array([110.2, 15, 3, 0.5, 1]).astype(np.float32))
     next_state = env.simulate(state, act)
-    assert np.any(state[robot] != next_state[robot])
+    assert not np.allclose(state[robot], next_state[robot])
     state = next_state
     # Can't directly move left through door6 and end next to door5
     act = Action(np.array([100.3, 15, 3, 0, 1]).astype(np.float32))
@@ -265,7 +265,7 @@ def test_playroom_simulate_doors_and_dial():
     # Shut door to playroom
     act = Action(np.array([110.2, 15, 3, 1, 1]).astype(np.float32))
     next_state = env.simulate(state, act)
-    assert np.any(state[door6] != next_state[door6])
+    assert not np.allclose(state[door6], next_state[door6])
     state = next_state
     # Cannot advance through closed door
     act = Action(np.array([109.6, 15, 3, 1, 1]).astype(np.float32))
@@ -280,15 +280,19 @@ def test_playroom_simulate_doors_and_dial():
         else:
             assert not np.allclose(state[o], next_state[o])
     state = next_state
-    # Turn dial on, facing S
-    act = Action(np.array([125, 15.1, 1, -0.5, 1]).astype(np.float32))
+    # Cannot move from dial into region 6
+    act = Action(np.array([109.7, 15, 3, 0, 1]).astype(np.float32))
     next_state = env.simulate(state, act)
-    assert np.any(state[dial] != next_state[dial])
+    assert state.allclose(next_state)
+    # Turn dial on, facing S (can toggle when not facing dial)
+    act = Action(np.array([125, 14.9, 1, -0.5, 1]).astype(np.float32))
+    next_state = env.simulate(state, act)
+    assert not np.allclose(state[dial], next_state[dial])
     state = next_state
     # Turn dial off, facing E
     act = Action(np.array([125, 15, 1, 0, 1]).astype(np.float32))
     next_state = env.simulate(state, act)
-    assert np.any(state[dial] != next_state[dial])
+    assert not np.allclose(state[dial], next_state[dial])
     state = next_state
     # Turn dial on, facing N
     act = Action(np.array([125, 14.9, 1, 0.5, 1]).astype(np.float32))
@@ -296,10 +300,6 @@ def test_playroom_simulate_doors_and_dial():
     # Turn dial off, facing W
     act = Action(np.array([125.1, 15, 1, 1, 1]).astype(np.float32))
     state = env.simulate(state, act)
-    # Can toggle when not facing dial
-    act = Action(np.array([125.1, 15, 1, 0, 1]).astype(np.float32))
-    next_state = env.simulate(state, act)
-    assert np.any(state[dial] != next_state[dial])
 
 
 def test_playroom_options():

--- a/tests/envs/test_playroom.py
+++ b/tests/envs/test_playroom.py
@@ -64,6 +64,9 @@ def test_playroom_failure_cases():
     # Check robot is not next to any door
     with pytest.raises(RuntimeError):
         env._get_door_next_to(state)  # pylint: disable=protected-access
+    # Test failure case for _get_region_in() helper
+    with pytest.raises(RuntimeError):
+        env._get_region_in(state, 150)  # pylint: disable=protected-access
     # block1 is on block0 is on the table, block2 is on the table
     assert OnTable([block0]) in atoms
     assert OnTable([block1]) not in atoms
@@ -239,7 +242,7 @@ def test_playroom_simulate_doors_and_dial():
         np.array([80.3, 15, 3, 0, 1]).astype(np.float32),
         np.array([99.8, 15, 3, 0, 1]).astype(np.float32),
         np.array([100.3, 15, 3, 0, 1]).astype(np.float32),
-        np.array( [109.8, 15, 3, 0, 1]).astype(np.float32),
+        np.array([109.8, 15, 3, 0, 1]).astype(np.float32),
     ]
     for arr in actions:
         act = Action(arr)
@@ -247,7 +250,9 @@ def test_playroom_simulate_doors_and_dial():
         assert not np.allclose(state[robot], next_state[robot])
         for o in state:
             if o.type != robot_type:
-                assert np.allclose(state[o], next_state[o]), f"obj {o} in state {state} and \nnext state {next_state}"
+                assert np.allclose(
+                    state[o], next_state[o]
+                ), f"obj {o} in state {state} and \nnext state {next_state}"
         state = next_state
     # Can't directly move through door6 to the dial
     act = Action(np.array([126, 15, 1, 0, 1]).astype(np.float32))
@@ -341,7 +346,6 @@ def test_playroom_options():
     Stack = [o for o in env.options if o.name == "Stack"][0]
     PutOnTable = [o for o in env.options if o.name == "PutOnTable"][0]
     MoveToDoor = [o for o in env.options if o.name == "MoveToDoor"][0]
-    MoveDoorToTable = [o for o in env.options if o.name == "MoveDoorToTable"][0]
     MoveDoorToDial = [o for o in env.options if o.name == "MoveDoorToDial"][0]
     OpenDoor = [o for o in env.options if o.name == "OpenDoor"][0]
     CloseDoor = [o for o in env.options if o.name == "CloseDoor"][0]
@@ -417,7 +421,7 @@ def test_playroom_action_sequence_video():
         np.array([80.3, 15, 3, 0, 1]).astype(np.float32),
         np.array([99.8, 15, 3, 0, 1]).astype(np.float32),
         np.array([100.3, 15, 3, 0, 1]).astype(np.float32),
-        np.array( [109.8, 15, 3, 0, 1]).astype(np.float32),
+        np.array([109.8, 15, 3, 0, 1]).astype(np.float32),
         np.array([110.2, 15, 3, 0.5, 1]).astype(np.float32),
         # Shut playroom door
         np.array([110.2, 15, 3, -1, 1]).astype(np.float32),


### PR DESCRIPTION
changes implemented to make nsrt learning work:
- make sure for each option, all option vars are used somewhere (either in policy or initiable fnc)
- make sure that each "move transition" by the robot can only be explained by one option -- so now there are 3 different move options, each with a different and more specific policy for movement
- simulator no longer allows the robot to move in ways that the oracle operators do not allow for (e.g. transitioning from region 1 directly to region 3)
- got rid of “robot must be facing x to interact with x” requirement in simulator b/c this made sampling for pick, stack, putontable too hard