### PR TITLE
check only expected atom classifiers during planning

### DIFF
--- a/src/planning.py
+++ b/src/planning.py
@@ -272,7 +272,6 @@ def _run_low_level_search(task: Task, option_model: _OptionModel,
                 cur_idx += 1
                 # Check atoms against expected atoms_sequence constraint.
                 assert len(traj) == len(atoms_sequence)
-                atoms = utils.abstract(traj[cur_idx], predicates)
                 # The expected atoms are ones that we definitely expect to be
                 # true at this point in the plan. They are not *all* the atoms
                 # that could be true.
@@ -281,7 +280,9 @@ def _run_low_level_search(task: Task, option_model: _OptionModel,
                     for atom in atoms_sequence[cur_idx]
                     if atom.predicate.name != _NOT_CAUSES_FAILURE
                 }
-                if atoms.issuperset(expected_atoms):
+                # This is equivalent to, but faster than, checking whether
+                # expected_atoms is a subset of utils.abstract(next_state, ...).
+                if all(atom.holds(next_state) for atom in expected_atoms):
                     can_continue_on = True
                     if cur_idx == len(skeleton):  # success!
                         result = plan

--- a/src/planning.py
+++ b/src/planning.py
@@ -87,8 +87,8 @@ def sesame_plan(
                     task, reachable_nsrts, init_atoms, heuristic, new_seed,
                     timeout - (time.time() - start_time), metrics):
                 plan = _run_low_level_search(
-                    task, option_model, skeleton, atoms_sequence, predicates,
-                    new_seed, timeout - (time.time() - start_time))
+                    task, option_model, skeleton, atoms_sequence, new_seed,
+                    timeout - (time.time() - start_time))
                 if plan is not None:
                     print(
                         f"Planning succeeded! Found plan of length "
@@ -224,7 +224,7 @@ def _skeleton_generator(
 def _run_low_level_search(task: Task, option_model: _OptionModel,
                           skeleton: List[_GroundNSRT],
                           atoms_sequence: List[Collection[GroundAtom]],
-                          predicates: Set[Predicate], seed: int,
+                          seed: int,
                           timeout: float) -> Optional[List[_Option]]:
     """Backtracking search over continuous values."""
     start_time = time.time()
@@ -281,8 +281,9 @@ def _run_low_level_search(task: Task, option_model: _OptionModel,
                     if atom.predicate.name != _NOT_CAUSES_FAILURE
                 }
                 # This is equivalent to, but faster than, checking whether
-                # expected_atoms is a subset of utils.abstract(next_state, ...).
-                if all(atom.holds(next_state) for atom in expected_atoms):
+                # expected_atoms is a subset of utils.abstract(traj[cur_idx],
+                # predicates).
+                if all(atom.holds(traj[cur_idx]) for atom in expected_atoms):
                     can_continue_on = True
                     if cur_idx == len(skeleton):  # success!
                         result = plan

--- a/src/structs.py
+++ b/src/structs.py
@@ -352,6 +352,10 @@ class GroundAtom(_Atom):
         assert set(self.objects).issubset(set(sub.keys()))
         return LiftedAtom(self.predicate, [sub[o] for o in self.objects])
 
+    def holds(self, state: State) -> bool:
+        """Check whether this ground atom holds in the given state."""
+        return self.predicate.holds(state, self.objects)
+
 
 @dataclass(frozen=True, eq=False)
 class Task:

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -242,6 +242,9 @@ def test_predicate_and_atom():
     assert (str(ground_atom) == repr(ground_atom) ==
             "On(cup1:cup_type, plate:plate_type)")
     assert isinstance(ground_atom, GroundAtom)
+    assert ground_atom.holds(state)
+    ground_atom2 = pred([cup2, plate])
+    assert not ground_atom2.holds(state)
     lifted_atom3 = ground_atom.lift({cup1: cup_var, plate: plate_var})
     assert lifted_atom3 == lifted_atom
     with pytest.raises(ValueError):


### PR DESCRIPTION
During conversation with @NishanthJKumar , we realized this could help a lot in behavior. For the other environments, it seems to help a little too...

Before change main script termination times:
**Cover / oracle**: 0.42699 seconds
**Blocks / oracle**: 7.29992 seconds
**Painting / oracle**: 5.32841 seconds

After change main script termination times:
**Cover / oracle**: 0.28366 seconds
**Blocks / oracle**: 6.93802 seconds 
**Painting / oracle**: 4.42495 seconds
