### PR TITLE
Add "experiment id" flag

### DIFF
--- a/analysis/analyze_supercloud_experiments.py
+++ b/analysis/analyze_supercloud_experiments.py
@@ -11,18 +11,18 @@ def _main() -> None:
     # Gather data.
     all_data = []
     column_names = [
-        "ENV", "APPROACH", "EXCLUDED_PREDICATES", "SEED", "NUM_SOLVED",
+        "ENV", "APPROACH", "EXCLUDED_PREDICATES", "EXPERIMENT_ID", "SEED", "NUM_SOLVED",
         "NUM_TOTAL", "AVG_TEST_TIME", "AVG_NUM_NODES", "AVG_PLAN_LEN",
         "LEARNING_TIME"
     ]
     for filepath in sorted(glob.glob(f"{CFG.results_dir}/*")):
         with open(filepath, "rb") as f:
             run_data = pkl.load(f)
-        env, approach, seed, excluded_predicates = filepath[8:-4].split("__")
+        env, approach, seed, excluded_predicates, experiment_id = filepath[8:-4].split("__")
         if not excluded_predicates:
             excluded_predicates = "none"
         data = [
-            env, approach, excluded_predicates, seed, run_data["num_solved"],
+            env, approach, excluded_predicates, experiment_id, seed, run_data["num_solved"],
             run_data["num_total"], run_data["avg_suc_time"],
             run_data["avg_nodes_expanded"], run_data["avg_plan_length"],
             run_data["learning_time"]
@@ -38,7 +38,7 @@ def _main() -> None:
     df.columns = column_names
     print("RAW DATA:")
     print(df)
-    grouped = df.groupby(["ENV", "APPROACH", "EXCLUDED_PREDICATES"])
+    grouped = df.groupby(["ENV", "APPROACH", "EXCLUDED_PREDICATES", "EXPERIMENT_ID"])
     means = grouped.mean()
     stds = grouped.std()
     sizes = grouped.size()

--- a/analysis/analyze_supercloud_experiments.py
+++ b/analysis/analyze_supercloud_experiments.py
@@ -11,21 +11,22 @@ def _main() -> None:
     # Gather data.
     all_data = []
     column_names = [
-        "ENV", "APPROACH", "EXCLUDED_PREDICATES", "EXPERIMENT_ID", "SEED", "NUM_SOLVED",
-        "NUM_TOTAL", "AVG_TEST_TIME", "AVG_NUM_NODES", "AVG_PLAN_LEN",
-        "LEARNING_TIME"
+        "ENV", "APPROACH", "EXCLUDED_PREDICATES", "EXPERIMENT_ID", "SEED",
+        "NUM_SOLVED", "NUM_TOTAL", "AVG_TEST_TIME", "AVG_NUM_NODES",
+        "AVG_PLAN_LEN", "LEARNING_TIME"
     ]
     for filepath in sorted(glob.glob(f"{CFG.results_dir}/*")):
         with open(filepath, "rb") as f:
             run_data = pkl.load(f)
-        env, approach, seed, excluded_predicates, experiment_id = filepath[8:-4].split("__")
+        env, approach, seed, excluded_predicates, experiment_id = filepath[
+            8:-4].split("__")
         if not excluded_predicates:
             excluded_predicates = "none"
         data = [
-            env, approach, excluded_predicates, experiment_id, seed, run_data["num_solved"],
-            run_data["num_total"], run_data["avg_suc_time"],
-            run_data["avg_nodes_expanded"], run_data["avg_plan_length"],
-            run_data["learning_time"]
+            env, approach, excluded_predicates, experiment_id, seed,
+            run_data["num_solved"], run_data["num_total"],
+            run_data["avg_suc_time"], run_data["avg_nodes_expanded"],
+            run_data["avg_plan_length"], run_data["learning_time"]
         ]
         assert len(data) == len(column_names)
         all_data.append(data)
@@ -38,7 +39,8 @@ def _main() -> None:
     df.columns = column_names
     print("RAW DATA:")
     print(df)
-    grouped = df.groupby(["ENV", "APPROACH", "EXCLUDED_PREDICATES", "EXPERIMENT_ID"])
+    grouped = df.groupby(
+        ["ENV", "APPROACH", "EXCLUDED_PREDICATES", "EXPERIMENT_ID"])
     means = grouped.mean()
     stds = grouped.std()
     sizes = grouped.size()

--- a/src/args.py
+++ b/src/args.py
@@ -16,4 +16,5 @@ def create_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--timeout", default=10, type=float)
     parser.add_argument("--make_videos", action="store_true")
     parser.add_argument("--load", action="store_true")
+    parser.add_argument("--experiment_id", default="", type=str)
     return parser

--- a/src/utils.py
+++ b/src/utils.py
@@ -1170,7 +1170,7 @@ def update_config(args: Dict[str, Any], default_seed: int = 123) -> None:
 
 def get_config_path_str() -> str:
     """Get a filename prefix for configuration based on the current CFG."""
-    return f"{CFG.env}__{CFG.approach}__{CFG.seed}__{CFG.excluded_predicates}"
+    return f"{CFG.env}__{CFG.approach}__{CFG.seed}__{CFG.excluded_predicates}__{CFG.experiment_id}"
 
 
 def get_save_path_str() -> str:

--- a/src/utils.py
+++ b/src/utils.py
@@ -1170,7 +1170,8 @@ def update_config(args: Dict[str, Any], default_seed: int = 123) -> None:
 
 def get_config_path_str() -> str:
     """Get a filename prefix for configuration based on the current CFG."""
-    return f"{CFG.env}__{CFG.approach}__{CFG.seed}__{CFG.excluded_predicates}__{CFG.experiment_id}"
+    return (f"{CFG.env}__{CFG.approach}__{CFG.seed}__{CFG.excluded_predicates}"
+            f"__{CFG.experiment_id}")
 
 
 def get_save_path_str() -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1301,9 +1301,10 @@ def test_get_config_path_str():
         "approach": "dummyapproach",
         "seed": 321,
         "excluded_predicates": "all",
+        "experiment_id": "foobar",
     })
     s = utils.get_config_path_str()
-    assert s == "dummyenv__dummyapproach__321__all"
+    assert s == "dummyenv__dummyapproach__321__all__foobar"
 
 
 def test_get_save_path_str():
@@ -1315,20 +1316,22 @@ def test_get_save_path_str():
         "approach": "test_approach",
         "seed": 123,
         "save_dir": dirname,
-        "excluded_predicates": "test_pred1,test_pred2"
+        "excluded_predicates": "test_pred1,test_pred2",
+        "experiment_id": "baz",
     })
     save_path = utils.get_save_path_str()
     assert save_path == dirname + ("/test_env__test_approach__123__"
-                                   "test_pred1,test_pred2.saved")
+                                   "test_pred1,test_pred2__baz.saved")
     utils.update_config({
         "env": "test_env",
         "approach": "test_approach",
         "seed": 123,
         "save_dir": dirname,
-        "excluded_predicates": ""
+        "excluded_predicates": "",
+        "experiment_id": "",
     })
     save_path = utils.get_save_path_str()
-    assert save_path == dirname + "/test_env__test_approach__123__.saved"
+    assert save_path == dirname + "/test_env__test_approach__123____.saved"
     os.rmdir(dirname)
     utils.update_config({"save_dir": old_save_dir})
 


### PR DESCRIPTION
The interactive learning approach can't use the excluded predicates flag, so I need some other way to distinguish between different experiment runs. This changes the config and save path strings.

The changes to `analysis/analyze_supercloud_experiments.py` mean the new script won't work on previously saved results.