### PR TITLE
clean up random seeding

### DIFF
--- a/src/approaches/base_approach.py
+++ b/src/approaches/base_approach.py
@@ -7,6 +7,7 @@ import numpy as np
 from gym.spaces import Box
 from predicators.src.structs import State, Task, Predicate, Type, \
     ParameterizedOption, Action, Dataset, Metrics
+from predicators.src.settings import CFG
 
 
 class BaseApproach:
@@ -24,7 +25,7 @@ class BaseApproach:
         self._types = types
         self._action_space = action_space
         self._metrics: Metrics = defaultdict(float)
-        self.seed(0)
+        self.seed(CFG.seed)
 
     @property
     @abc.abstractmethod

--- a/src/envs/base_env.py
+++ b/src/envs/base_env.py
@@ -15,13 +15,6 @@ class BaseEnv:
     def __init__(self) -> None:
         self.seed(CFG.seed)
 
-    def __post_init__(self) -> None:
-        # The action space and option spaces should be seeded after __init__
-        # because they may be created during __init__.
-        self.action_space.seed(CFG.seed)
-        for option in self.options:
-            option.params_space.seed(CFG.seed)
-
     @abc.abstractmethod
     def simulate(self, state: State, action: Action) -> State:
         """Get the next state, given a state and an action.

--- a/src/envs/base_env.py
+++ b/src/envs/base_env.py
@@ -14,6 +14,10 @@ class BaseEnv:
 
     def __init__(self) -> None:
         self.seed(CFG.seed)
+
+    def __post_init__(self) -> None:
+        # The action space and option spaces should be seeded after __init__
+        # because they may be created during __init__.
         self.action_space.seed(CFG.seed)
         for option in self.options:
             option.params_space.seed(CFG.seed)

--- a/src/envs/base_env.py
+++ b/src/envs/base_env.py
@@ -6,13 +6,17 @@ import numpy as np
 from gym.spaces import Box
 from predicators.src.structs import State, Task, Predicate, \
     ParameterizedOption, Type, Action, Image, Object
+from predicators.src.settings import CFG
 
 
 class BaseEnv:
     """Base environment."""
 
     def __init__(self) -> None:
-        self.seed(0)
+        self.seed(CFG.seed)
+        self.action_space.seed(CFG.seed)
+        for option in self.options:
+            option.params_space.seed(CFG.seed)
 
     @abc.abstractmethod
     def simulate(self, state: State, action: Action) -> State:

--- a/src/main.py
+++ b/src/main.py
@@ -53,6 +53,11 @@ def main() -> None:
         os.mkdir(CFG.results_dir)
     # Create classes. Note that seeding happens inside the env and approach.
     env = create_env(CFG.env)
+    # The action space and options need to be seeded externally, because
+    # env.action_space and env.options are often created during env __init__().
+    env.action_space.seed(CFG.seed)
+    for option in env.options:
+        option.params_space.seed(CFG.seed)
     assert env.goal_predicates.issubset(env.predicates)
     if CFG.excluded_predicates:
         if CFG.excluded_predicates == "all":

--- a/src/main.py
+++ b/src/main.py
@@ -51,7 +51,7 @@ def main() -> None:
                                  "HEAD"]).decode("ascii").strip())
     if not os.path.exists(CFG.results_dir):
         os.mkdir(CFG.results_dir)
-    # Create classes. Note that seeding happens in __init__().
+    # Create classes. Note that seeding happens inside the env and approach.
     env = create_env(CFG.env)
     assert env.goal_predicates.issubset(env.predicates)
     if CFG.excluded_predicates:

--- a/src/main.py
+++ b/src/main.py
@@ -51,7 +51,7 @@ def main() -> None:
                                  "HEAD"]).decode("ascii").strip())
     if not os.path.exists(CFG.results_dir):
         os.mkdir(CFG.results_dir)
-    # Create & seed classes
+    # Create classes. Note that seeding happens in __init__().
     env = create_env(CFG.env)
     assert env.goal_predicates.issubset(env.predicates)
     if CFG.excluded_predicates:
@@ -76,11 +76,6 @@ def main() -> None:
         preds = env.predicates
     approach = create_approach(CFG.approach, env.simulate, preds, env.options,
                                env.types, env.action_space)
-    env.seed(CFG.seed)
-    approach.seed(CFG.seed)
-    env.action_space.seed(CFG.seed)
-    for option in env.options:
-        option.params_space.seed(CFG.seed)
     # If approach is learning-based, get training datasets and do learning,
     # testing after each learning call. Otherwise, just do testing.
     if approach.is_learning_based:

--- a/src/utils.py
+++ b/src/utils.py
@@ -1146,7 +1146,7 @@ def save_video(outfile: str, video: Video) -> None:
     print(f"Wrote out to {outpath}")
 
 
-def update_config(args: Dict[str, Any]) -> None:
+def update_config(args: Dict[str, Any], default_seed: int = 123) -> None:
     """Args is a dictionary of new arguments to add to the config CFG."""
     # Only override attributes, don't create new ones
     allowed_args = set(CFG.__dict__)
@@ -1160,6 +1160,12 @@ def update_config(args: Dict[str, Any]) -> None:
     for d in [GlobalSettings.get_arg_specific_settings(args), args]:
         for k, v in d.items():
             CFG.__setattr__(k, v)
+    # Maintain the invariant that CFG has some seed set. This is very useful
+    # in unit tests, where there are often no commandline args being passed, so
+    # no seed is being set. We always want a seed set because environments and
+    # approaches use the seed during construction.
+    if "seed" not in CFG.__dict__:
+        CFG.__setattr__("seed", default_seed)
 
 
 def get_config_path_str() -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1353,6 +1353,13 @@ def test_update_config():
     assert CFG.seed == 321
     with pytest.raises(ValueError):
         utils.update_config({"not a real setting name": 0})
+    # Test that default seed gets set automatically.
+    del CFG.seed
+    assert "seed" not in CFG.__dict__
+    with pytest.raises(AttributeError):
+        _ = CFG.seed
+    utils.update_config({"env": "cover"})
+    assert CFG.seed == 123
 
 
 def test_run_gbfs():


### PR DESCRIPTION
@ronuchit the change to `update_config` is not super ideal, but the alternatives -- updating all current and future unit tests to explicitly set `seed`, or keep things the way they are now -- seem less good. lmk what you think though.

cc @NishanthJKumar , who originally pointed out the seed(0) grossness.