### PR TITLE
remove policy stuck check

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -266,7 +266,6 @@ def run_policy_until(policy: Callable[[State], Action],
     Terminates when any of these conditions hold:
     (1) the termination_function returns True,
     (2) max_num_steps is reached,
-    (3) the state does not change within a single step.
 
     Returns a LowLevelTrajectory object.
     """
@@ -275,15 +274,11 @@ def run_policy_until(policy: Callable[[State], Action],
     actions: List[Action] = []
     if not termination_function(state):
         for _ in range(max_num_steps):
-            last_state = state
             act = policy(state)
             state = simulator(state, act)
             actions.append(act)
             states.append(state)
             if termination_function(state):
-                break
-            # Detect if stuck; skip potentially expensive simulation.
-            if state.allclose(last_state):
                 break
     traj = LowLevelTrajectory(states, actions)
     return traj

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -256,31 +256,6 @@ def test_option_to_trajectory():
                                       max_num_steps=10)
     assert len(traj.actions) == len(traj.states) - 1 == 10
 
-    # Test that option terminates early if it's stuck.
-    def _simulator(s, a):
-        del a  # unused
-        return s.copy()
-
-    traj = utils.option_to_trajectory(state,
-                                      _simulator,
-                                      option,
-                                      max_num_steps=100)
-    assert len(traj.actions) == len(traj.states) - 1 == 1
-
-    # Test that option terminates early if it's stuck after the first time step.
-    def _simulator(s, a):
-        del a  # unused
-        ns = s.copy()
-        if s[cup][0] == 0.5:
-            ns[cup][0] = 0.0
-        return ns
-
-    traj = utils.option_to_trajectory(state,
-                                      _simulator,
-                                      option,
-                                      max_num_steps=100)
-    assert len(traj.actions) == len(traj.states) - 1 == 2
-
 
 def test_option_plan_to_policy():
     """Tests for option_plan_to_policy()."""


### PR DESCRIPTION
this check does not make sense for all policies; for example, policies with certain kinds of memory may be able to get out of "stuck" states.