### PR TITLE
don't give approaches redundant train_tasks argument

### DIFF
--- a/analysis/grammar_search_analysis.py
+++ b/analysis/grammar_search_analysis.py
@@ -14,7 +14,7 @@ from predicators.src.approaches.grammar_search_invention_approach import \
 from predicators.src.approaches.oracle_approach import _get_predicates_by_names
 from predicators.src.main import _run_testing
 from predicators.src import utils
-from predicators.src.structs import Predicate, Dataset, Task
+from predicators.src.structs import Predicate, Dataset
 from predicators.src.settings import CFG
 
 
@@ -97,7 +97,7 @@ def _run_proxy_analysis_for_env(env_name: str,
 
     for non_goal_predicates in non_goal_predicate_sets:
         results_for_predicates = \
-            _run_proxy_analysis_for_predicates(env, dataset, train_tasks,
+            _run_proxy_analysis_for_predicates(env, dataset,
                                                env.goal_predicates,
                                                non_goal_predicates,
                                                score_function_names,
@@ -119,7 +119,6 @@ def _run_proxy_analysis_for_env(env_name: str,
 def _run_proxy_analysis_for_predicates(
     env: BaseEnv,
     dataset: Dataset,
-    train_tasks: List[Task],
     initial_predicates: Set[Predicate],
     predicates: Set[Predicate],
     score_function_names: List[str],
@@ -134,7 +133,7 @@ def _run_proxy_analysis_for_predicates(
     for score_function_name in score_function_names:
         score_function = _create_score_function(score_function_name,
                                                 initial_predicates,
-                                                atom_dataset, train_tasks,
+                                                atom_dataset,
                                                 candidates)
         start_time = time.time()
         score = score_function.evaluate(frozenset(predicates))
@@ -147,7 +146,7 @@ def _run_proxy_analysis_for_predicates(
         approach = create_approach("nsrt_learning", env.simulate,
                                    all_predicates, env.options, env.types,
                                    env.action_space)
-        approach.learn_from_offline_dataset(dataset, train_tasks)
+        approach.learn_from_offline_dataset(dataset)
         approach.seed(CFG.seed)
         planning_result = _run_testing(env, approach)
         results.update(planning_result)

--- a/analysis/grammar_search_analysis.py
+++ b/analysis/grammar_search_analysis.py
@@ -133,8 +133,7 @@ def _run_proxy_analysis_for_predicates(
     for score_function_name in score_function_names:
         score_function = _create_score_function(score_function_name,
                                                 initial_predicates,
-                                                atom_dataset,
-                                                candidates)
+                                                atom_dataset, candidates)
         start_time = time.time()
         score = score_function.evaluate(frozenset(predicates))
         eval_time = time.time() - start_time

--- a/src/approaches/base_approach.py
+++ b/src/approaches/base_approach.py
@@ -2,7 +2,7 @@
 
 import abc
 from collections import defaultdict
-from typing import Set, Callable, List
+from typing import Set, Callable
 import numpy as np
 from gym.spaces import Box
 from predicators.src.structs import State, Task, Predicate, Type, \
@@ -62,11 +62,9 @@ class BaseApproach:
         self._rng = np.random.default_rng(self._seed)
         self._action_space.seed(seed)
 
-    def learn_from_offline_dataset(self, dataset: Dataset,
-                                   train_tasks: List[Task]) -> None:
+    def learn_from_offline_dataset(self, dataset: Dataset) -> None:
         """For learning-based approaches, learn whatever is needed from the
-        given dataset, which was generated from the given train_tasks. Also,
-        should save whatever is necessary to load() later.
+        given dataset. Also, save whatever is necessary to load() later.
 
         Note: this is not an abc.abstractmethod because it does
         not need to be defined by the subclasses. (mypy complains

--- a/src/approaches/grammar_search_invention_approach.py
+++ b/src/approaches/grammar_search_invention_approach.py
@@ -466,8 +466,7 @@ def _create_score_function(
                                              candidates)
     if score_function_name == "hadd_match":
         return _RelaxationHeuristicMatchBasedScoreFunction(
-            initial_predicates, atom_dataset, candidates,
-            ["hadd"])
+            initial_predicates, atom_dataset, candidates, ["hadd"])
     match = re.match(r"([a-z\,]+)_lookahead_depth(\d+)", score_function_name)
     if match is not None:
         # heuristic_name can be any of {"hadd", "hmax", "hff", "hsa", "lmcut"},

--- a/src/approaches/grammar_search_invention_approach.py
+++ b/src/approaches/grammar_search_invention_approach.py
@@ -20,7 +20,7 @@ from predicators.src.nsrt_learning import segment_trajectory, \
     learn_strips_operators
 from predicators.src.planning import task_plan, task_plan_grounding
 from predicators.src.structs import State, Predicate, ParameterizedOption, \
-    Type, Task, Action, Dataset, Object, GroundAtomTrajectory, STRIPSOperator, \
+    Type, Action, Dataset, Object, GroundAtomTrajectory, STRIPSOperator, \
     OptionSpec, Segment, GroundAtom, _GroundSTRIPSOperator
 from predicators.src.settings import CFG
 
@@ -456,17 +456,17 @@ class _ForallPredicateGrammarWrapper(_PredicateGrammar):
 
 def _create_score_function(
         score_function_name: str, initial_predicates: Set[Predicate],
-        atom_dataset: List[GroundAtomTrajectory], train_tasks: List[Task],
+        atom_dataset: List[GroundAtomTrajectory],
         candidates: Dict[Predicate, float]) -> _PredicateSearchScoreFunction:
     if score_function_name == "prediction_error":
         return _PredictionErrorScoreFunction(initial_predicates, atom_dataset,
-                                             train_tasks, candidates)
+                                             candidates)
     if score_function_name == "branching_factor":
         return _BranchingFactorScoreFunction(initial_predicates, atom_dataset,
-                                             train_tasks, candidates)
+                                             candidates)
     if score_function_name == "hadd_match":
         return _RelaxationHeuristicMatchBasedScoreFunction(
-            initial_predicates, atom_dataset, train_tasks, candidates,
+            initial_predicates, atom_dataset, candidates,
             ["hadd"])
     match = re.match(r"([a-z\,]+)_lookahead_depth(\d+)", score_function_name)
     if match is not None:
@@ -477,19 +477,20 @@ def _create_score_function(
         heuristic_names_str, depth = match.groups()
         heuristic_names = heuristic_names_str.split(",")
         depth = int(depth)
+        assert heuristic_names
+        assert depth >= 0
         return _RelaxationHeuristicLookaheadBasedScoreFunction(
             initial_predicates,
             atom_dataset,
-            train_tasks,
             candidates,
             heuristic_names,
             lookahead_depth=depth)
     if score_function_name == "exact_lookahead":
         return _ExactHeuristicLookaheadBasedScoreFunction(
-            initial_predicates, atom_dataset, train_tasks, candidates)
+            initial_predicates, atom_dataset, candidates)
     if score_function_name == "task_planning":
         return _TaskPlanningScoreFunction(initial_predicates, atom_dataset,
-                                          train_tasks, candidates)
+                                          candidates)
     raise NotImplementedError(
         f"Unknown score function: {score_function_name}.")
 
@@ -499,7 +500,6 @@ class _PredicateSearchScoreFunction:
     """A score function for guiding search over predicate sets."""
     _initial_predicates: Set[Predicate]  # predicates given by the environment
     _atom_dataset: List[GroundAtomTrajectory]  # data with all candidates
-    _train_tasks: List[Task]  # training tasks that this data was generated on
     _candidates: Dict[Predicate, float]  # candidate predicates to costs
 
     def evaluate(self, predicates: FrozenSet[Predicate]) -> float:
@@ -615,18 +615,20 @@ class _TaskPlanningScoreFunction(_OperatorLearningBasedScoreFunction):
         del pruned_atom_data, segments  # unused
         score = 0.0
         node_expansion_upper_bound = 1e7
-        for task in self._train_tasks:
-            init_atoms = utils.abstract(task.init,
+        for traj, _ in self._atom_dataset:
+            if not traj.is_demo:
+                continue
+            init_atoms = utils.abstract(traj.states[0],
                                         predicates | self._initial_predicates)
-            objects = set(task.init)
+            objects = set(traj.states[0])
             ground_nsrts, reachable_atoms = task_plan_grounding(
                 init_atoms, objects, strips_ops, option_specs)
             heuristic = utils.create_task_planning_heuristic(
-                CFG.task_planning_heuristic, init_atoms, task.goal,
+                CFG.task_planning_heuristic, init_atoms, traj.goal,
                 ground_nsrts, predicates | self._initial_predicates, objects)
             try:
                 _, _, metrics = task_plan(
-                    init_atoms, task.goal, ground_nsrts, reachable_atoms,
+                    init_atoms, traj.goal, ground_nsrts, reachable_atoms,
                     heuristic, CFG.seed,
                     CFG.grammar_search_task_planning_timeout)
                 node_expansions = metrics["num_nodes_expanded"]
@@ -785,7 +787,6 @@ class _RelaxationHeuristicBasedScoreFunction(_HeuristicBasedScoreFunction):  # p
             set(predicates) | self._initial_predicates, objects)
         del init_atoms  # unused after this
         cache: Dict[Tuple[FrozenSet[GroundAtom], int], float] = {}
-        assert self.lookahead_depth >= 0
 
         def _relaxation_h(atoms: Set[GroundAtom], depth: int = 0) -> float:
             cache_key = (frozenset(atoms), depth)
@@ -903,8 +904,7 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
     def _get_current_predicates(self) -> Set[Predicate]:
         return self._initial_predicates | self._learned_predicates
 
-    def learn_from_offline_dataset(self, dataset: Dataset,
-                                   train_tasks: List[Task]) -> None:
+    def learn_from_offline_dataset(self, dataset: Dataset) -> None:
         self._dataset.extend(dataset)
         del dataset
         # Generate a candidate set of predicates.
@@ -924,7 +924,7 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
         # Create the score function that will be used to guide search.
         score_function = _create_score_function(
             CFG.grammar_search_score_function, self._initial_predicates,
-            atom_dataset, train_tasks, candidates)
+            atom_dataset, candidates)
         # Select a subset of the candidates to keep.
         print("Selecting a subset...")
         self._learned_predicates = _select_predicates_to_keep(

--- a/src/approaches/interactive_learning_approach.py
+++ b/src/approaches/interactive_learning_approach.py
@@ -55,8 +55,9 @@ class InteractiveLearningApproach(NSRTLearningApproach):
     def learn_from_offline_dataset(self, dataset: Dataset) -> None:
         self._load_dataset(dataset)
         del dataset
-        demo_idxs = [idx for idx, traj in enumerate(self._dataset)
-                     if traj.is_demo]
+        demo_idxs = [
+            idx for idx, traj in enumerate(self._dataset) if traj.is_demo
+        ]
         # Learn predicates and NSRTs
         self._relearn_predicates_and_nsrts()
         # Active learning

--- a/src/approaches/interactive_learning_approach.py
+++ b/src/approaches/interactive_learning_approach.py
@@ -52,10 +52,11 @@ class InteractiveLearningApproach(NSRTLearningApproach):
         self._dataset.extend(dataset)
         self._dataset_with_atoms.extend(self._teacher.generate_data(dataset))
 
-    def learn_from_offline_dataset(self, dataset: Dataset,
-                                   train_tasks: List[Task]) -> None:
+    def learn_from_offline_dataset(self, dataset: Dataset) -> None:
         self._load_dataset(dataset)
         del dataset
+        demo_idxs = [idx for idx, traj in enumerate(self._dataset)
+                     if traj.is_demo]
         # Learn predicates and NSRTs
         self._relearn_predicates_and_nsrts()
         # Active learning
@@ -63,8 +64,8 @@ class InteractiveLearningApproach(NSRTLearningApproach):
         for i in range(1, CFG.interactive_num_episodes + 1):
             print(f"\nActive learning episode {i}")
             # Sample initial state from train tasks
-            index = self._rng.choice(len(train_tasks))
-            state = train_tasks[index].init
+            index = self._rng.choice(demo_idxs)
+            state = self._dataset[index].states[0]
             # Find policy for exploration
             task_list = glib_sample(state, self._get_current_predicates(),
                                     self._dataset_with_atoms)

--- a/src/approaches/iterative_invention_approach.py
+++ b/src/approaches/iterative_invention_approach.py
@@ -8,8 +8,8 @@ from gym.spaces import Box
 from predicators.src import utils
 from predicators.src.approaches import NSRTLearningApproach
 from predicators.src.structs import State, Predicate, ParameterizedOption, \
-    Type, Task, Action, Dataset, Array, STRIPSOperator, Datastore, \
-    Segment, LiftedAtom, GroundAtom, OptionSpec
+    Type, Action, Dataset, Array, STRIPSOperator, Datastore, Segment, \
+    LiftedAtom, GroundAtom, OptionSpec
 from predicators.src.torch_models import LearnedPredicateClassifier, \
     MLPClassifier
 from predicators.src.nsrt_learning import segment_trajectory, \
@@ -32,8 +32,7 @@ class IterativeInventionApproach(NSRTLearningApproach):
     def _get_current_predicates(self) -> Set[Predicate]:
         return self._initial_predicates | self._learned_predicates
 
-    def learn_from_offline_dataset(self, dataset: Dataset,
-                                   train_tasks: List[Task]) -> None:
+    def learn_from_offline_dataset(self, dataset: Dataset) -> None:
         self._dataset.extend(dataset)
         del dataset
         # Use the current predicates to segment dataset.

--- a/src/approaches/nsrt_learning_approach.py
+++ b/src/approaches/nsrt_learning_approach.py
@@ -4,12 +4,12 @@ In contrast to other approaches, this approach does not attempt to learn
 new predicates or options.
 """
 
-from typing import Callable, Set, List
+from typing import Callable, Set
 import dill as pkl
 from gym.spaces import Box
 from predicators.src.approaches import TAMPApproach
 from predicators.src.structs import Dataset, NSRT, ParameterizedOption, \
-    State, Action, Predicate, Type, Task
+    State, Action, Predicate, Type
 from predicators.src.nsrt_learning import learn_nsrts_from_data
 from predicators.src.settings import CFG
 from predicators.src import utils
@@ -35,8 +35,7 @@ class NSRTLearningApproach(TAMPApproach):
         assert self._nsrts, "NSRTs not learned"
         return self._nsrts
 
-    def learn_from_offline_dataset(self, dataset: Dataset,
-                                   train_tasks: List[Task]) -> None:
+    def learn_from_offline_dataset(self, dataset: Dataset) -> None:
         # The only thing we need to do here is learn NSRTs,
         # which we split off into a different function in case
         # subclasses want to make use of it.

--- a/src/main.py
+++ b/src/main.py
@@ -96,7 +96,7 @@ def main() -> None:
                 print(f"\n\nDATASET INDEX: {dataset_idx}")
                 dataset_idx += 1
                 learning_start = time.time()
-                approach.learn_from_offline_dataset(dataset, train_tasks)
+                approach.learn_from_offline_dataset(dataset)
                 learning_time = time.time() - learning_start
                 results = _run_testing(env, approach)
                 _save_test_results(results, learning_time=learning_time)

--- a/src/settings.py
+++ b/src/settings.py
@@ -131,7 +131,7 @@ class GlobalSettings:
     grammar_search_pred_complexity_weight = 1
     grammar_search_max_predicates = 50
     grammar_search_predicate_cost_upper_bound = 6
-    grammar_search_score_function = "hff_lookahead_depth0"
+    grammar_search_score_function = "task_planning"
     grammar_search_heuristic_based_weight = 10.
     grammar_search_heuristic_based_max_demos = 5
     grammar_search_lookahead_based_temperature = 10.

--- a/src/structs.py
+++ b/src/structs.py
@@ -903,7 +903,7 @@ class LowLevelTrajectory:
 
         Requires is_demo to be True.
         """
-        assert self._goal is not None
+        assert self._goal is not None, "This trajectory is not a demo!"
         return self._goal
 
 

--- a/tests/approaches/test_base_approach.py
+++ b/tests/approaches/test_base_approach.py
@@ -72,7 +72,7 @@ def test_base_approach():
     approach = _DummyApproach(_simulator, predicates, options, types,
                               action_space)
     assert not approach.is_learning_based
-    assert approach.learn_from_offline_dataset([], []) is None
+    assert approach.learn_from_offline_dataset([]) is None
     # Try solving with dummy approach.
     policy = approach.solve(task, 500)
     for _ in range(10):

--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -190,7 +190,8 @@ def test_create_score_function():
                       _RelaxationHeuristicLookaheadBasedScoreFunction)
     assert score_func.lookahead_depth == 0
     assert score_func.heuristic_names == ["hsa"]
-    score_func = _create_score_function("lmcut_lookahead_depth0", set(), [], {})
+    score_func = _create_score_function("lmcut_lookahead_depth0", set(), [],
+                                        {})
     assert isinstance(score_func,
                       _RelaxationHeuristicLookaheadBasedScoreFunction)
     assert score_func.lookahead_depth == 0
@@ -220,8 +221,7 @@ def test_create_score_function():
 def test_predicate_search_heuristic_base_classes():
     """Cover the abstract methods for _PredicateSearchScoreFunction &
     subclasses."""
-    pred_search_score_function = _PredicateSearchScoreFunction(
-        set(), [], {})
+    pred_search_score_function = _PredicateSearchScoreFunction(set(), [], {})
     with pytest.raises(NotImplementedError):
         pred_search_score_function.evaluate(set())
     op_learning_score_function = _OperatorLearningBasedScoreFunction(
@@ -245,8 +245,8 @@ def test_predicate_search_heuristic_base_classes():
     action.set_option(option)
     dataset = [LowLevelTrajectory([state, other_state], [action], set())]
     atom_dataset = utils.create_ground_atom_dataset(dataset, set())
-    heuristic_score_fn = _HeuristicBasedScoreFunction(set(), atom_dataset,
-                                                      {}, ["hadd"])
+    heuristic_score_fn = _HeuristicBasedScoreFunction(set(), atom_dataset, {},
+                                                      ["hadd"])
     with pytest.raises(NotImplementedError):
         heuristic_score_fn.evaluate(set())
     hadd_score_fn = _RelaxationHeuristicBasedScoreFunction(

--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -168,71 +168,64 @@ def test_unary_free_forall_classifier():
 
 def test_create_score_function():
     """Tests for _create_score_function()."""
-    score_func = _create_score_function("prediction_error", set(), [], [], {})
+    score_func = _create_score_function("prediction_error", set(), [], {})
     assert isinstance(score_func, _PredictionErrorScoreFunction)
-    score_func = _create_score_function("hadd_match", set(), [], [], {})
+    score_func = _create_score_function("hadd_match", set(), [], {})
     assert isinstance(score_func, _RelaxationHeuristicMatchBasedScoreFunction)
     assert score_func.heuristic_names == ["hadd"]
-    score_func = _create_score_function("branching_factor", set(), [], [], {})
+    score_func = _create_score_function("branching_factor", set(), [], {})
     assert isinstance(score_func, _BranchingFactorScoreFunction)
-    score_func = _create_score_function("hadd_lookahead_depth0", set(), [], [],
-                                        {})
+    score_func = _create_score_function("hadd_lookahead_depth0", set(), [], {})
     assert isinstance(score_func,
                       _RelaxationHeuristicLookaheadBasedScoreFunction)
     assert score_func.lookahead_depth == 0
     assert score_func.heuristic_names == ["hadd"]
-    score_func = _create_score_function("hmax_lookahead_depth0", set(), [], [],
-                                        {})
+    score_func = _create_score_function("hmax_lookahead_depth0", set(), [], {})
     assert isinstance(score_func,
                       _RelaxationHeuristicLookaheadBasedScoreFunction)
     assert score_func.lookahead_depth == 0
     assert score_func.heuristic_names == ["hmax"]
-    score_func = _create_score_function("hsa_lookahead_depth0", set(), [], [],
-                                        {})
+    score_func = _create_score_function("hsa_lookahead_depth0", set(), [], {})
     assert isinstance(score_func,
                       _RelaxationHeuristicLookaheadBasedScoreFunction)
     assert score_func.lookahead_depth == 0
     assert score_func.heuristic_names == ["hsa"]
-    score_func = _create_score_function("lmcut_lookahead_depth0", set(), [],
-                                        [], {})
+    score_func = _create_score_function("lmcut_lookahead_depth0", set(), [], {})
     assert isinstance(score_func,
                       _RelaxationHeuristicLookaheadBasedScoreFunction)
     assert score_func.lookahead_depth == 0
     assert score_func.heuristic_names == ["lmcut"]
-    score_func = _create_score_function("hadd_lookahead_depth1", set(), [], [],
-                                        {})
+    score_func = _create_score_function("hadd_lookahead_depth1", set(), [], {})
     assert score_func.lookahead_depth == 1
-    score_func = _create_score_function("hadd_lookahead_depth2", set(), [], [],
-                                        {})
+    score_func = _create_score_function("hadd_lookahead_depth2", set(), [], {})
     assert score_func.lookahead_depth == 2
-    score_func = _create_score_function("hff_lookahead_depth0", set(), [], [],
-                                        {})
+    score_func = _create_score_function("hff_lookahead_depth0", set(), [], {})
     assert isinstance(score_func,
                       _RelaxationHeuristicLookaheadBasedScoreFunction)
     assert score_func.heuristic_names == ["hff"]
     score_func = _create_score_function("lmcut,hff_lookahead_depth0", set(),
-                                        [], [], {})
+                                        [], {})
     assert isinstance(score_func,
                       _RelaxationHeuristicLookaheadBasedScoreFunction)
     assert score_func.lookahead_depth == 0
     assert score_func.heuristic_names == ["lmcut", "hff"]
-    score_func = _create_score_function("exact_lookahead", set(), [], [], {})
+    score_func = _create_score_function("exact_lookahead", set(), [], {})
     assert isinstance(score_func, _ExactHeuristicLookaheadBasedScoreFunction)
-    score_func = _create_score_function("task_planning", set(), [], [], {})
+    score_func = _create_score_function("task_planning", set(), [], {})
     assert isinstance(score_func, _TaskPlanningScoreFunction)
     with pytest.raises(NotImplementedError):
-        _create_score_function("not a real score function", set(), [], [], {})
+        _create_score_function("not a real score function", set(), [], {})
 
 
 def test_predicate_search_heuristic_base_classes():
     """Cover the abstract methods for _PredicateSearchScoreFunction &
     subclasses."""
     pred_search_score_function = _PredicateSearchScoreFunction(
-        set(), [], [], {})
+        set(), [], {})
     with pytest.raises(NotImplementedError):
         pred_search_score_function.evaluate(set())
     op_learning_score_function = _OperatorLearningBasedScoreFunction(
-        set(), [], [], {})
+        set(), [], {})
     with pytest.raises(NotImplementedError):
         op_learning_score_function.evaluate(set())
     utils.update_config({"env": "cover"})
@@ -253,12 +246,11 @@ def test_predicate_search_heuristic_base_classes():
     dataset = [LowLevelTrajectory([state, other_state], [action], set())]
     atom_dataset = utils.create_ground_atom_dataset(dataset, set())
     heuristic_score_fn = _HeuristicBasedScoreFunction(set(), atom_dataset,
-                                                      train_tasks, {},
-                                                      ["hadd"])
+                                                      {}, ["hadd"])
     with pytest.raises(NotImplementedError):
         heuristic_score_fn.evaluate(set())
     hadd_score_fn = _RelaxationHeuristicBasedScoreFunction(
-        set(), atom_dataset, train_tasks, {}, ["hadd"])
+        set(), atom_dataset, {}, ["hadd"])
     with pytest.raises(NotImplementedError):
         hadd_score_fn.evaluate(set())
 
@@ -285,8 +277,7 @@ def test_prediction_error_score_function():
     dataset = create_dataset(env, train_tasks)
     atom_dataset = utils.create_ground_atom_dataset(dataset, env.predicates)
     score_function = _PredictionErrorScoreFunction(initial_predicates,
-                                                   atom_dataset, train_tasks,
-                                                   candidates)
+                                                   atom_dataset, candidates)
     all_included_s = score_function.evaluate(set(candidates))
     handempty_included_s = score_function.evaluate({name_to_pred["HandEmpty"]})
     holding_included_s = score_function.evaluate({name_to_pred["Holding"]})
@@ -315,8 +306,7 @@ def test_prediction_error_score_function():
     dataset = create_dataset(env, train_tasks)
     atom_dataset = utils.create_ground_atom_dataset(dataset, env.predicates)
     score_function = _PredictionErrorScoreFunction(initial_predicates,
-                                                   atom_dataset, train_tasks,
-                                                   candidates)
+                                                   atom_dataset, candidates)
     all_included_s = score_function.evaluate(set(candidates))
     holding_included_s = score_function.evaluate({name_to_pred["Holding"]})
     clear_included_s = score_function.evaluate({name_to_pred["Clear"]})
@@ -350,7 +340,7 @@ def test_hadd_match_score_function():
     dataset = create_dataset(env, train_tasks)
     atom_dataset = utils.create_ground_atom_dataset(dataset, env.predicates)
     score_function = _RelaxationHeuristicMatchBasedScoreFunction(
-        initial_predicates, atom_dataset, train_tasks, candidates, ["hadd"])
+        initial_predicates, atom_dataset, candidates, ["hadd"])
     handempty_included_s = score_function.evaluate({name_to_pred["HandEmpty"]})
     none_included_s = score_function.evaluate(set())
     assert handempty_included_s > none_included_s  # this is very bad!
@@ -381,7 +371,7 @@ def test_relaxation_lookahead_score_function():
     dataset = create_dataset(env, train_tasks)
     atom_dataset = utils.create_ground_atom_dataset(dataset, env.predicates)
     score_function = _RelaxationHeuristicLookaheadBasedScoreFunction(
-        initial_predicates, atom_dataset, train_tasks, candidates, ["hadd"])
+        initial_predicates, atom_dataset, candidates, ["hadd"])
     all_included_s = score_function.evaluate(set(candidates))
     handempty_included_s = score_function.evaluate({name_to_pred["HandEmpty"]})
     holding_included_s = score_function.evaluate({name_to_pred["Holding"]})
@@ -412,8 +402,7 @@ def test_relaxation_lookahead_score_function():
     for heuristic_name in ["hadd", "hmax", "hff", "hsa", "lmcut"]:
         # Reuse dataset from above.
         score_function = _MockLookahead(initial_predicates, atom_dataset,
-                                        train_tasks, candidates,
-                                        [heuristic_name])
+                                        candidates, [heuristic_name])
         assert score_function.evaluate(set()) == float("inf")
 
     # Tests for BlocksEnv.
@@ -437,7 +426,7 @@ def test_relaxation_lookahead_score_function():
     dataset = create_dataset(env, train_tasks)
     atom_dataset = utils.create_ground_atom_dataset(dataset, env.predicates)
     score_function = _RelaxationHeuristicLookaheadBasedScoreFunction(
-        initial_predicates, atom_dataset, train_tasks, candidates, ["hadd"])
+        initial_predicates, atom_dataset, candidates, ["hadd"])
     all_included_s = score_function.evaluate(set(candidates))
     none_included_s = score_function.evaluate(set())
     gripperopen_excluded_s = score_function.evaluate(
@@ -460,7 +449,6 @@ def test_relaxation_lookahead_score_function():
     score_function = _RelaxationHeuristicLookaheadBasedScoreFunction(
         initial_predicates,
         atom_dataset,
-        train_tasks,
         candidates, ["hadd"],
         lookahead_depth=1)
     all_included_s = score_function.evaluate(set(candidates))
@@ -491,7 +479,7 @@ def test_relaxation_lookahead_score_function():
     dataset = create_dataset(env, train_tasks)
     atom_dataset = utils.create_ground_atom_dataset(dataset, env.predicates)
     score_function = _RelaxationHeuristicLookaheadBasedScoreFunction(
-        initial_predicates, atom_dataset, train_tasks, candidates, ["hadd"])
+        initial_predicates, atom_dataset, candidates, ["hadd"])
     all_included_s = score_function.evaluate(set(candidates))
     none_included_s = score_function.evaluate(set())
 
@@ -529,7 +517,6 @@ def test_relaxation_lookahead_score_function():
 
     score_function = _MockHAddLookahead(initial_predicates,
                                         atom_dataset,
-                                        train_tasks,
                                         candidates, ["hadd"],
                                         lookahead_depth=1)
     assert score_function.evaluate(set(candidates)) == float("inf")
@@ -563,7 +550,7 @@ def test_exact_lookahead_score_function():
     dataset = create_dataset(env, train_tasks)
     atom_dataset = utils.create_ground_atom_dataset(dataset, env.predicates)
     score_function = _ExactHeuristicLookaheadBasedScoreFunction(
-        initial_predicates, atom_dataset, train_tasks, candidates)
+        initial_predicates, atom_dataset, candidates)
     all_included_s = score_function.evaluate(set(candidates))
     none_included_s = score_function.evaluate(set())
     gripperopen_excluded_s = score_function.evaluate(
@@ -582,7 +569,7 @@ def test_exact_lookahead_score_function():
     candidates = {p: 1.0 for p in name_to_pred.values()}
     # Reuse dataset from above.
     score_function = _ExactHeuristicLookaheadBasedScoreFunction(
-        initial_predicates, atom_dataset, train_tasks, candidates)
+        initial_predicates, atom_dataset, candidates)
     assert score_function.evaluate(set()) == float("inf")
     old_hbmd = CFG.grammar_search_heuristic_based_max_demos
     utils.update_config({"grammar_search_heuristic_based_max_demos": 0})
@@ -626,8 +613,7 @@ def test_branching_factor_score_function():
     atom_dataset = utils.create_ground_atom_dataset(
         dataset, env.goal_predicates | set(candidates))
     score_function = _BranchingFactorScoreFunction(env.goal_predicates,
-                                                   atom_dataset, train_tasks,
-                                                   candidates)
+                                                   atom_dataset, candidates)
     holding_s = score_function.evaluate({Holding})
     forall_not_covers_s = score_function.evaluate(
         {forall_not_covers0, forall_not_covers1})
@@ -662,8 +648,7 @@ def test_task_planning_score_function():
     atom_dataset = utils.create_ground_atom_dataset(
         dataset, env.goal_predicates | set(candidates))
     score_function = _TaskPlanningScoreFunction(env.goal_predicates,
-                                                atom_dataset, train_tasks,
-                                                candidates)
+                                                atom_dataset, candidates)
     all_included_s = score_function.evaluate({Holding, HandEmpty})
     none_included_s = score_function.evaluate(set())
     # This is terrible!

--- a/tests/approaches/test_interactive_approach.py
+++ b/tests/approaches/test_interactive_approach.py
@@ -84,7 +84,7 @@ def test_interactive_learning_approach():
     train_tasks = next(env.train_tasks_generator())
     dataset = create_dataset(env, train_tasks)
     assert approach.is_learning_based
-    approach.learn_from_offline_dataset(dataset, train_tasks)
+    approach.learn_from_offline_dataset(dataset)
     for task in env.get_test_tasks():
         try:
             approach.solve(task, timeout=CFG.timeout)
@@ -179,4 +179,4 @@ def test_interactive_learning_approach_no_ground_atoms():
     assert approach.is_learning_based
     # MLP training fails since there are 0 positive examples
     with pytest.raises(RuntimeError):
-        approach.learn_from_offline_dataset(dataset, train_tasks)
+        approach.learn_from_offline_dataset(dataset)

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -53,7 +53,7 @@ def _test_approach(env_name,
     train_tasks = next(env.train_tasks_generator())
     dataset = create_dataset(env, train_tasks)
     assert approach.is_learning_based
-    approach.learn_from_offline_dataset(dataset, train_tasks)
+    approach.learn_from_offline_dataset(dataset)
     task = env.get_test_tasks()[0]
     if try_solving:
         policy = approach.solve(task, timeout=CFG.timeout)


### PR DESCRIPTION
A simple code quality change here. Passing train_tasks into
learn_from_offline_dataset is a relic from the past, when we didn't have
our demonstration trajectories annotated with goals. All the information
in train_tasks is already contained in the Dataset object itself.

Instead of:
```
for task in train_tasks:
    print(task.init, task.goal)
```
one can do:
```
for traj in dataset:
    if not traj.is_demo:
        continue
    print(traj.states[0], traj.goal)
```