### PR TITLE
update HoldingSide/Top arguments for painting and make painting easier

### DIFF
--- a/src/envs/painting.py
+++ b/src/envs/painting.py
@@ -422,8 +422,8 @@ class PaintingEnv(BaseEnv):
                 grasp = state.get(held_obj, "grasp")
                 assert grasp < self.side_grasp_thresh or \
                     grasp > self.top_grasp_thresh
-                edgecolor = ("yellow" if grasp < self.side_grasp_thresh else
-                             "orange")
+                edgecolor = ("yellow"
+                             if grasp < self.side_grasp_thresh else "orange")
             else:
                 edgecolor = "gray"
             # Normalize poses to [0, 1]

--- a/src/envs/painting.py
+++ b/src/envs/painting.py
@@ -45,19 +45,18 @@ class PaintingEnv(BaseEnv):
     open_fingers = 0.8
     top_grasp_thresh = 0.5 + 1e-2
     side_grasp_thresh = 0.5 - 1e-2
-    held_tol = 0.5
 
     def __init__(self) -> None:
         super().__init__()
         # Types
         self._obj_type = Type("obj", [
             "pose_x", "pose_y", "pose_z", "dirtiness", "wetness", "color",
-            "held"
+            "grasp"
         ])
         self._box_type = Type("box", ["color"])
         self._lid_type = Type("lid", ["is_open"])
         self._shelf_type = Type("shelf", ["color"])
-        self._robot_type = Type("robot", ["gripper_rot", "fingers"])
+        self._robot_type = Type("robot", ["fingers"])
         # Predicates
         self._InBox = Predicate("InBox", [self._obj_type, self._box_type],
                                 self._InBox_holds)
@@ -74,9 +73,9 @@ class PaintingEnv(BaseEnv):
                                       self._GripperOpen_holds)
         self._OnTable = Predicate("OnTable", [self._obj_type],
                                   self._OnTable_holds)
-        self._HoldingTop = Predicate("HoldingTop", [self._robot_type],
+        self._HoldingTop = Predicate("HoldingTop", [self._obj_type],
                                      self._HoldingTop_holds)
-        self._HoldingSide = Predicate("HoldingSide", [self._robot_type],
+        self._HoldingSide = Predicate("HoldingSide", [self._obj_type],
                                       self._HoldingSide_holds)
         self._Holding = Predicate("Holding", [self._obj_type],
                                   self._Holding_holds)
@@ -89,7 +88,7 @@ class PaintingEnv(BaseEnv):
         # Options
         self._Pick = ParameterizedOption(
             # variables: [robot, object to pick]
-            # params: [delta x, delta y, delta z, grasp rotation]
+            # params: [delta x, delta y, delta z, grasp]
             "Pick",
             types=[self._robot_type, self._obj_type],
             params_space=Box(
@@ -173,7 +172,7 @@ class PaintingEnv(BaseEnv):
 
     def _transition_pick_or_openlid(self, state: State,
                                     action: Action) -> State:
-        x, y, z, rot = action.arr[:4]
+        x, y, z, grasp = action.arr[:4]
         next_state = state.copy()
         # Open lid
         if self.box_lb < y < self.box_ub:
@@ -186,14 +185,16 @@ class PaintingEnv(BaseEnv):
         # Cannot pick if object pose not on table
         if not self.table_lb < y < self.table_ub:
             return next_state
+        # Cannot pick if grasp is invalid
+        if self.side_grasp_thresh < grasp < self.top_grasp_thresh:
+            return next_state
         # Check if some object is close enough to (x, y, z)
         target_obj = self._get_object_at_xyz(state, x, y, z)
         if target_obj is None:
             return next_state
         # Execute pick
-        next_state.set(self._robot, "gripper_rot", rot)
         next_state.set(self._robot, "fingers", 0.0)
-        next_state.set(target_obj, "held", 1.0)
+        next_state.set(target_obj, "grasp", grasp)
         return next_state
 
     def _transition_wash(self, state: State, action: Action) -> State:
@@ -258,11 +259,10 @@ class PaintingEnv(BaseEnv):
             # Cannot place in box if lid is not open
             raise EnvironmentFailure("Box lid is closed.", {self._lid})
         # Detect top grasp vs side grasp
-        rot = state.get(self._robot, "gripper_rot")
-        top_or_side = "neither"
-        if rot > self.top_grasp_thresh:
+        grasp = state.get(held_obj, "grasp")
+        if grasp > self.top_grasp_thresh:
             top_or_side = "top"
-        elif rot < self.side_grasp_thresh:
+        elif grasp < self.side_grasp_thresh:
             top_or_side = "side"
         # Can only place in shelf if side grasping, box if top grasping. If the
         # receptacle is table, we don't care what kind of grasp it is.
@@ -278,12 +278,11 @@ class PaintingEnv(BaseEnv):
             raise EnvironmentFailure("Collision during place on table.",
                                      {collider})
         # Execute place
-        next_state.set(self._robot, "gripper_rot", 0.5)
         next_state.set(self._robot, "fingers", 1.0)
         next_state.set(held_obj, "pose_x", x)
         next_state.set(held_obj, "pose_y", y)
         next_state.set(held_obj, "pose_z", z)
-        next_state.set(held_obj, "held", 0.0)
+        next_state.set(held_obj, "grasp", 0.5)  # revert to not grasped
         return next_state
 
     def train_tasks_generator(self) -> Iterator[List[Task]]:
@@ -343,9 +342,9 @@ class PaintingEnv(BaseEnv):
     @property
     def action_space(self) -> Box:
         # Actions are 8-dimensional vectors:
-        # [x, y, z, rot, pickplace, water level, heat level, color]
+        # [x, y, z, grasp, pickplace, water level, heat level, color]
         # Note that pickplace is 1 for pick, -1 for place, and 0 otherwise,
-        # while rot, water level, heat level, and color are in [0, 1].
+        # while grasp, water level, heat level, and color are in [0, 1].
         lowers = np.array([
             self.obj_x - 1e-2, self.env_lb, self.obj_z - 1e-2, 0.0, -1.0, 0.0,
             0.0, 0.0
@@ -420,10 +419,10 @@ class PaintingEnv(BaseEnv):
                 facecolor = [obj_color, 0, 0]
             if held_obj == obj:
                 assert state.get(self._robot, "fingers") < self.open_fingers
-                grip_rot = state.get(self._robot, "gripper_rot")
-                assert grip_rot < self.side_grasp_thresh or \
-                    grip_rot > self.top_grasp_thresh
-                edgecolor = ("yellow" if grip_rot < self.side_grasp_thresh else
+                grasp = state.get(held_obj, "grasp")
+                assert grasp < self.side_grasp_thresh or \
+                    grasp > self.top_grasp_thresh
+                edgecolor = ("yellow" if grasp < self.side_grasp_thresh else
                              "orange")
             else:
                 edgecolor = "gray"
@@ -460,7 +459,7 @@ class PaintingEnv(BaseEnv):
             num_objs = num_objs_lst[i % len(num_objs_lst)]
             data = {}
             # Initialize robot
-            data[self._robot] = np.array([0.5, 1.0])  # fingers start off open
+            data[self._robot] = np.array([1.0])  # fingers start off open
             # Sample distinct colors for shelf and box
             color1 = rng.uniform(0.2, 0.4)
             color2 = rng.uniform(0.6, 1.0)
@@ -494,9 +493,9 @@ class PaintingEnv(BaseEnv):
                     wetness = 0.0
                     dirtiness = 0.0
                 color = 0.0
-                held = 0.0
+                grasp = 0.5  # object starts off not grasped
                 data[obj] = np.array([
-                    pose[0], pose[1], pose[2], dirtiness, wetness, color, held
+                    pose[0], pose[1], pose[2], dirtiness, wetness, color, grasp
                 ],
                                      dtype=np.float32)
                 # Last object should go in box
@@ -511,11 +510,10 @@ class PaintingEnv(BaseEnv):
             # Sometimes start out holding an object, possibly with the wrong
             # grip, so that we'll have to put it on the table and regrasp
             if rng.uniform() < CFG.painting_initial_holding_prob:
-                rot = rng.choice([0.0, 1.0])
+                grasp = rng.choice([0.0, 1.0])
                 target_obj = objs[rng.choice(len(objs))]
-                state.set(self._robot, "gripper_rot", rot)
                 state.set(self._robot, "fingers", 0.0)
-                state.set(target_obj, "held", 1.0)
+                state.set(target_obj, "grasp", grasp)
                 assert self._OnTable_holds(state, [target_obj])
             tasks.append(Task(state, goal))
         return tasks
@@ -539,9 +537,9 @@ class PaintingEnv(BaseEnv):
         obj_x = state.get(obj, "pose_x")
         obj_y = state.get(obj, "pose_y")
         obj_z = state.get(obj, "pose_z")
-        dx, dy, dz, rot = params
+        dx, dy, dz, grasp = params
         arr = np.array(
-            [obj_x + dx, obj_y + dy, obj_z + dz, rot, 1.0, 0.0, 0.0, 0.0],
+            [obj_x + dx, obj_y + dy, obj_z + dz, grasp, 1.0, 0.0, 0.0, 0.0],
             dtype=np.float32)
         # The addition of dx, dy, and dz could cause the action to go
         # out of bounds, so we clip it back into the bounds for safety.
@@ -589,7 +587,7 @@ class PaintingEnv(BaseEnv):
                       params: Array) -> Action:
         del state, memory, objects  # unused
         x, y, z = params
-        arr = np.array([x, y, z, 0.0, -1.0, 0.0, 0.0, 0.0], dtype=np.float32)
+        arr = np.array([x, y, z, 0.5, -1.0, 0.0, 0.0, 0.0], dtype=np.float32)
         return Action(arr)
 
     def _holding_initiable(self, state: State, memory: Dict,
@@ -627,7 +625,7 @@ class PaintingEnv(BaseEnv):
     def _InBox_holds(self, state: State, objects: Sequence[Object]) -> bool:
         obj, _ = objects
         # If the object is held, not yet in box
-        if state.get(obj, "held") > 0.5:
+        if self._obj_is_held(state, obj):
             return False
         # Check pose of object
         obj_y = state.get(obj, "pose_y")
@@ -636,7 +634,7 @@ class PaintingEnv(BaseEnv):
     def _InShelf_holds(self, state: State, objects: Sequence[Object]) -> bool:
         obj, _ = objects
         # If the object is held, not yet in shelf
-        if state.get(obj, "held") > 0.5:
+        if self._obj_is_held(state, obj):
             return False
         # Check pose of object
         obj_y = state.get(obj, "pose_y")
@@ -667,19 +665,19 @@ class PaintingEnv(BaseEnv):
 
     def _HoldingTop_holds(self, state: State,
                           objects: Sequence[Object]) -> bool:
-        robot, = objects
-        rot = state.get(robot, "gripper_rot")
-        return rot > self.top_grasp_thresh
+        obj, = objects
+        grasp = state.get(obj, "grasp")
+        return grasp > self.top_grasp_thresh
 
     def _HoldingSide_holds(self, state: State,
                            objects: Sequence[Object]) -> bool:
-        robot, = objects
-        rot = state.get(robot, "gripper_rot")
-        return rot < self.side_grasp_thresh
+        obj, = objects
+        grasp = state.get(obj, "grasp")
+        return grasp < self.side_grasp_thresh
 
     def _Holding_holds(self, state: State, objects: Sequence[Object]) -> bool:
         obj, = objects
-        return state.get(obj, "held") > self.held_tol
+        return self._obj_is_held(state, obj)
 
     def _IsWet_holds(self, state: State, objects: Sequence[Object]) -> bool:
         obj, = objects
@@ -701,9 +699,13 @@ class PaintingEnv(BaseEnv):
         for obj in state:
             if obj.type != self._obj_type:
                 continue
-            if state.get(obj, "held") > self.held_tol:
+            if self._obj_is_held(state, obj):
                 return obj
         return None
+
+    def _obj_is_held(self, state: State, obj: Object) -> bool:
+        grasp = state.get(obj, "grasp")
+        return grasp > self.top_grasp_thresh or grasp < self.side_grasp_thresh
 
     def _get_object_at_xyz(self, state: State, x: float, y: float,
                            z: float) -> Optional[Object]:

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -553,10 +553,7 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         LiftedAtom(GripperOpen, [robot]),
         LiftedAtom(OnTable, [obj])
     }
-    add_effects = {
-        LiftedAtom(Holding, [obj]),
-        LiftedAtom(HoldingSide, [obj])
-    }
+    add_effects = {LiftedAtom(Holding, [obj]), LiftedAtom(HoldingSide, [obj])}
     delete_effects = {LiftedAtom(GripperOpen, [robot])}
 
     def pickfromside_sampler(state: State, rng: np.random.Generator,
@@ -670,10 +667,7 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
     parameters = [obj, box, robot]
     option_vars = [robot]
     option = Place
-    preconditions = {
-        LiftedAtom(Holding, [obj]),
-        LiftedAtom(HoldingTop, [obj])
-    }
+    preconditions = {LiftedAtom(Holding, [obj]), LiftedAtom(HoldingTop, [obj])}
     add_effects = {
         LiftedAtom(InBox, [obj, box]),
         LiftedAtom(GripperOpen, [robot])

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -530,7 +530,7 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         LiftedAtom(GripperOpen, [robot]),
         LiftedAtom(OnTable, [obj])
     }
-    add_effects = {LiftedAtom(Holding, [obj]), LiftedAtom(HoldingTop, [robot])}
+    add_effects = {LiftedAtom(Holding, [obj]), LiftedAtom(HoldingTop, [obj])}
     delete_effects = {LiftedAtom(GripperOpen, [robot])}
 
     def pickfromtop_sampler(state: State, rng: np.random.Generator,
@@ -555,7 +555,7 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
     }
     add_effects = {
         LiftedAtom(Holding, [obj]),
-        LiftedAtom(HoldingSide, [robot])
+        LiftedAtom(HoldingSide, [obj])
     }
     delete_effects = {LiftedAtom(GripperOpen, [robot])}
 
@@ -672,14 +672,14 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
     option = Place
     preconditions = {
         LiftedAtom(Holding, [obj]),
-        LiftedAtom(HoldingTop, [robot])
+        LiftedAtom(HoldingTop, [obj])
     }
     add_effects = {
         LiftedAtom(InBox, [obj, box]),
         LiftedAtom(GripperOpen, [robot])
     }
     delete_effects = {
-        LiftedAtom(HoldingTop, [robot]),
+        LiftedAtom(HoldingTop, [obj]),
         LiftedAtom(Holding, [obj]),
         LiftedAtom(OnTable, [obj])
     }
@@ -705,14 +705,14 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
     option = Place
     preconditions = {
         LiftedAtom(Holding, [obj]),
-        LiftedAtom(HoldingSide, [robot])
+        LiftedAtom(HoldingSide, [obj])
     }
     add_effects = {
         LiftedAtom(InShelf, [obj, shelf]),
         LiftedAtom(GripperOpen, [robot])
     }
     delete_effects = {
-        LiftedAtom(HoldingSide, [robot]),
+        LiftedAtom(HoldingSide, [obj]),
         LiftedAtom(Holding, [obj]),
         LiftedAtom(OnTable, [obj])
     }
@@ -758,7 +758,7 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         option = Place
         preconditions = {
             LiftedAtom(Holding, [obj]),
-            LiftedAtom(holding_rot_pred, [robot]),
+            LiftedAtom(holding_rot_pred, [obj]),
             LiftedAtom(OnTable, [obj]),
         }
         add_effects = {
@@ -766,7 +766,7 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         }
         delete_effects = {
             LiftedAtom(Holding, [obj]),
-            LiftedAtom(holding_rot_pred, [robot]),
+            LiftedAtom(holding_rot_pred, [obj]),
         }
 
         def placeontable_sampler(state: State, rng: np.random.Generator,

--- a/src/settings.py
+++ b/src/settings.py
@@ -42,8 +42,8 @@ class GlobalSettings:
 
     # painting env parameters
     painting_initial_holding_prob = 0.0
-    painting_num_objs_train = [3, 4]
-    painting_num_objs_test = [5, 6]
+    painting_num_objs_train = [2]
+    painting_num_objs_test = [3, 4]
     painting_train_families = [
         "box_and_shelf",  # placing into both box and shelf
         # "box_only",  # just placing into the box

--- a/tests/envs/test_painting.py
+++ b/tests/envs/test_painting.py
@@ -122,27 +122,26 @@ def test_painting_failure_cases():
     atoms = utils.abstract(state, env.predicates)
     assert OnTable([obj0]) in atoms
     assert OnTable([obj1]) in atoms
-    assert OnTable([obj2]) in atoms
     # In the first initial state, we are holding an object, because
     # painting_initial_holding_prob = 1.0
-    assert Holding([obj2]) in atoms
+    assert Holding([obj0]) in atoms
     # Placing it on another object causes a collision
     with pytest.raises(EnvironmentFailure):
-        x = state.get(obj0, "pose_x")
-        y = state.get(obj0, "pose_y")
-        z = state.get(obj0, "pose_z")
+        x = state.get(obj1, "pose_x")
+        y = state.get(obj1, "pose_y")
+        z = state.get(obj1, "pose_z")
         act = Place.ground([robot], np.array([x, y, z],
                                              dtype=np.float32)).policy(state)
         env.simulate(state, act)
     # Advance to a state where we are not holding anything
-    x = state.get(obj2, "pose_x")
-    y = state.get(obj2, "pose_y")
-    z = state.get(obj2, "pose_z")
+    x = state.get(obj0, "pose_x")
+    y = state.get(obj0, "pose_y")
+    z = state.get(obj0, "pose_z")
     act = Place.ground([robot], np.array([x, y, z],
                                          dtype=np.float32)).policy(state)
     handempty_state = env.simulate(state, act)
     state = handempty_state
-    assert Holding([obj2]) not in utils.abstract(state, env.predicates)
+    assert Holding([obj0]) not in utils.abstract(state, env.predicates)
     # No object at this pose, pick fails
     act = Pick.ground([robot, obj0], np.array([0, -1, 0, 0],
                                               dtype=np.float32)).policy(state)

--- a/tests/envs/test_painting.py
+++ b/tests/envs/test_painting.py
@@ -167,41 +167,12 @@ def test_painting_failure_cases():
                  dtype=np.float32)).policy(state)
     next_state = env.simulate(state, act)
     assert state.allclose(next_state)
-    # Perform valid pick with gripper_rot = 0.5
+    # Cannot pick with grasp = 0.5
     act = Pick.ground([robot, obj0], np.array([0, 0, 0, 0.5],
                                               dtype=np.float32)).policy(state)
     next_state = env.simulate(state, act)
-    assert not state.allclose(next_state)
-    # Change the state
-    state = next_state
-    # Cannot pick twice in a row
-    act = Pick.ground([robot, obj1], np.array([0, 0, 0, 0],
-                                              dtype=np.float32)).policy(state)
-    next_state = env.simulate(state, act)
     assert state.allclose(next_state)
-    # Cannot paint because not dry/clean
-    act = Paint.ground([robot], np.array([0], dtype=np.float32)).policy(state)
-    next_state = env.simulate(state, act)
-    assert state.allclose(next_state)
-    # Cannot place outside of shelf/box
-    act = Place.ground(
-        [robot],
-        np.array(
-            [PaintingEnv.obj_x, PaintingEnv.shelf_lb - 0.1, PaintingEnv.obj_z],
-            dtype=np.float32)).policy(state)
-    next_state = env.simulate(state, act)
-    # Cannot place because gripper_rot is 0.5
-    act = Place.ground(
-        [robot],
-        np.array([
-            PaintingEnv.obj_x, PaintingEnv.shelf_lb + 1e-3, PaintingEnv.obj_z
-        ],
-                 dtype=np.float32)).policy(state)
-    next_state = env.simulate(state, act)
-    assert state.allclose(next_state)
-    # Reset state
-    state = handempty_state
-    # Perform valid pick with gripper_rot = 1 (top grasp)
+    # Perform valid pick with grasp = 1 (top grasp)
     act = Pick.ground([robot, obj0], np.array([0, 0, 0, 1],
                                               dtype=np.float32)).policy(state)
     next_state = env.simulate(state, act)
@@ -210,7 +181,7 @@ def test_painting_failure_cases():
     state = next_state
     # Render with holding
     env.render(state, task)
-    # Cannot place in shelf because gripper_rot is 1
+    # Cannot place in shelf because grasp is 1
     act = Place.ground(
         [robot],
         np.array([
@@ -247,7 +218,7 @@ def test_painting_failure_cases():
     assert not state.allclose(next_state)
     # Reset state
     state = handempty_state
-    # Perform valid pick with gripper_rot = 0 (side grasp)
+    # Perform valid pick with grasp = 0 (side grasp)
     act = Pick.ground([robot, obj0], np.array([0, 0, 0, 0],
                                               dtype=np.float32)).policy(state)
     next_state = env.simulate(state, act)


### PR DESCRIPTION
This change makes HoldingSide/Top in painting take in an object instead of a robot. The `held` field of an object has been changed into a `grasp` field, where <0.48 means side grasped, 0.48-0.52 means not grasped, >0.52 means top grasped. The `gripper_rot` field of a robot has been removed.

With lmcut, before this change:
```
Test results: defaultdict(<class 'float'>, {'num_solved': 50, 'num_total': 50, 'avg_suc_time': 0.5432149934768676, 'avg_skeletons_optimized': 1.76, 'min_skeletons_optimized': 1.0, 'max_skeletons_optimized': 2.0, 'avg_nodes_expanded': 802.36, 'avg_plan_length': 14.5, 'avg_execution_failures': 0.0, 'learning_time': 0.0})
Main script terminated in 27.19248 seconds
```

With lmcut, after this change:
```
Test results: defaultdict(<class 'float'>, {'num_solved': 50, 'num_total': 50, 'avg_suc_time': 0.3771005344390869, 'avg_skeletons_optimized': 1.76, 'min_skeletons_optimized': 1.0, 'max_skeletons_optimized': 2.0, 'avg_nodes_expanded': 479.92, 'avg_plan_length': 14.5, 'avg_execution_failures': 0.0, 'learning_time': 0.0})
Wrote out test results to results/painting__oracle__0____.pkl
Main script terminated in 18.88804 seconds
```