### PR TITLE
planning determinism + test

### DIFF
--- a/src/planning.py
+++ b/src/planning.py
@@ -53,7 +53,7 @@ def sesame_plan(
     objects = list(task.init)
     start_time = time.time()
     ground_nsrts = []
-    for nsrt in nsrts:
+    for nsrt in sorted(nsrts):
         for ground_nsrt in utils.all_ground_nsrts(nsrt, objects):
             ground_nsrts.append(ground_nsrt)
             if time.time() - start_time > timeout:
@@ -120,7 +120,7 @@ def task_plan(
     """
     nsrts = utils.ops_and_specs_to_dummy_nsrts(strips_ops, option_specs)
     ground_nsrts = []
-    for nsrt in nsrts:
+    for nsrt in sorted(nsrts):
         for ground_nsrt in utils.all_ground_nsrts(nsrt, objects):
             ground_nsrts.append(ground_nsrt)
     nonempty_ground_nsrts = [

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -9,8 +9,7 @@ from predicators.src.envs import CoverEnv
 from predicators.src.planning import sesame_plan, task_plan
 from predicators.src import utils
 from predicators.src.structs import Task, NSRT, ParameterizedOption, _Option, \
-    _GroundNSRT, STRIPSOperator, Predicate, State, GroundAtom, LiftedAtom, \
-    Type, Action
+    _GroundNSRT, STRIPSOperator, Predicate, State, Type, Action
 from predicators.src.settings import CFG
 from predicators.src.option_model import create_option_model
 

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -171,16 +171,15 @@ def test_planning_determinism():
     delete_effects = set()
     side_predicates = set()
     neg_params_space = Box(-0.75, -0.25, (1, ))
-    parameterized_option = ParameterizedOption(
+    sleep_option = ParameterizedOption(
         "Sleep", [robot_type], neg_params_space,
         lambda s, m, o, p: Action(p - int(o[0] == robby)),
         lambda s, m, o, p: True, lambda s, m, o, p: True)
     sleep_op = STRIPSOperator("Sleep", parameters, preconditions, add_effects,
                               delete_effects, side_predicates)
-    sleep_nsrt = NSRT("Sleep", parameters, preconditions, add_effects,
-                      delete_effects, side_predicates, parameterized_option,
-                      [robot_var],
-                      lambda s, rng, objs: neg_params_space.sample())
+    sleep_nsrt = sleep_op.make_nsrt(
+        sleep_option, [robot_var],
+        lambda s, rng, objs: neg_params_space.sample())
     cried = Predicate("Cried", [robot_type], lambda s, o: s[o[0]][1])
     parameters = [robot_var]
     preconditions = set()
@@ -188,16 +187,14 @@ def test_planning_determinism():
     delete_effects = set()
     side_predicates = set()
     pos_params_space = Box(0.25, 0.75, (1, ))
-    parameterized_option = ParameterizedOption(
+    cry_option = ParameterizedOption(
         "Cry", [robot_type], pos_params_space,
         lambda s, m, o, p: Action(p + int(o[0] == robby)),
         lambda s, m, o, p: True, lambda s, m, o, p: True)
     cry_op = STRIPSOperator("Cry", parameters, preconditions, add_effects,
                             delete_effects, side_predicates)
-    cry_nsrt = NSRT("Cry", parameters, preconditions, add_effects,
-                    delete_effects, side_predicates, parameterized_option,
-                    [robot_var],
-                    lambda s, rng, objs: pos_params_space.sample())
+    cry_nsrt = cry_op.make_nsrt(cry_option, [robot_var],
+                                lambda s, rng, objs: pos_params_space.sample())
 
     def _simulator(s, a):
         ns = s.copy()

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -1,6 +1,7 @@
 """Test cases for planning algorithms."""
 
 import pytest
+from gym.spaces import Box
 from predicators.src.approaches import OracleApproach
 from predicators.src.approaches.oracle_approach import get_gt_nsrts
 from predicators.src.approaches import ApproachFailure, ApproachTimeout
@@ -8,7 +9,8 @@ from predicators.src.envs import CoverEnv
 from predicators.src.planning import sesame_plan, task_plan
 from predicators.src import utils
 from predicators.src.structs import Task, NSRT, ParameterizedOption, _Option, \
-    _GroundNSRT, STRIPSOperator
+    _GroundNSRT, STRIPSOperator, Predicate, State, GroundAtom, LiftedAtom, \
+    Type, Action
 from predicators.src.settings import CFG
 from predicators.src.option_model import create_option_model
 
@@ -152,3 +154,118 @@ def test_sesame_plan_uninitiable_option():
                     timeout=500,
                     seed=123)
     assert "Planning reached max_skeletons_optimized!" in str(e.value)
+
+
+def test_planning_determinism():
+    """Tests that planning is deterministic when there are multiple ways of
+    achieving a goal."""
+    utils.update_config({"env": "cover"})
+    robot_type = Type("robot_type", ["asleep", "cried"])
+    robot_var = robot_type("?robot")
+    robby = robot_type("robby")
+    robin = robot_type("robin")
+    asleep = Predicate("Asleep", [robot_type], lambda s, o: s[o[0]][0])
+    parameters = [robot_var]
+    preconditions = set()
+    add_effects = {asleep([robot_var])}
+    delete_effects = set()
+    side_predicates = set()
+    neg_params_space = Box(-0.75, -0.25, (1, ))
+    parameterized_option = ParameterizedOption(
+        "Sleep", [robot_type], neg_params_space,
+        lambda s, m, o, p: Action(p - int(o[0] == robby)),
+        lambda s, m, o, p: True, lambda s, m, o, p: True)
+    sleep_op = STRIPSOperator("Sleep", parameters, preconditions, add_effects,
+                              delete_effects, side_predicates)
+    sleep_nsrt = NSRT("Sleep", parameters, preconditions, add_effects,
+                      delete_effects, side_predicates, parameterized_option,
+                      [robot_var],
+                      lambda s, rng, objs: neg_params_space.sample())
+    cried = Predicate("Cried", [robot_type], lambda s, o: s[o[0]][1])
+    parameters = [robot_var]
+    preconditions = set()
+    add_effects = {cried([robot_var])}
+    delete_effects = set()
+    side_predicates = set()
+    pos_params_space = Box(0.25, 0.75, (1, ))
+    parameterized_option = ParameterizedOption(
+        "Cry", [robot_type], pos_params_space,
+        lambda s, m, o, p: Action(p + int(o[0] == robby)),
+        lambda s, m, o, p: True, lambda s, m, o, p: True)
+    cry_op = STRIPSOperator("Cry", parameters, preconditions, add_effects,
+                            delete_effects, side_predicates)
+    cry_nsrt = NSRT("Cry", parameters, preconditions, add_effects,
+                    delete_effects, side_predicates, parameterized_option,
+                    [robot_var],
+                    lambda s, rng, objs: pos_params_space.sample())
+
+    def _simulator(s, a):
+        ns = s.copy()
+        if a.arr.item() < -1:
+            ns[robby][0] = 1
+        elif a.arr.item() < 0:
+            ns[robin][0] = 1
+        elif a.arr.item() < 1:
+            ns[robin][1] = 1
+        else:
+            ns[robby][1] = 1
+        return ns
+
+    goal = {asleep([robby]), asleep([robin]), cried([robby]), cried([robin])}
+    task1 = Task(State({robby: [0, 0], robin: [0, 0]}), goal)
+    task2 = Task(State({robin: [0, 0], robby: [0, 0]}), goal)
+    option_model = create_option_model("default", _simulator)
+    # Check that sesame_plan is deterministic, over both NSRTs and objects.
+    plan1 = [(act.name, act.objects)
+             for act in sesame_plan(task1,
+                                    option_model, [sleep_nsrt, cry_nsrt],
+                                    set(),
+                                    timeout=10,
+                                    seed=123)[0]]
+    plan2 = [(act.name, act.objects)
+             for act in sesame_plan(task1,
+                                    option_model, [cry_nsrt, sleep_nsrt],
+                                    set(),
+                                    timeout=10,
+                                    seed=123)[0]]
+    plan3 = [(act.name, act.objects)
+             for act in sesame_plan(task2,
+                                    option_model, [sleep_nsrt, cry_nsrt],
+                                    set(),
+                                    timeout=10,
+                                    seed=123)[0]]
+    plan4 = [(act.name, act.objects)
+             for act in sesame_plan(task2,
+                                    option_model, [cry_nsrt, sleep_nsrt],
+                                    set(),
+                                    timeout=10,
+                                    seed=123)[0]]
+    assert plan1 == plan2 == plan3 == plan4
+    # Check that task_plan is deterministic, over both NSRTs and objects.
+    option_specs = [(sleep_nsrt.option, sleep_nsrt.option_vars),
+                    (cry_nsrt.option, cry_nsrt.option_vars)]
+    plan1 = [(act.name, act.objects)
+             for act in task_plan(set(), [robby, robin],
+                                  goal, [sleep_op, cry_op],
+                                  option_specs,
+                                  seed=123,
+                                  timeout=10)[0]]
+    plan2 = [(act.name, act.objects)
+             for act in task_plan(set(), [robby, robin],
+                                  goal, [cry_op, sleep_op],
+                                  option_specs,
+                                  seed=123,
+                                  timeout=10)[0]]
+    plan3 = [(act.name, act.objects)
+             for act in task_plan(set(), [robin, robby],
+                                  goal, [sleep_op, cry_op],
+                                  option_specs,
+                                  seed=123,
+                                  timeout=10)[0]]
+    plan4 = [(act.name, act.objects)
+             for act in task_plan(set(), [robin, robby],
+                                  goal, [cry_op, sleep_op],
+                                  option_specs,
+                                  seed=123,
+                                  timeout=10)[0]]
+    assert plan1 == plan2 == plan3 == plan4


### PR DESCRIPTION
Two line edit, 100 line test, lol. @tomsilver note that we don't have to sort `objects` because all the grounding utils methods eventually use `get_object_combinations`, which sorts the objects.