### PR TITLE
multistep cover env updates

### DIFF
--- a/src/envs/__init__.py
+++ b/src/envs/__init__.py
@@ -2,7 +2,8 @@
 
 from predicators.src.envs.base_env import BaseEnv, EnvironmentFailure
 from predicators.src.envs.cover import CoverEnv, CoverEnvTypedOptions, \
-    CoverEnvHierarchicalTypes, CoverMultistepOptions
+    CoverEnvHierarchicalTypes, CoverMultistepOptions, \
+    CoverMultistepOptionsFixedTasks
 from predicators.src.envs.behavior import BehaviorEnv
 from predicators.src.envs.cluttered_table import ClutteredTableEnv, \
     ClutteredTablePlaceEnv
@@ -18,6 +19,7 @@ __all__ = [
     "CoverEnvTypedOptions",
     "CoverEnvHierarchicalTypes",
     "CoverMultistepOptions",
+    "CoverMultistepOptionsFixedTasks",
     "ClutteredTableEnv",
     "BlocksEnv",
     "PaintingEnv",
@@ -42,6 +44,8 @@ def _create_new_env_instance(name: str) -> BaseEnv:
         return CoverEnvHierarchicalTypes()
     if name == "cover_multistep_options":
         return CoverMultistepOptions()
+    if name == "cover_multistep_options_fixed_tasks":
+        return CoverMultistepOptionsFixedTasks()
     if name == "cluttered_table":
         return ClutteredTableEnv()
     if name == "cluttered_table_place":

--- a/src/envs/cover.py
+++ b/src/envs/cover.py
@@ -457,7 +457,7 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
             types=[self._block_type, self._robot_type],
             params_space=Box(-np.inf, np.inf, (11, )),
             _policy=self._Pick_learned_equivalent_policy,
-            _initiable=self._Pick_initiable,
+            _initiable=self._Pick_learned_equivalent_initiable,
             _terminal=self._Pick_learned_equivalent_terminal)
         self._LearnedEquivalentPlace = ParameterizedOption(
             "LearnedEquivalentPlace",
@@ -728,6 +728,13 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         del m, o, p  # unused
         return self._HandEmpty_holds(s, [])
 
+    def _Pick_learned_equivalent_initiable(self,
+        s: State, m: Dict, o: Sequence[Object], p: Array) -> bool:
+        # Convert the relative parameters into absolute parameters.
+        m["params"] = p
+        m["absolute_params"] = s.vec(o) + p
+        return self._Pick_initiable(s, m, o, p)
+
     def _Pick_policy(  # type: ignore
             self, s: State, m: Dict, o: Sequence[Object], p: Array) -> Action:
         del m  # unused
@@ -769,18 +776,18 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
             m: Dict,  # type: ignore
             o: Sequence[Object],
             p: Array) -> Action:
-        # TODO: change to relative
-        import ipdb; ipdb.set_trace()
-        del m
+        assert np.allclose(p, m["params"])
+        del p
+        absolute_params = m["absolute_params"]
         # The object is the one we want to pick.
         assert len(o) == 2
         obj = o[0]
-        assert len(p) == self._block_type.dim + self._robot_type.dim
+        assert len(absolute_params) == self._block_type.dim + self._robot_type.dim
         assert obj.type == self._block_type
         x = s.get(self._robot, "x")
         y = s.get(self._robot, "y")
         by = s.get(obj, "y")
-        desired_x = p[7]
+        desired_x = absolute_params[7]
         desired_y = by + 1e-3
         at_desired_x = abs(desired_x - x) < 1e-5
         at_desired_y = abs(desired_y - y) < 1e-5
@@ -814,19 +821,16 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
     def _Pick_learned_equivalent_terminal(self, s: State, m: Dict,
                                           o: Sequence[Object],
                                           p: Array) -> bool:
-        del m  # unused
+        assert np.allclose(p, m["params"])
+        del p
+        absolute_params = m["absolute_params"]
         block, robot = o
         # Pick is done when we're holding the desired object.
         terminal = self._Holding_holds(s, [block, robot])
         if terminal and CFG.sampler_learner == "neural":
             # Ensure terminal state matches parameterization.
             param_from_terminal = np.hstack((s[block], s[robot]))
-            # TODO: change to relative
-            import ipdb; ipdb.set_trace()
-            try:
-                assert np.allclose(p, param_from_terminal, atol=1e-05)
-            except:
-                import ipdb; ipdb.set_trace()
+            assert np.allclose(absolute_params, param_from_terminal, atol=1e-05)
         return terminal
 
     def _Place_initiable(self, s: State, m: Dict, o: Sequence[Object],
@@ -839,16 +843,18 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
     def _Place_learned_equivalent_initiable(self, s: State, m: Dict,
                                             o: Sequence[Object],
                                             p: Array) -> bool:
-        # Place is initiable if we're holding the object.
-        del m, p  # unused
         block, robot, _ = o
         assert block.is_instance(self._block_type)
         assert robot.is_instance(self._robot_type)
+        # Convert the relative parameters into absolute parameters.
+        m["params"] = p
+        # Only the block and robot are changing.
+        m["absolute_params"] = s.vec([block, robot]) + p
+        # Place is initiable if we're holding the object.
         return self._Holding_holds(s, [block, robot])
 
     def _Place_policy(self, s: State, m: Dict, o: Sequence[Object],
                       p: Array) -> Action:
-        del m  # unused
         # The object is the one we want to place at.
         assert len(o) == 1
         obj = o[0]
@@ -860,7 +866,7 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         x = s.get(self._robot, "x")
         at_desired_x = abs(desired_x - x) < 1e-5
         y = s.get(self._robot, "y")
-        desired_y = self.block_height + 1e-2
+        desired_y = self.block_height + 1e-3
         at_desired_y = abs(desired_y - y) < 1e-5
         lb, ub = CFG.cover_multistep_action_limits
         # If we're already above the object and prepared to place,
@@ -887,19 +893,19 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
             m: Dict,
             o: Sequence[Object],
             p: Array) -> Action:
-        # TODO: change to relative
-        import ipdb; ipdb.set_trace()
-        del m
+        assert np.allclose(p, m["params"])
+        del p
+        absolute_params = m["absolute_params"]
         # The object is the one we want to place at.
         assert len(o) == 3
         obj = o[0]
-        assert len(p) == self._block_type.dim + self._robot_type.dim
+        assert len(absolute_params) == self._block_type.dim + self._robot_type.dim
         assert obj.type == self._block_type
         x = s.get(self._robot, "x")
         y = s.get(self._robot, "y")
         bh = s.get(obj, "height")
-        desired_x = p[7]
-        desired_y = bh + 1e-2
+        desired_x = absolute_params[7]
+        desired_y = bh + 1e-3
 
         at_desired_x = abs(desired_x - x) < 1e-5
         at_desired_y = abs(desired_y - y) < 1e-5
@@ -932,16 +938,16 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
     def _Place_learned_equivalent_terminal(self, s: State, m: Dict,
                                            o: Sequence[Object],
                                            p: Array) -> bool:
-        del m  # unused
+        assert np.allclose(p, m["params"])
+        del p
+        absolute_params = m["absolute_params"]
         block, robot, _ = o
         # Place is done when the hand is empty.
         terminal = self._HandEmpty_holds(s, [])
         if terminal and CFG.sampler_learner == "neural":
-            # TODO: change to relative
-            import ipdb; ipdb.set_trace()
             # Ensure terminal state matches parameterization.
             param_from_terminal = np.hstack((s[block], s[robot]))
-            assert np.allclose(p, param_from_terminal, atol=1e-5)
+            assert np.allclose(absolute_params, param_from_terminal, atol=1e-5)
         return terminal
 
     def _get_hand_regions(self, state: State) -> List[Tuple[float, float]]:

--- a/src/envs/cover.py
+++ b/src/envs/cover.py
@@ -505,13 +505,11 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
                 hw, hh = state.get(held_block, "width"), \
                          state.get(held_block, "height")
 
-        # Ensure neither the gripper nor the possible held block go below the
-        # y-axis.
+        # Ensure neither the gripper does not go below the y-axis.
+        # Currently we allow the block to penetrate the y-axis for simplicity.
+        # We can revisit this later.
         if y + dy < 0 - self.collision_threshold:
             return state.copy()
-        if held_block is not None:
-            if hy - hh + dy < 0 - self.collision_threshold:
-                return state.copy()
 
         # Ensure neither the gripper nor the possible held block collide with
         # another block during the trajectory defined by dx, dy.

--- a/src/envs/cover.py
+++ b/src/envs/cover.py
@@ -728,8 +728,9 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         del m, o, p  # unused
         return self._HandEmpty_holds(s, [])
 
-    def _Pick_learned_equivalent_initiable(self,
-        s: State, m: Dict, o: Sequence[Object], p: Array) -> bool:
+    def _Pick_learned_equivalent_initiable(self, s: State, m: Dict,
+                                           o: Sequence[Object],
+                                           p: Array) -> bool:
         # Convert the relative parameters into absolute parameters.
         m["params"] = p
         m["absolute_params"] = s.vec(o) + p
@@ -782,7 +783,8 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         # The object is the one we want to pick.
         assert len(o) == 2
         obj = o[0]
-        assert len(absolute_params) == self._block_type.dim + self._robot_type.dim
+        assert len(
+            absolute_params) == self._block_type.dim + self._robot_type.dim
         assert obj.type == self._block_type
         x = s.get(self._robot, "x")
         y = s.get(self._robot, "y")
@@ -830,7 +832,9 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         if terminal and CFG.sampler_learner == "neural":
             # Ensure terminal state matches parameterization.
             param_from_terminal = np.hstack((s[block], s[robot]))
-            assert np.allclose(absolute_params, param_from_terminal, atol=1e-05)
+            assert np.allclose(absolute_params,
+                               param_from_terminal,
+                               atol=1e-05)
         return terminal
 
     def _Place_initiable(self, s: State, m: Dict, o: Sequence[Object],
@@ -855,6 +859,7 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
 
     def _Place_policy(self, s: State, m: Dict, o: Sequence[Object],
                       p: Array) -> Action:
+        del m  # unused
         # The object is the one we want to place at.
         assert len(o) == 1
         obj = o[0]
@@ -899,7 +904,8 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         # The object is the one we want to place at.
         assert len(o) == 3
         obj = o[0]
-        assert len(absolute_params) == self._block_type.dim + self._robot_type.dim
+        assert len(
+            absolute_params) == self._block_type.dim + self._robot_type.dim
         assert obj.type == self._block_type
         x = s.get(self._robot, "x")
         y = s.get(self._robot, "y")

--- a/src/envs/cover.py
+++ b/src/envs/cover.py
@@ -505,11 +505,13 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
                 hw, hh = state.get(held_block, "width"), \
                          state.get(held_block, "height")
 
-        # Ensure neither the gripper does not go below the y-axis.
-        # Currently we allow the block to penetrate the y-axis for simplicity.
-        # We can revisit this later.
+        # Ensure neither the gripper nor the possible held block go below the
+        # y-axis.
         if y + dy < 0 - self.collision_threshold:
             return state.copy()
+        if held_block is not None:
+            if hy - hh + dy < 0 - self.collision_threshold:
+                return state.copy()
 
         # Ensure neither the gripper nor the possible held block collide with
         # another block during the trajectory defined by dx, dy.
@@ -590,6 +592,7 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
             by_ub = by + self.grasp_height_tol
             by_lb = by - self.grasp_height_tol
             if by_lb <= y <= by_ub:
+                next_state.set(self._robot, "y", by)
                 next_state.set(above_block, "grasp", 1)
                 next_state.set(self._robot, "holding", 1)
 

--- a/src/envs/cover.py
+++ b/src/envs/cover.py
@@ -779,7 +779,7 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         y = s.get(self._robot, "y")
         by = s.get(obj, "y")
         desired_x = p[7]
-        desired_y = by
+        desired_y = by + 1e-3
         at_desired_x = abs(desired_x - x) < 1e-5
         at_desired_y = abs(desired_y - y) < 1e-5
 
@@ -819,7 +819,7 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         if terminal and CFG.sampler_learner == "neural":
             # Ensure terminal state matches parameterization.
             param_from_terminal = np.hstack((s[block], s[robot]))
-            assert np.allclose(p, param_from_terminal, atol=1e-03)
+            assert np.allclose(p, param_from_terminal, atol=1e-05)
         return terminal
 
     def _Place_initiable(self, s: State, m: Dict, o: Sequence[Object],
@@ -930,12 +930,7 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         if terminal and CFG.sampler_learner == "neural":
             # Ensure terminal state matches parameterization.
             param_from_terminal = np.hstack((s[block], s[robot]))
-            # Note that here we require a tolerance of no less than 1e-02
-            # because before letting go of the block, the robot holds the block
-            # block_height + 1e-02 above the ground before dropping it, so the
-            # difference of the param_from_terminal and p will differ by 1e-02
-            # in the block's y value.
-            assert np.allclose(p, param_from_terminal, atol=1e-02)
+            assert np.allclose(p, param_from_terminal, atol=1e-5)
         return terminal
 
     def _get_hand_regions(self, state: State) -> List[Tuple[float, float]]:

--- a/src/envs/cover.py
+++ b/src/envs/cover.py
@@ -769,6 +769,8 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
             m: Dict,  # type: ignore
             o: Sequence[Object],
             p: Array) -> Action:
+        # TODO: change to relative
+        import ipdb; ipdb.set_trace()
         del m
         # The object is the one we want to pick.
         assert len(o) == 2
@@ -819,7 +821,12 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         if terminal and CFG.sampler_learner == "neural":
             # Ensure terminal state matches parameterization.
             param_from_terminal = np.hstack((s[block], s[robot]))
-            assert np.allclose(p, param_from_terminal, atol=1e-05)
+            # TODO: change to relative
+            import ipdb; ipdb.set_trace()
+            try:
+                assert np.allclose(p, param_from_terminal, atol=1e-05)
+            except:
+                import ipdb; ipdb.set_trace()
         return terminal
 
     def _Place_initiable(self, s: State, m: Dict, o: Sequence[Object],
@@ -880,6 +887,8 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
             m: Dict,
             o: Sequence[Object],
             p: Array) -> Action:
+        # TODO: change to relative
+        import ipdb; ipdb.set_trace()
         del m
         # The object is the one we want to place at.
         assert len(o) == 3
@@ -928,6 +937,8 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         # Place is done when the hand is empty.
         terminal = self._HandEmpty_holds(s, [])
         if terminal and CFG.sampler_learner == "neural":
+            # TODO: change to relative
+            import ipdb; ipdb.set_trace()
             # Ensure terminal state matches parameterization.
             param_from_terminal = np.hstack((s[block], s[robot]))
             assert np.allclose(p, param_from_terminal, atol=1e-5)

--- a/src/envs/cover.py
+++ b/src/envs/cover.py
@@ -972,3 +972,21 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         return (block_pose-block_width/2 <= target_pose-target_width/2) and \
                (block_pose+block_width/2 >= target_pose+target_width/2) and \
                (by - bh == 0)
+
+
+class CoverMultistepOptionsFixedTasks(CoverMultistepOptions):
+    """A variation of CoverMultistepOptions where there is only one possible
+    initial state.
+
+    This environment is useful for debugging option learning.
+
+    Note that like the parent env, there are three possible goals:
+    Cover(block0, target0), Cover(block1, target1), or both.
+    """
+
+    def _create_initial_state(self, rng: np.random.Generator) -> State:
+        # Force one initial state by overriding the rng and using an identical
+        # one on every call, so this method becomes deterministic.
+        del rng
+        zero_rng = np.random.default_rng(0)
+        return super()._create_initial_state(zero_rng)

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -136,7 +136,7 @@ def _get_cover_gt_nsrts() -> Set[NSRT]:
 
         def pick_sampler(state: State, rng: np.random.Generator,
                          objs: Sequence[Object]) -> Array:
-            # The only things that change are the block's held bit and the
+            # The only things that change are the block's grasp, and the
             # robot's grip, holding, x, and y.
             assert len(objs) == 2
             block, robot = objs
@@ -155,7 +155,7 @@ def _get_cover_gt_nsrts() -> Set[NSRT]:
             # x, y, grip, holding
             # grip changes from -1.0 to 1.0
             # holding changes from -1.0 to 1.0
-            robot_param = [desired_x - rx, by + 1e-3 - ry, 2.0, 2.0]
+            robot_param = [desired_x - rx, by - ry, 2.0, 2.0]
             param = block_param + robot_param
             return np.array(param, dtype=np.float32)
     else:
@@ -245,14 +245,14 @@ def _get_cover_gt_nsrts() -> Set[NSRT]:
             else:
                 desired_x = rng.uniform(tx - tw / 2, tx + tw / 2)
             delta_x = desired_x - rx
-            delta_y = bh + grasp_offset - ry
+            delta_y = bh - ry
             # is_block, is_target, width, x, grasp, y, height
             # grasp changes from 1.0 to -1.0
             block_param = [0.0, 0.0, 0.0, delta_x, -2.0, delta_y, 0.0]
             # x, y, grip, holding
             # grip changes from 1.0 to -1.0
             # holding changes from 1.0 to -1.0
-            robot_param = [delta_x, delta_y, -2.0, -2.0]
+            robot_param = [delta_x, delta_y + grasp_offset, -2.0, -2.0]
             param = block_param + robot_param
             return np.array(param, dtype=np.float32)
     else:

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -224,12 +224,14 @@ def _get_cover_gt_nsrts() -> Set[NSRT]:
             assert robot.is_instance(robot_type)
             assert target.is_instance(target_type)
             tx, tw = state.get(target, "x"), state.get(target, "width")
+            relative_grasp = state.get(block, "x") - state.get(robot, "x")
             desired_x = rng.uniform(tx - tw / 2, tx + tw / 2)
             bw, bh = state.get(block, "width"), state.get(block, "height")
             desired_y = bh + 1e-2  # This is the desired y for the robot.
             # is_block, is_target, width, x, grasp, y, height
             # grasp changes from 1 to -1
-            block_param = [1.0, 0.0, bw, desired_x, -1.0, desired_y - 1e-2, bh]
+            block_param = [1.0, 0.0, bw, desired_x + relative_grasp, -1.0,
+                           desired_y - 1e-2, bh]
             # x, y, grip, holding
             # grip changes from 1.0 to -1.0
             # holding changes from 1 to -1

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -224,30 +224,36 @@ def _get_cover_gt_nsrts() -> Set[NSRT]:
 
         def place_sampler(state: State, rng: np.random.Generator,
                           objs: Sequence[Object]) -> Array:
-            # The x and held features of the block change, and the x, grasp, and
-            # holding features of the robot change. Note that the y features do
-            # not need to change because the robot picks and places at the same
-            # table y position.
+            # The x, y, and held features of the block change, and the x, y,
+            # grasp, and holding features of the robot change.
+            # Note that the y features changing is a little surprising. One
+            # thing to keep in mind is that during replay data collection,
+            # the replays can start from any low-level state in a trajectory,
+            # so there are many cases where the robot is holding the object in
+            # mid-air, and it starts a new place option from there.
             assert len(objs) == 3
             block, robot, target = objs
             assert block.is_instance(block_type)
             assert robot.is_instance(robot_type)
             assert target.is_instance(target_type)
-            rx = state.get(robot, "x")
+            rx, ry = state.get(robot, "x"), state.get(robot, "y")
+            by, bh = state.get(block, "y"), state.get(block, "height")
+            grasp_offset = 1e-3
             tx, tw = state.get(target, "x"), state.get(target, "width")
             if CFG.cover_multistep_degenerate_oracle_samplers:
                 desired_x = float(tx)
             else:
                 desired_x = rng.uniform(tx - tw / 2, tx + tw / 2)
             delta_x = desired_x - rx
+            delta_y = bh + grasp_offset - ry
             bw = state.get(block, "width")
             # is_block, is_target, width, x, grasp, y, height
             # grasp changes from 1.0 to -1.0
-            block_param = [0.0, 0.0, 0.0, delta_x, -2.0, 0.0, 0.0]
+            block_param = [0.0, 0.0, 0.0, delta_x, -2.0, delta_y, 0.0]
             # x, y, grip, holding
             # grip changes from 1.0 to -1.0
             # holding changes from 1.0 to -1.0
-            robot_param = [delta_x, 0.0, -2.0, -2.0]
+            robot_param = [delta_x, delta_y, -2.0, -2.0]
             param = block_param + robot_param
             return np.array(param, dtype=np.float32)
     else:

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -237,7 +237,7 @@ def _get_cover_gt_nsrts() -> Set[NSRT]:
             assert robot.is_instance(robot_type)
             assert target.is_instance(target_type)
             rx, ry = state.get(robot, "x"), state.get(robot, "y")
-            by, bh = state.get(block, "y"), state.get(block, "height")
+            bh = state.get(block, "height")
             grasp_offset = 1e-3
             tx, tw = state.get(target, "x"), state.get(target, "width")
             if CFG.cover_multistep_degenerate_oracle_samplers:
@@ -246,7 +246,6 @@ def _get_cover_gt_nsrts() -> Set[NSRT]:
                 desired_x = rng.uniform(tx - tw / 2, tx + tw / 2)
             delta_x = desired_x - rx
             delta_y = bh + grasp_offset - ry
-            bw = state.get(block, "width")
             # is_block, is_target, width, x, grasp, y, height
             # grasp changes from 1.0 to -1.0
             block_param = [0.0, 0.0, 0.0, delta_x, -2.0, delta_y, 0.0]

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -17,7 +17,8 @@ def get_gt_nsrts(predicates: Set[Predicate],
                  options: Set[ParameterizedOption]) -> Set[NSRT]:
     """Create ground truth NSRTs for an env."""
     if CFG.env in ("cover", "cover_hierarchical_types", "cover_typed_options",
-                   "cover_multistep_options"):
+                   "cover_multistep_options",
+                   "cover_multistep_options_fixed_tasks"):
         nsrts = _get_cover_gt_nsrts()
     elif CFG.env == "cluttered_table":
         nsrts = _get_cluttered_table_gt_nsrts()
@@ -94,9 +95,11 @@ def _get_cover_gt_nsrts() -> Set[NSRT]:
     # Options
     if CFG.env in ("cover", "cover_hierarchical_types"):
         PickPlace, = _get_options_by_names(CFG.env, ["PickPlace"])
-    elif CFG.env in ("cover_typed_options", "cover_multistep_options"):
+    elif CFG.env in ("cover_typed_options", "cover_multistep_options",
+                     "cover_multistep_options_fixed_tasks"):
         Pick, Place = _get_options_by_names(CFG.env, ["Pick", "Place"])
-    if CFG.env == "cover_multistep_options" and \
+    if CFG.env in ("cover_multistep_options",
+                   "cover_multistep_options_fixed_tasks") and \
         CFG.cover_multistep_use_learned_equivalents:
         LearnedEquivalentPick, LearnedEquivalentPlace = _get_options_by_names(
             CFG.env, ["LearnedEquivalentPick", "LearnedEquivalentPlace"])
@@ -106,7 +109,8 @@ def _get_cover_gt_nsrts() -> Set[NSRT]:
     # Pick
     parameters = [block]
     holding_predicate_args = [block]
-    if CFG.env == "cover_multistep_options":
+    if CFG.env in ("cover_multistep_options",
+                   "cover_multistep_options_fixed_tasks"):
         parameters.append(robot)
         holding_predicate_args.append(robot)
     preconditions = {LiftedAtom(IsBlock, [block]), LiftedAtom(HandEmpty, [])}
@@ -116,15 +120,18 @@ def _get_cover_gt_nsrts() -> Set[NSRT]:
     if CFG.env in ("cover", "cover_hierarchical_types"):
         option = PickPlace
         option_vars = []
-    elif CFG.env == "cover_multistep_options" and \
+    elif CFG.env in ("cover_multistep_options",
+                     "cover_multistep_options_fixed_tasks") and \
         CFG.cover_multistep_use_learned_equivalents:
         option = LearnedEquivalentPick
         option_vars = [block, robot]
-    elif CFG.env in ("cover_typed_options", "cover_multistep_options"):
+    elif CFG.env in ("cover_typed_options", "cover_multistep_options",
+                     "cover_multistep_options_fixed_tasks"):
         option = Pick
         option_vars = [block]
 
-    if CFG.env == "cover_multistep_options" and \
+    if CFG.env in ("cover_multistep_options",
+                   "cover_multistep_options_fixed_tasks") and \
         CFG.cover_multistep_use_learned_equivalents:
 
         def pick_sampler(state: State, rng: np.random.Generator,
@@ -150,13 +157,15 @@ def _get_cover_gt_nsrts() -> Set[NSRT]:
 
         def pick_sampler(state: State, rng: np.random.Generator,
                          objs: Sequence[Object]) -> Array:
-            if CFG.env == "cover_multistep_options":
+            if CFG.env in ("cover_multistep_options",
+                           "cover_multistep_options_fixed_tasks"):
                 assert len(objs) == 2
             else:
                 assert len(objs) == 1
             b = objs[0]
             assert b.is_instance(block_type)
-            if CFG.env == "cover_multistep_options":
+            if CFG.env in ("cover_multistep_options",
+                           "cover_multistep_options_fixed_tasks"):
                 lb = -1.0
                 ub = 1.0
             elif CFG.env == "cover_typed_options":
@@ -176,7 +185,8 @@ def _get_cover_gt_nsrts() -> Set[NSRT]:
     # Place
     parameters = [block, target]
     holding_predicate_args = [block]
-    if CFG.env == "cover_multistep_options":
+    if CFG.env in ("cover_multistep_options",
+                   "cover_multistep_options_fixed_tasks"):
         parameters = [block, robot, target]
         holding_predicate_args.append(robot)
     preconditions = {
@@ -193,15 +203,18 @@ def _get_cover_gt_nsrts() -> Set[NSRT]:
     if CFG.env in ("cover", "cover_hierarchical_types"):
         option = PickPlace
         option_vars = []
-    elif CFG.env in ("cover_typed_options", "cover_multistep_options"):
+    elif CFG.env in ("cover_typed_options", "cover_multistep_options",
+                     "cover_multistep_options_fixed_tasks"):
         option = Place
         option_vars = [target]
-        if CFG.env == "cover_multistep_options" and \
+        if CFG.env in ("cover_multistep_options",
+                       "cover_multistep_options_fixed_tasks") and \
             CFG.cover_multistep_use_learned_equivalents:
             option = LearnedEquivalentPlace
             option_vars = [block, robot, target]
 
-    if CFG.env == "cover_multistep_options" and \
+    if CFG.env in ("cover_multistep_options",
+                   "cover_multistep_options_fixed_tasks") and \
         CFG.cover_multistep_use_learned_equivalents:
 
         def place_sampler(state: State, rng: np.random.Generator,
@@ -229,13 +242,15 @@ def _get_cover_gt_nsrts() -> Set[NSRT]:
 
         def place_sampler(state: State, rng: np.random.Generator,
                           objs: Sequence[Object]) -> Array:
-            if CFG.env == "cover_multistep_options":
+            if CFG.env in ("cover_multistep_options",
+                           "cover_multistep_options_fixed_tasks"):
                 assert len(objs) == 3
             else:
                 assert len(objs) == 2
             t = objs[-1]
             assert t.is_instance(target_type)
-            if CFG.env == "cover_multistep_options":
+            if CFG.env in ("cover_multistep_options",
+                           "cover_multistep_options_fixed_tasks"):
                 lb = -1.0
                 ub = 1.0
             else:

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -143,14 +143,13 @@ def _get_cover_gt_nsrts() -> Set[NSRT]:
             bx, by = state.get(block, "x"), state.get(block, "y")
             bw, bh = state.get(block, "width"), state.get(block, "height")
             desired_x = rng.uniform(bx - bw / 2, bx + bw / 2)
-            desired_x = float(bx)
             # is_block, is_target, width, x, grasp, y, height
             # grasp changes from -1 to 1
             block_param = [1.0, 0.0, bw, bx, 1.0, by, bh]
             # x, y, grip, holding
             # grip changes from -1.0 to 1.0
             # holding changes from -1 to 1
-            robot_param = [desired_x, by, 1.0, 1.0]
+            robot_param = [desired_x, by + 1e-3, 1.0, 1.0]
             param = block_param + robot_param
             return np.array(param, dtype=np.float32)
     else:
@@ -226,12 +225,11 @@ def _get_cover_gt_nsrts() -> Set[NSRT]:
             assert target.is_instance(target_type)
             tx, tw = state.get(target, "x"), state.get(target, "width")
             desired_x = rng.uniform(tx - tw / 2, tx + tw / 2)
-            desired_x = float(tx)
             bw, bh = state.get(block, "width"), state.get(block, "height")
-            desired_y = bh + 1e-2
+            desired_y = bh + 1e-2  # This is the desired y for the robot.
             # is_block, is_target, width, x, grasp, y, height
             # grasp changes from 1 to -1
-            block_param = [1.0, 0.0, bw, desired_x, -1.0, desired_y, bh]
+            block_param = [1.0, 0.0, bw, desired_x, -1.0, desired_y - 1e-2, bh]
             # x, y, grip, holding
             # grip changes from 1.0 to -1.0
             # holding changes from 1 to -1

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -142,7 +142,10 @@ def _get_cover_gt_nsrts() -> Set[NSRT]:
             assert robot.is_instance(robot_type)
             bx, by = state.get(block, "x"), state.get(block, "y")
             bw, bh = state.get(block, "width"), state.get(block, "height")
-            desired_x = rng.uniform(bx - bw / 2, bx + bw / 2)
+            if CFG.cover_multistep_degenerate_oracle_samplers:
+                desired_x = float(bx)
+            else:
+                desired_x = rng.uniform(bx - bw / 2, bx + bw / 2)
             # is_block, is_target, width, x, grasp, y, height
             # grasp changes from -1 to 1
             block_param = [1.0, 0.0, bw, bx, 1.0, by, bh]
@@ -225,7 +228,10 @@ def _get_cover_gt_nsrts() -> Set[NSRT]:
             assert target.is_instance(target_type)
             tx, tw = state.get(target, "x"), state.get(target, "width")
             relative_grasp = state.get(block, "x") - state.get(robot, "x")
-            desired_x = rng.uniform(tx - tw / 2, tx + tw / 2)
+            if CFG.cover_multistep_degenerate_oracle_samplers:
+                desired_x = float(tx)
+            else:
+                desired_x = rng.uniform(tx - tw / 2, tx + tw / 2)
             bw, bh = state.get(block, "width"), state.get(block, "height")
             desired_y = bh + 1e-2  # This is the desired y for the robot.
             # is_block, is_target, width, x, grasp, y, height

--- a/src/settings.py
+++ b/src/settings.py
@@ -28,6 +28,7 @@ class GlobalSettings:
     # cover_multistep_options parameters
     cover_multistep_action_limits = [-np.inf, np.inf]
     cover_multistep_use_learned_equivalents = True
+    cover_multistep_degenerate_oracle_samplers = False
 
     # cluttered table env parameters
     cluttered_table_num_cans_train = 5

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -8,7 +8,7 @@ from predicators.src.ground_truth_nsrts import get_gt_nsrts
 from predicators.src.envs import CoverEnv, CoverEnvTypedOptions, \
     CoverEnvHierarchicalTypes, ClutteredTableEnv, ClutteredTablePlaceEnv, \
     EnvironmentFailure, BlocksEnv, PaintingEnv, PlayroomEnv, \
-    CoverMultistepOptions, RepeatedNextToEnv
+    CoverMultistepOptions, CoverMultistepOptionsFixedTasks, RepeatedNextToEnv
 from predicators.src.structs import Action, NSRT, Variable
 from predicators.src import utils
 
@@ -217,6 +217,34 @@ def test_oracle_approach_cover_multistep_options():
     for task in env.get_test_tasks():
         policy = approach.solve(task, timeout=500)
         assert utils.policy_solves_task(policy, task, env.simulate)
+
+
+def test_oracle_approach_cover_multistep_options_fixed_tasks():
+    """Tests for OracleApproach class with CoverMultistepOptionsFixedTasks."""
+    utils.update_config({"env": "cover_multistep_options_fixed_tasks"})
+    utils.update_config({
+        "env": "cover_multistep_options",
+        "cover_multistep_use_learned_equivalents": True
+    })
+    env = CoverMultistepOptionsFixedTasks()
+    env.seed(123)
+    approach = OracleApproach(env.simulate, env.predicates, env.options,
+                              env.types, env.action_space)
+    assert not approach.is_learning_based
+    random_action = Action(env.action_space.sample())
+    approach.seed(123)
+    for task in next(env.train_tasks_generator()):
+        policy = approach.solve(task, timeout=500)
+        assert utils.policy_solves_task(policy, task, env.simulate)
+        # Test that a repeated random action fails.
+        assert not utils.policy_solves_task(lambda s: random_action, task,
+                                            env.simulate)
+    for task in env.get_test_tasks():
+        policy = approach.solve(task, timeout=500)
+        assert utils.policy_solves_task(policy, task, env.simulate)
+        # Test that a repeated random action fails.
+        assert not utils.policy_solves_task(lambda s: random_action, task,
+                                            env.simulate)
 
 
 def test_cluttered_table_get_gt_nsrts(place_version=False):

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -177,7 +177,8 @@ def test_oracle_approach_cover_multistep_options():
     utils.update_config({"env": "cover_multistep_options"})
     utils.update_config({
         "env": "cover_multistep_options",
-        "cover_multistep_use_learned_equivalents": False
+        "cover_multistep_use_learned_equivalents": False,
+        "cover_multistep_degenerate_oracle_samplers": False,
     })
     env = CoverMultistepOptions()
     env.seed(123)
@@ -202,6 +203,7 @@ def test_oracle_approach_cover_multistep_options():
     utils.update_config({
         "env": "cover_multistep_options",
         "cover_multistep_use_learned_equivalents": True,
+        "cover_multistep_degenerate_oracle_samplers": False,
         "sampler_learner": "neural"
     })
     env = CoverMultistepOptions()
@@ -217,6 +219,32 @@ def test_oracle_approach_cover_multistep_options():
     for task in env.get_test_tasks():
         policy = approach.solve(task, timeout=500)
         assert utils.policy_solves_task(policy, task, env.simulate)
+        # Test cover_multistep_degenerate_oracle_samplers.
+        utils.update_config({"env": "cover_multistep_options"})
+    utils.update_config({
+        "env": "cover_multistep_options",
+        "cover_multistep_use_learned_equivalents": False,
+        "cover_multistep_degenerate_oracle_samplers": True,
+    })
+    env = CoverMultistepOptions()
+    env.seed(123)
+    approach = OracleApproach(env.simulate, env.predicates, env.options,
+                              env.types, env.action_space)
+    assert not approach.is_learning_based
+    random_action = Action(env.action_space.sample())
+    approach.seed(123)
+    for task in next(env.train_tasks_generator()):
+        policy = approach.solve(task, timeout=500)
+        assert utils.policy_solves_task(policy, task, env.simulate)
+        # Test that a repeated random action fails.
+        assert not utils.policy_solves_task(lambda s: random_action, task,
+                                            env.simulate)
+    for task in env.get_test_tasks():
+        policy = approach.solve(task, timeout=500)
+        assert utils.policy_solves_task(policy, task, env.simulate)
+        # Test that a repeated random action fails.
+        assert not utils.policy_solves_task(lambda s: random_action, task,
+                                            env.simulate)
 
 
 def test_oracle_approach_cover_multistep_options_fixed_tasks():

--- a/tests/envs/test_base_env.py
+++ b/tests/envs/test_base_env.py
@@ -4,10 +4,12 @@ import pytest
 from predicators.src.envs import BaseEnv, create_env, EnvironmentFailure, \
     get_cached_env_instance
 from predicators.src.structs import State, Type, Task
+from predicators.src import utils
 
 
 def test_base_env():
     """Tests for BaseEnv class."""
+    utils.update_config({"seed": 123})
     cup_type = Type("cup_type", ["feat1"])
     plate_type = Type("plate_type", ["feat1", "feat2"])
     cup = cup_type("cup")
@@ -39,10 +41,18 @@ def test_base_env():
 
 def test_create_env():
     """Tests for create_env() and get_cached_env_instance()."""
+    utils.update_config({"seed": 123})
     for name in [
-            "cover", "cover_typed_options", "cover_hierarchical_types",
-            "cluttered_table", "blocks", "playroom", "painting",
-            "repeated_nextto"
+            "cover",
+            "cover_typed_options",
+            "cover_hierarchical_types",
+            "cluttered_table",
+            "blocks",
+            "playroom",
+            "painting",
+            "repeated_nextto",
+            "cover_multistep_options",
+            "cover_multistep_options_fixed_tasks",
     ]:
         env = create_env(name)
         assert isinstance(env, BaseEnv)

--- a/tests/envs/test_cover.py
+++ b/tests/envs/test_cover.py
@@ -4,7 +4,7 @@ import pytest
 import numpy as np
 from gym.spaces import Box
 from predicators.src.envs import CoverEnv, CoverEnvTypedOptions, \
-    CoverMultistepOptions
+    CoverMultistepOptions, CoverMultistepOptionsFixedTasks
 from predicators.src.structs import State, Action
 from predicators.src import utils
 
@@ -469,3 +469,27 @@ def test_cover_multistep_options():
         utils.save_video(outfile, video)  # pragma: no cover
     robot = [r for r in traj.states[0] if r.name == "robby"][0]
     assert np.array_equal(traj.states[-1][robot], traj.states[-2][robot])
+
+
+def test_cover_multistep_options_fixed_tasks():
+    """Tests for CoverMultistepOptionsFixedTasks."""
+    utils.update_config({
+        "env": "cover_multistep_options_fixed_tasks",
+        "num_train_tasks": 10,
+        "num_test_tasks": 10
+    })
+    env = CoverMultistepOptionsFixedTasks()
+    env.seed(123)
+    # This env is mostly the same as CoverMultistepOptions(), so we just test
+    # that the tasks are indeed fixed.
+    state = None
+    all_goals = set()
+    for task in next(env.train_tasks_generator()):
+        if state is None:
+            state = task.init
+        assert state.allclose(task.init)
+        all_goals.add(frozenset(task.goal))
+    assert len(all_goals) == 3
+    for task in env.get_test_tasks():
+        assert state.allclose(task.init)
+        assert frozenset(task.goal) in all_goals

--- a/tests/envs/test_cover.py
+++ b/tests/envs/test_cover.py
@@ -429,6 +429,47 @@ def test_cover_multistep_options():
     robot = [r for r in traj.states[0] if r.name == "robby"][0]
     assert np.array_equal(traj.states[-1][robot], traj.states[-2][robot])
 
+    # Check collision of held block with the floor.
+    action_arrs = [
+        np.array([0.05, 0., 0.], dtype=np.float32),
+        np.array([0.05, 0., 0.], dtype=np.float32),
+        np.array([0.05, 0., 0.], dtype=np.float32),
+        np.array([0.05, 0., 0.], dtype=np.float32),
+        np.array([0.05, 0., 0.], dtype=np.float32),
+        np.array([0.05, 0., 0.], dtype=np.float32),
+        np.array([0.05, 0., 0.], dtype=np.float32),
+        np.array([0.05, 0., 0.], dtype=np.float32),
+        np.array([0.05, 0., 0.], dtype=np.float32),
+        np.array([0., -0.05, 0], dtype=np.float32),
+        np.array([0., -0.05, 0.], dtype=np.float32),
+        np.array([0., -0.05, 0.], dtype=np.float32),
+        np.array([0., -0.05, 0.], dtype=np.float32),
+        np.array([0., -0.05, 0.], dtype=np.float32),
+        np.array([0., -0.045, 0.1], dtype=np.float32),
+        np.array([0., 0.05, 0.1], dtype=np.float32),
+        np.array([0., 0.05, 0.1], dtype=np.float32),
+        np.array([0., 0.05, 0.1], dtype=np.float32),
+        np.array([0., 0.05, 0.1], dtype=np.float32),
+        np.array([0., 0.05, 0.1], dtype=np.float32),
+        np.array([0., 0.05, 0.1], dtype=np.float32),
+        np.array([0.1, 0., 0.1], dtype=np.float32),
+        np.array([0.1, 0., 0.1], dtype=np.float32),
+        np.array([0.08, 0., 0.1], dtype=np.float32),
+        np.array([0., -0.1, 0.1], dtype=np.float32),
+        np.array([0., -0.1, 0.1], dtype=np.float32),
+        np.array([0., -0.05, 0.1], dtype=np.float32),
+        np.array([0., -0.07, 0.1], dtype=np.float32),
+    ]
+    make_video = False  # Can toggle to true for debugging
+    traj, video, _ = utils.run_policy_on_task(
+        policy, task, env.simulate, len(action_arrs),
+        env.render if make_video else None)
+    if make_video:
+        outfile = "hardcoded_actions_block_collision3.mp4"  # pragma: no cover
+        utils.save_video(outfile, video)  # pragma: no cover
+    robot = [r for r in traj.states[0] if r.name == "robby"][0]
+    assert np.array_equal(traj.states[-1][robot], traj.states[-2][robot])
+
 
 def test_cover_multistep_options_fixed_tasks():
     """Tests for CoverMultistepOptionsFixedTasks."""

--- a/tests/envs/test_cover.py
+++ b/tests/envs/test_cover.py
@@ -429,47 +429,6 @@ def test_cover_multistep_options():
     robot = [r for r in traj.states[0] if r.name == "robby"][0]
     assert np.array_equal(traj.states[-1][robot], traj.states[-2][robot])
 
-    # Check collision of held block with the floor.
-    action_arrs = [
-        np.array([0.05, 0., 0.], dtype=np.float32),
-        np.array([0.05, 0., 0.], dtype=np.float32),
-        np.array([0.05, 0., 0.], dtype=np.float32),
-        np.array([0.05, 0., 0.], dtype=np.float32),
-        np.array([0.05, 0., 0.], dtype=np.float32),
-        np.array([0.05, 0., 0.], dtype=np.float32),
-        np.array([0.05, 0., 0.], dtype=np.float32),
-        np.array([0.05, 0., 0.], dtype=np.float32),
-        np.array([0.05, 0., 0.], dtype=np.float32),
-        np.array([0., -0.05, 0], dtype=np.float32),
-        np.array([0., -0.05, 0.], dtype=np.float32),
-        np.array([0., -0.05, 0.], dtype=np.float32),
-        np.array([0., -0.05, 0.], dtype=np.float32),
-        np.array([0., -0.05, 0.], dtype=np.float32),
-        np.array([0., -0.045, 0.1], dtype=np.float32),
-        np.array([0., 0.05, 0.1], dtype=np.float32),
-        np.array([0., 0.05, 0.1], dtype=np.float32),
-        np.array([0., 0.05, 0.1], dtype=np.float32),
-        np.array([0., 0.05, 0.1], dtype=np.float32),
-        np.array([0., 0.05, 0.1], dtype=np.float32),
-        np.array([0., 0.05, 0.1], dtype=np.float32),
-        np.array([0.1, 0., 0.1], dtype=np.float32),
-        np.array([0.1, 0., 0.1], dtype=np.float32),
-        np.array([0.08, 0., 0.1], dtype=np.float32),
-        np.array([0., -0.1, 0.1], dtype=np.float32),
-        np.array([0., -0.1, 0.1], dtype=np.float32),
-        np.array([0., -0.05, 0.1], dtype=np.float32),
-        np.array([0., -0.07, 0.1], dtype=np.float32),
-    ]
-    make_video = False  # Can toggle to true for debugging
-    traj, video, _ = utils.run_policy_on_task(
-        policy, task, env.simulate, len(action_arrs),
-        env.render if make_video else None)
-    if make_video:
-        outfile = "hardcoded_actions_block_collision3.mp4"  # pragma: no cover
-        utils.save_video(outfile, video)  # pragma: no cover
-    robot = [r for r in traj.states[0] if r.name == "robby"][0]
-    assert np.array_equal(traj.states[-1][robot], traj.states[-2][robot])
-
 
 def test_cover_multistep_options_fixed_tasks():
     """Tests for CoverMultistepOptionsFixedTasks."""


### PR DESCRIPTION
this PR has a number of updates to the multistep cover environment to facilitate the option learning project:

1. adds `CoverMultistepOptionsFixedTasks`, a variant where the initial state is fixed (and there are only 3 possible goals).
2. adds `cover_multistep_degenerate_oracle_samplers`, a setting that allows us to use oracle samplers that only sample in the middle of blocks/targets.
3. converts the existing "learned_equivalent" oracle samplers and options to relative parameterization, for consistency with how we're going to learn the options.
4. snaps the robot to the block during picking
5. fixes a few tolerance issues for picking and placing