### PR TITLE
switch to LM-Cut across the board

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -68,6 +68,7 @@ class GlobalSettings:
     max_num_steps_option_rollout = 1000
     max_skeletons_optimized = 8  # if 1, can only solve downward refinable tasks
     max_samples_per_step = 10  # max effort on sampling a single skeleton
+    task_planning_heuristic = "lmcut"
 
     # evaluation parameters
     results_dir = "results"
@@ -159,15 +160,6 @@ class GlobalSettings:
         if "approach" not in args:
             args["approach"] = ""
         return dict(
-            # Task planning heuristic to use in SeSamE.
-            task_planning_heuristic=defaultdict(
-                # Use HAdd by default.
-                lambda: "hadd",
-                {
-                    # In the playroom domain, HFF works better.
-                    "playroom": "hff",
-                })[args["env"]],
-
             # In SeSamE, when to propagate failures back up to the high level
             # search. Choices are: {"after_exhaust", "immediately", "never"}.
             sesame_propagate_failures=defaultdict(

--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -577,8 +577,9 @@ def test_exact_energy_score_function():
     assert all_included_s < none_included_s  # good!
     assert all_included_s < gripperopen_excluded_s  # good!
     # Test that the score is inf when the operators make the data impossible.
-    # Note: this test will crash pyperplan's implementation of LM-Cut, so
-    #       we'll make sure to use HAdd for it.
+    # Note: this test will crash pyperplan's implementation of LM-Cut, because
+    #       there is a predicate (On) named in the goal that doesn't appear in
+    #       any of the reachable facts. So, we'll use HAdd.
     old_heur = CFG.task_planning_heuristic
     utils.update_config({"task_planning_heuristic": "hadd"})
     ablated = {"On"}

--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -577,6 +577,10 @@ def test_exact_energy_score_function():
     assert all_included_s < none_included_s  # good!
     assert all_included_s < gripperopen_excluded_s  # good!
     # Test that the score is inf when the operators make the data impossible.
+    # Note: this test will crash pyperplan's implementation of LM-Cut, so
+    #       we'll make sure to use HAdd for it.
+    old_heur = CFG.task_planning_heuristic
+    utils.update_config({"task_planning_heuristic": "hadd"})
     ablated = {"On"}
     initial_predicates = set()
     name_to_pred = {}
@@ -590,6 +594,7 @@ def test_exact_energy_score_function():
     score_function = _ExactHeuristicEnergyBasedScoreFunction(
         initial_predicates, atom_dataset, candidates)
     assert score_function.evaluate(set()) == float("inf")
+    utils.update_config({"task_planning_heuristic": old_heur})
     old_hbmd = CFG.grammar_search_heuristic_based_max_demos
     utils.update_config({"grammar_search_heuristic_based_max_demos": 0})
     assert abs(score_function.evaluate(set()) - 0.39) < 0.11  # only op penalty


### PR DESCRIPTION
Big change! Here are oracle results (TL;DR, LM-Cut is worse, but hey, it's optimal...)

```
painting:
lmcut:
Test results: defaultdict(<class 'float'>, {'num_solved': 50, 'num_total': 50, 'avg_suc_time': 0.3736675071716309, 'avg_skeletons_optimized': 1.76, 'min_skeletons_optimized': 1.0, 'max_skeletons_optimized': 2.0, 'avg_nodes_expanded': 479.92, 'avg_nodes_created': 0.0, 'avg_plan_length': 14.5, 'avg_execution_failures': 0.0, 'learning_time': 0.0})
Main script terminated in 18.71742 seconds

previous (hadd):
Test results: defaultdict(<class 'float'>, {'num_solved': 50, 'num_total': 50, 'avg_suc_time': 0.053870744705200195, 'avg_skeletons_optimized': 1.76, 'min_skeletons_optimized': 1.0, 'max_skeletons_optimized': 2.0, 'avg_nodes_expanded': 68.18, 'avg_nodes_created': 0.0, 'avg_plan_length': 14.78, 'avg_execution_failures': 0.0, 'learning_time': 0.0})
Main script terminated in 2.72733 seconds

blocks:
lmcut:
Test results: defaultdict(<class 'float'>, {'num_solved': 50, 'num_total': 50, 'avg_suc_time': 0.1755300998687744, 'avg_skeletons_optimized': 1.0, 'min_skeletons_optimized': 1.0, 'max_skeletons_optimized': 1.0, 'avg_nodes_expanded': 478.02, 'avg_nodes_created': 0.0, 'avg_plan_length': 8.96, 'avg_execution_failures': 0.0, 'learning_time': 0.0})
Main script terminated in 8.80946 seconds

previous (hadd):
Test results: defaultdict(<class 'float'>, {'num_solved': 50, 'num_total': 50, 'avg_suc_time': 0.1049272632598877, 'avg_skeletons_optimized': 1.0, 'min_skeletons_optimized': 1.0, 'max_skeletons_optimized': 1.0, 'avg_nodes_expanded': 557.56, 'avg_nodes_created': 0.0, 'avg_plan_length': 8.96, 'avg_execution_failures': 0.0, 'learning_time': 0.0})
Main script terminated in 5.27787 seconds

cover:
lmcut:
Test results: defaultdict(<class 'float'>, {'num_solved': 50, 'num_total': 50, 'avg_suc_time': 0.005876617431640625, 'avg_skeletons_optimized': 1.0, 'min_skeletons_optimized': 1.0, 'max_skeletons_optimized': 1.0, 'avg_nodes_expanded': 2.94, 'avg_nodes_created': 0.0, 'avg_plan_length': 2.64, 'avg_execution_failures': 0.0, 'learning_time': 0.0})
Main script terminated in 0.31466 seconds

previous (hadd):
Test results: defaultdict(<class 'float'>, {'num_solved': 50, 'num_total': 50, 'avg_suc_time': 0.006201438903808594, 'avg_skeletons_optimized': 1.0, 'min_skeletons_optimized': 1.0, 'max_skeletons_optimized': 1.0, 'avg_nodes_expanded': 2.64, 'avg_nodes_created': 0.0, 'avg_plan_length': 2.64, 'avg_execution_failures': 0.0, 'learning_time': 0.0})
Main script terminated in 0.33141 seconds

playroom:
lmcut:
Test results: defaultdict(<class 'float'>, {'num_solved': 50, 'num_total': 50, 'avg_suc_time': 0.14313022613525392, 'avg_skeletons_optimized': 1.0, 'min_skeletons_optimized': 1.0, 'max_skeletons_optimized': 1.0, 'avg_nodes_expanded': 33.82, 'avg_nodes_created': 0.0, 'avg_plan_length': 19.04, 'avg_execution_failures': 0.0, 'learning_time': 0.0})
Main script terminated in 7.18861 seconds

previous (hff):
Test results: defaultdict(<class 'float'>, {'num_solved': 50, 'num_total': 50, 'avg_suc_time': 0.143670015335083, 'avg_skeletons_optimized': 1.0, 'min_skeletons_optimized': 1.0, 'max_skeletons_optimized': 1.0, 'avg_nodes_expanded': 33.82, 'avg_nodes_created': 0.0, 'avg_plan_length': 19.04, 'avg_execution_failures': 0.0, 'learning_time': 0.0})
Main script terminated in 7.21490 seconds
```