### PR TITLE
low-hanging optimizations for exact lookahead

### DIFF
--- a/analysis/grammar_search_analysis.py
+++ b/analysis/grammar_search_analysis.py
@@ -182,13 +182,13 @@ def _main() -> None:
         "painting",
     ]
     score_function_names = [
-        "prediction_error",
-        "hadd_lookahead_depth0",
+        # "prediction_error",
+        # "hadd_lookahead_depth0",
         "exact_lookahead",
-        "hadd_lookahead_depth1",
-        "hadd_lookahead_depth2",
+        # "hadd_lookahead_depth1",
+        # "hadd_lookahead_depth2",
     ]
-    run_planning = True
+    run_planning = False
 
     outdir = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                           "results")

--- a/analysis/grammar_search_analysis.py
+++ b/analysis/grammar_search_analysis.py
@@ -182,13 +182,13 @@ def _main() -> None:
         "painting",
     ]
     score_function_names = [
-        # "prediction_error",
-        # "hadd_lookahead_depth0",
+        "prediction_error",
+        "hadd_lookahead_depth0",
         "exact_lookahead",
-        # "hadd_lookahead_depth1",
-        # "hadd_lookahead_depth2",
+        "hadd_lookahead_depth1",
+        "hadd_lookahead_depth2",
     ]
-    run_planning = False
+    run_planning = True
 
     outdir = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                           "results")

--- a/src/approaches/grammar_search_invention_approach.py
+++ b/src/approaches/grammar_search_invention_approach.py
@@ -619,8 +619,8 @@ class _TaskPlanningScoreFunction(_OperatorLearningBasedScoreFunction):
             init_atoms = utils.abstract(task.init,
                                         predicates | self._initial_predicates)
             objects = set(task.init)
-            ground_nsrts = task_plan_grounding(init_atoms, objects, task.goal,
-                                               strips_ops, option_specs)
+            ground_nsrts = task_plan_grounding(init_atoms, objects, strips_ops,
+                                               option_specs)
             heuristic = utils.create_task_planning_heuristic(
                 CFG.task_planning_heuristic, init_atoms, task.goal,
                 ground_nsrts, predicates | self._initial_predicates, objects)
@@ -832,8 +832,8 @@ class _ExactHeuristicBasedScoreFunction(_HeuristicBasedScoreFunction):  # pylint
 
         # It's important for efficiency that we only ground once, and create
         # the heuristic once, for every task.
-        ground_nsrts = task_plan_grounding(init_atoms, objects, goal,
-                                           strips_ops, option_specs)
+        ground_nsrts = task_plan_grounding(init_atoms, objects, strips_ops,
+                                           option_specs)
         heuristic = utils.create_task_planning_heuristic(
             CFG.task_planning_heuristic, init_atoms, goal, ground_nsrts,
             set(predicates) | self._initial_predicates, objects)

--- a/src/planning.py
+++ b/src/planning.py
@@ -108,7 +108,6 @@ def sesame_plan(
 def task_plan_grounding(
     init_atoms: Set[GroundAtom],
     objects: Set[Object],
-    goal: Set[GroundAtom],
     strips_ops: Sequence[STRIPSOperator],
     option_specs: Sequence[OptionSpec],
 ) -> List[_GroundNSRT]:
@@ -122,10 +121,7 @@ def task_plan_grounding(
     nonempty_ground_nsrts = [
         nsrt for nsrt in ground_nsrts if nsrt.add_effects | nsrt.delete_effects
     ]
-    all_reachable_atoms = utils.get_reachable_atoms(nonempty_ground_nsrts,
-                                                    init_atoms)
-    if not goal.issubset(all_reachable_atoms):
-        raise ApproachFailure(f"Goal {goal} not dr-reachable")
+    all_reachable_atoms = utils.get_reachable_atoms(ground_nsrts, init_atoms)
     reachable_nsrts = [
         nsrt for nsrt in nonempty_ground_nsrts
         if nsrt.preconditions.issubset(all_reachable_atoms)
@@ -149,6 +145,9 @@ def task_plan(
     convenient wrapper around _skeleton_generator below (which IS used
     by SeSamE) that takes in only the minimal necessary arguments.
     """
+    all_reachable_atoms = utils.get_reachable_atoms(ground_nsrts, init_atoms)
+    if not goal.issubset(all_reachable_atoms):
+        raise ApproachFailure(f"Goal {goal} not dr-reachable")
     dummy_task = Task(State({}), goal)
     metrics: Metrics = defaultdict(float)
     generator = _skeleton_generator(dummy_task, ground_nsrts, init_atoms,

--- a/src/planning.py
+++ b/src/planning.py
@@ -15,6 +15,7 @@ from predicators.src.structs import State, Task, NSRT, Predicate, \
     GroundAtom, _GroundNSRT, DummyOption, DefaultState, _Option, \
     Metrics, STRIPSOperator, OptionSpec, Object
 from predicators.src import utils
+from predicators.src.utils import _TaskPlanningHeuristic
 from predicators.src.envs import EnvironmentFailure
 from predicators.src.option_model import _OptionModel
 from predicators.src.settings import CFG
@@ -77,11 +78,14 @@ def sesame_plan(
             nsrt for nsrt in nonempty_ground_nsrts
             if nsrt.preconditions.issubset(all_reachable_atoms)
         ]
+        heuristic = utils.create_task_planning_heuristic(
+            CFG.task_planning_heuristic, init_atoms, task.goal,
+            reachable_nsrts, predicates, objects)
         try:
             new_seed = seed + int(metrics["num_failures_discovered"])
             for skeleton, atoms_sequence in _skeleton_generator(
-                    task, reachable_nsrts, init_atoms, predicates, objects,
-                    new_seed, timeout - (time.time() - start_time), metrics):
+                    task, reachable_nsrts, init_atoms, heuristic, new_seed,
+                    timeout - (time.time() - start_time), metrics):
                 plan = _run_low_level_search(
                     task, option_model, skeleton, atoms_sequence, predicates,
                     new_seed, timeout - (time.time() - start_time))
@@ -101,6 +105,34 @@ def sesame_plan(
             predicates |= new_predicates
 
 
+def task_plan_grounding(
+    init_atoms: Set[GroundAtom],
+    objects: Set[Object],
+    goal: Set[GroundAtom],
+    strips_ops: Sequence[STRIPSOperator],
+    option_specs: Sequence[OptionSpec],
+) -> List[_GroundNSRT]:
+    """Ground all operators for task planning into dummy _GroundNSRTs,
+    filtering out ones that are unreachable or have empty effects."""
+    nsrts = utils.ops_and_specs_to_dummy_nsrts(strips_ops, option_specs)
+    ground_nsrts = []
+    for nsrt in nsrts:
+        for ground_nsrt in utils.all_ground_nsrts(nsrt, objects):
+            ground_nsrts.append(ground_nsrt)
+    nonempty_ground_nsrts = [
+        nsrt for nsrt in ground_nsrts if nsrt.add_effects | nsrt.delete_effects
+    ]
+    all_reachable_atoms = utils.get_reachable_atoms(nonempty_ground_nsrts,
+                                                    init_atoms)
+    if not goal.issubset(all_reachable_atoms):
+        raise ApproachFailure(f"Goal {goal} not dr-reachable")
+    reachable_nsrts = [
+        nsrt for nsrt in nonempty_ground_nsrts
+        if nsrt.preconditions.issubset(all_reachable_atoms)
+    ]
+    return reachable_nsrts
+
+
 def task_plan(
     init_atoms: Set[GroundAtom],
     objects: Set[Object],
@@ -118,37 +150,25 @@ def task_plan(
     convenient wrapper around _skeleton_generator below (which IS used
     by SeSamE) that takes in only the minimal necessary arguments.
     """
-    nsrts = utils.ops_and_specs_to_dummy_nsrts(strips_ops, option_specs)
-    ground_nsrts = []
-    for nsrt in nsrts:
-        for ground_nsrt in utils.all_ground_nsrts(nsrt, objects):
-            ground_nsrts.append(ground_nsrt)
-    nonempty_ground_nsrts = [
-        nsrt for nsrt in ground_nsrts if nsrt.add_effects | nsrt.delete_effects
-    ]
-    all_reachable_atoms = utils.get_reachable_atoms(nonempty_ground_nsrts,
-                                                    init_atoms)
-    if not goal.issubset(all_reachable_atoms):
-        raise ApproachFailure(f"Goal {goal} not dr-reachable")
-    reachable_nsrts = [
-        nsrt for nsrt in nonempty_ground_nsrts
-        if nsrt.preconditions.issubset(all_reachable_atoms)
-    ]
+    reachable_nsrts = task_plan_grounding(init_atoms, objects, goal,
+                                          strips_ops, option_specs)
     dummy_task = Task(State({}), goal)
     metrics: Metrics = defaultdict(float)
     predicates_dict, _ = utils.extract_preds_and_types(strips_ops)
     predicates = set(predicates_dict.values())
+    heuristic = utils.create_task_planning_heuristic(
+        CFG.task_planning_heuristic, init_atoms, goal, reachable_nsrts,
+        predicates, objects)
     generator = _skeleton_generator(dummy_task, reachable_nsrts, init_atoms,
-                                    predicates, objects, seed, timeout,
-                                    metrics)
+                                    heuristic, seed, timeout, metrics)
     skeleton, atoms_sequence = next(generator)  # get the first one
     return skeleton, atoms_sequence, metrics
 
 
 def _skeleton_generator(
     task: Task, ground_nsrts: List[_GroundNSRT], init_atoms: Set[GroundAtom],
-    predicates: Collection[Predicate], objects: Collection[Object], seed: int,
-    timeout: float, metrics: Metrics
+    heuristic: _TaskPlanningHeuristic, seed: int, timeout: float,
+    metrics: Metrics
 ) -> Iterator[Tuple[List[_GroundNSRT], List[Collection[GroundAtom]]]]:
     """A* search over skeletons (sequences of ground NSRTs).
     Iterates over pairs of (skeleton, atoms sequence).
@@ -160,9 +180,6 @@ def _skeleton_generator(
                       atoms_sequence=[init_atoms],
                       parent=None)
     rng_prio = np.random.default_rng(seed)
-    heuristic = utils.create_task_planning_heuristic(
-        CFG.task_planning_heuristic, init_atoms, task.goal, ground_nsrts,
-        predicates, objects)
     hq.heappush(queue,
                 (heuristic(root_node.atoms), rng_prio.uniform(), root_node))
     # Start search.

--- a/src/planning.py
+++ b/src/planning.py
@@ -116,6 +116,8 @@ def task_plan_grounding(
 
     Also return the set of reachable atoms, which is used by task
     planning to quickly determine if a goal is unreachable.
+
+    See the task_plan docstring for usage instructions.
     """
     nsrts = utils.ops_and_specs_to_dummy_nsrts(strips_ops, option_specs)
     ground_nsrts = []
@@ -150,6 +152,14 @@ def task_plan(
     This method is NOT used by SeSamE, but is instead provided as a
     convenient wrapper around _skeleton_generator below (which IS used
     by SeSamE) that takes in only the minimal necessary arguments.
+
+    This method is tightly coupled with task_plan_grounding -- the reason they
+    are separate methods is that it is sometimes possible to ground only once
+    and then plan multiple times (e.g. from different initial states, or to
+    different goals). To run task planning once, call task_plan_grounding to
+    get ground_nsrts and reachable_atoms; then create a heuristic using
+    utils.create_task_planning_heuristic; then call this method. See the tests
+    in tests/test_planning for usage examples.
     """
     if not goal.issubset(reachable_atoms):
         raise ApproachFailure(f"Goal {goal} not dr-reachable")

--- a/src/planning.py
+++ b/src/planning.py
@@ -135,10 +135,9 @@ def task_plan_grounding(
 
 def task_plan(
     init_atoms: Set[GroundAtom],
-    objects: Set[Object],
     goal: Set[GroundAtom],
-    strips_ops: Sequence[STRIPSOperator],
-    option_specs: Sequence[OptionSpec],
+    ground_nsrts: List[_GroundNSRT],
+    heuristic: _TaskPlanningHeuristic,
     seed: int,
     timeout: float,
 ) -> Tuple[List[_GroundNSRT], List[Collection[GroundAtom]], Metrics]:
@@ -150,16 +149,9 @@ def task_plan(
     convenient wrapper around _skeleton_generator below (which IS used
     by SeSamE) that takes in only the minimal necessary arguments.
     """
-    reachable_nsrts = task_plan_grounding(init_atoms, objects, goal,
-                                          strips_ops, option_specs)
     dummy_task = Task(State({}), goal)
     metrics: Metrics = defaultdict(float)
-    predicates_dict, _ = utils.extract_preds_and_types(strips_ops)
-    predicates = set(predicates_dict.values())
-    heuristic = utils.create_task_planning_heuristic(
-        CFG.task_planning_heuristic, init_atoms, goal, reachable_nsrts,
-        predicates, objects)
-    generator = _skeleton_generator(dummy_task, reachable_nsrts, init_atoms,
+    generator = _skeleton_generator(dummy_task, ground_nsrts, init_atoms,
                                     heuristic, seed, timeout, metrics)
     skeleton, atoms_sequence = next(generator)  # get the first one
     return skeleton, atoms_sequence, metrics

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -48,14 +48,15 @@ def test_task_plan():
                            nsrt.add_effects, nsrt.delete_effects,
                            nsrt.side_predicates))
         option_specs.append((nsrt.option, nsrt.option_vars))
-    ground_nsrts = task_plan_grounding(init_atoms, objects, strips_ops,
-                                       option_specs)
+    ground_nsrts, reachable_atoms = task_plan_grounding(
+        init_atoms, objects, strips_ops, option_specs)
     heuristic = utils.create_task_planning_heuristic("hadd", init_atoms,
                                                      task.goal, ground_nsrts,
                                                      env.predicates, objects)
     skeleton, _, _ = task_plan(init_atoms,
                                task.goal,
                                ground_nsrts,
+                               reachable_atoms,
                                heuristic,
                                timeout=1,
                                seed=123)
@@ -242,30 +243,29 @@ def test_planning_determinism():
                                     seed=123)[0]]
     assert plan1 == plan2 == plan3 == plan4
     # Check that task_plan is deterministic, over both NSRTs and objects.
+    predicates = {asleep, cried}
+    init_atoms = set()
     option_specs = [(sleep_nsrt.option, sleep_nsrt.option_vars),
                     (cry_nsrt.option, cry_nsrt.option_vars)]
-    plan1 = [(act.name, act.objects)
-             for act in task_plan(set(), [robby, robin],
-                                  goal, [sleep_op, cry_op],
-                                  option_specs,
-                                  seed=123,
-                                  timeout=10)[0]]
-    plan2 = [(act.name, act.objects)
-             for act in task_plan(set(), [robby, robin],
-                                  goal, [cry_op, sleep_op],
-                                  option_specs,
-                                  seed=123,
-                                  timeout=10)[0]]
-    plan3 = [(act.name, act.objects)
-             for act in task_plan(set(), [robin, robby],
-                                  goal, [sleep_op, cry_op],
-                                  option_specs,
-                                  seed=123,
-                                  timeout=10)[0]]
-    plan4 = [(act.name, act.objects)
-             for act in task_plan(set(), [robin, robby],
-                                  goal, [cry_op, sleep_op],
-                                  option_specs,
-                                  seed=123,
-                                  timeout=10)[0]]
-    assert plan1 == plan2 == plan3 == plan4
+    nsrt_orders = [[sleep_op, cry_op], [cry_op, sleep_op]]
+    object_orders = [[robby, robin], [robin, robby]]
+
+    all_plans = []
+    for nsrts in nsrt_orders:
+        for objects in object_orders:
+            ground_nsrts, reachable_atoms = task_plan_grounding(
+                init_atoms, objects, nsrts, option_specs)
+            heuristic = utils.create_task_planning_heuristic(
+                "hadd", init_atoms, goal, ground_nsrts, predicates, objects)
+            skeleton, _, _ = task_plan(init_atoms,
+                                       goal,
+                                       ground_nsrts,
+                                       reachable_atoms,
+                                       heuristic,
+                                       timeout=10,
+                                       seed=123)
+            all_plans.append([(act.name, act.objects) for act in skeleton])
+
+    assert len(all_plans) == 4
+    for plan in all_plans[1:]:
+        assert plan == all_plans[0]

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -5,7 +5,7 @@ from predicators.src.approaches import OracleApproach
 from predicators.src.approaches.oracle_approach import get_gt_nsrts
 from predicators.src.approaches import ApproachFailure, ApproachTimeout
 from predicators.src.envs import CoverEnv
-from predicators.src.planning import sesame_plan, task_plan
+from predicators.src.planning import sesame_plan, task_plan, task_plan_grounding
 from predicators.src import utils
 from predicators.src.structs import Task, NSRT, ParameterizedOption, _Option, \
     _GroundNSRT, STRIPSOperator
@@ -47,11 +47,15 @@ def test_task_plan():
                            nsrt.add_effects, nsrt.delete_effects,
                            nsrt.side_predicates))
         option_specs.append((nsrt.option, nsrt.option_vars))
+    ground_nsrts = task_plan_grounding(init_atoms, objects, task.goal,
+                                       strips_ops, option_specs)
+    heuristic = utils.create_task_planning_heuristic("hadd", init_atoms,
+                                                     task.goal, ground_nsrts,
+                                                     env.predicates, objects)
     skeleton, _, _ = task_plan(init_atoms,
-                               objects,
                                task.goal,
-                               strips_ops,
-                               option_specs,
+                               ground_nsrts,
+                               heuristic,
                                timeout=1,
                                seed=123)
     assert len(skeleton) == 2

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -47,8 +47,8 @@ def test_task_plan():
                            nsrt.add_effects, nsrt.delete_effects,
                            nsrt.side_predicates))
         option_specs.append((nsrt.option, nsrt.option_vars))
-    ground_nsrts = task_plan_grounding(init_atoms, objects, task.goal,
-                                       strips_ops, option_specs)
+    ground_nsrts = task_plan_grounding(init_atoms, objects, strips_ops,
+                                       option_specs)
     heuristic = utils.create_task_planning_heuristic("hadd", init_atoms,
                                                      task.goal, ground_nsrts,
                                                      env.predicates, objects)


### PR DESCRIPTION
ground the NSRTs only once per task, rather than on every call to `task_plan`. this seems to be a 2-3x speedup (based on running the analysis script before vs after).