### PR TITLE
Interactive approach: change known predicates setting to string format

### DIFF
--- a/src/approaches/interactive_learning_approach.py
+++ b/src/approaches/interactive_learning_approach.py
@@ -28,8 +28,7 @@ class InteractiveLearningApproach(NSRTLearningApproach):
         known_predicates = set(CFG.interactive_known_predicates.split(","))
         self._known_predicates = {
             p
-            for p in initial_predicates
-            if p.name in known_predicates
+            for p in initial_predicates if p.name in known_predicates
         }
         predicates_to_learn = initial_predicates - self._known_predicates
         self._teacher = _Teacher(initial_predicates, predicates_to_learn)

--- a/src/approaches/interactive_learning_approach.py
+++ b/src/approaches/interactive_learning_approach.py
@@ -25,10 +25,11 @@ class InteractiveLearningApproach(NSRTLearningApproach):
         # Predicates should not be ablated
         assert not CFG.excluded_predicates
         # Only the teacher is allowed to know about the initial predicates
+        known_predicates = set(CFG.interactive_known_predicates.split(","))
         self._known_predicates = {
             p
             for p in initial_predicates
-            if p.name in CFG.interactive_known_predicates
+            if p.name in known_predicates
         }
         predicates_to_learn = initial_predicates - self._known_predicates
         self._teacher = _Teacher(initial_predicates, predicates_to_learn)

--- a/src/settings.py
+++ b/src/settings.py
@@ -109,7 +109,7 @@ class GlobalSettings:
     predicate_mlp_classifier_max_itr = 1000
 
     # interactive learning parameters
-    interactive_known_predicates = f"GripperOpen,Holding,Clear,NextToTable," \
+    interactive_known_predicates = "GripperOpen,Holding,Clear,NextToTable," \
         "NextToDoor,NextToDial,InRegion,Borders,Connects,IsBoringRoom," \
         "IsPlayroom,IsBoringRoomDoor,IsPlayroomDoor,DoorOpen,DoorClosed," \
         "LightOn,LightOff,On,OnTable"

--- a/src/settings.py
+++ b/src/settings.py
@@ -109,12 +109,10 @@ class GlobalSettings:
     predicate_mlp_classifier_max_itr = 1000
 
     # interactive learning parameters
-    interactive_known_predicates = {
-        "GripperOpen", "Holding", "Clear", "NextToTable", "NextToDoor",
-        "NextToDial", "InRegion", "Borders", "Connects", "IsBoringRoom",
-        "IsPlayroom", "IsBoringRoomDoor", "IsPlayroomDoor", "DoorOpen",
-        "DoorClosed", "LightOn", "LightOff", "On", "OnTable"
-    }
+    interactive_known_predicates = f"GripperOpen,Holding,Clear,NextToTable," \
+        "NextToDoor,NextToDial,InRegion,Borders,Connects,IsBoringRoom," \
+        "IsPlayroom,IsBoringRoomDoor,IsPlayroomDoor,DoorOpen,DoorClosed," \
+        "LightOn,LightOff,On,OnTable"
     interactive_num_episodes = 0
     interactive_max_steps = 21
     interactive_relearn_every = 1

--- a/tests/approaches/test_interactive_approach.py
+++ b/tests/approaches/test_interactive_approach.py
@@ -55,18 +55,30 @@ def test_create_teacher_dataset():
 def test_interactive_learning_approach():
     """Test for InteractiveLearningApproach class, entire pipeline."""
     utils.update_config({
-        "env": "cover",
-        "approach": "interactive_learning",
-        "excluded_predicates": "",
-        "timeout": 10,
-        "max_samples_per_step": 10,
-        "seed": 12345,
-        "sampler_mlp_classifier_max_itr": 500,
-        "predicate_mlp_classifier_max_itr": 500,
-        "neural_gaus_regressor_max_itr": 500,
-        "interactive_num_episodes": 1,
-        "interactive_relearn_every": 1,
-        "interactive_known_predicates": "HandEmpty,Holding,Covers"
+        "env":
+        "cover",
+        "approach":
+        "interactive_learning",
+        "excluded_predicates":
+        "",
+        "timeout":
+        10,
+        "max_samples_per_step":
+        10,
+        "seed":
+        12345,
+        "sampler_mlp_classifier_max_itr":
+        500,
+        "predicate_mlp_classifier_max_itr":
+        500,
+        "neural_gaus_regressor_max_itr":
+        500,
+        "interactive_num_episodes":
+        1,
+        "interactive_relearn_every":
+        1,
+        "interactive_known_predicates":
+        "HandEmpty,Holding,Covers"
     })
     env = CoverEnv()
     approach = _DummyInteractiveLearningApproach(env.simulate, env.predicates,
@@ -96,13 +108,20 @@ def test_interactive_learning_approach_no_ground_atoms():
     """Test for InteractiveLearningApproach class where the dataset contains an
     empty ground atom set."""
     utils.update_config({
-        "env": "cover",
-        "approach": "interactive_learning",
-        "timeout": 10,
-        "max_samples_per_step": 10,
-        "seed": 12345,
-        "interactive_num_episodes": 0,
-        "teacher_dataset_label_ratio": 0.0,
+        "env":
+        "cover",
+        "approach":
+        "interactive_learning",
+        "timeout":
+        10,
+        "max_samples_per_step":
+        10,
+        "seed":
+        12345,
+        "interactive_num_episodes":
+        0,
+        "teacher_dataset_label_ratio":
+        0.0,
         "interactive_known_predicates":
         "HandEmpty,IsBlock,IsTarget,Holding"
     })

--- a/tests/approaches/test_interactive_approach.py
+++ b/tests/approaches/test_interactive_approach.py
@@ -66,7 +66,7 @@ def test_interactive_learning_approach():
         "neural_gaus_regressor_max_itr": 500,
         "interactive_num_episodes": 1,
         "interactive_relearn_every": 1,
-        "interactive_known_predicates": {'HandEmpty', 'Holding', 'Covers'}
+        "interactive_known_predicates": "HandEmpty,Holding,Covers"
     })
     env = CoverEnv()
     approach = _DummyInteractiveLearningApproach(env.simulate, env.predicates,
@@ -104,7 +104,7 @@ def test_interactive_learning_approach_no_ground_atoms():
         "interactive_num_episodes": 0,
         "teacher_dataset_label_ratio": 0.0,
         "interactive_known_predicates":
-        {'HandEmpty', 'IsBlock', 'IsTarget', 'Holding'}
+        "HandEmpty,IsBlock,IsTarget,Holding"
     })
     env = CoverEnv()
     approach = _DummyInteractiveLearningApproach(env.simulate, env.predicates,


### PR DESCRIPTION
Changes the `interactive_known_predicates` config setting to be a string, so it can easily be changed from the commandline.