### PR TITLE
speed up tests ~3.3x

### DIFF
--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -16,7 +16,7 @@ from predicators.src.approaches.grammar_search_invention_approach import (
     _RelaxationHeuristicCountBasedScoreFunction,
     _ExactHeuristicCountBasedScoreFunction, _BranchingFactorScoreFunction)
 from predicators.src.datasets import create_dataset
-from predicators.src.envs import CoverEnv, BlocksEnv, PaintingEnv
+from predicators.src.envs import CoverEnv, BlocksEnv
 from predicators.src.structs import Type, Predicate, STRIPSOperator, State, \
     Action, ParameterizedOption, Box, LowLevelTrajectory, GroundAtom, \
     _GroundSTRIPSOperator, OptionSpec
@@ -40,7 +40,7 @@ def test_predicate_grammar():
                            [np.zeros(1, dtype=np.float32)])
     ]
     base_grammar = _PredicateGrammar()
-    assert base_grammar.generate(max_num=0) == {}
+    assert not base_grammar.generate(max_num=0)
     with pytest.raises(NotImplementedError):
         base_grammar.generate(max_num=1)
     data_based_grammar = _DataBasedPredicateGrammar(dataset)

--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -40,6 +40,7 @@ def test_predicate_grammar():
                            [np.zeros(1, dtype=np.float32)])
     ]
     base_grammar = _PredicateGrammar()
+    assert base_grammar.generate(max_num=0) == {}
     with pytest.raises(NotImplementedError):
         base_grammar.generate(max_num=1)
     data_based_grammar = _DataBasedPredicateGrammar(dataset)
@@ -471,32 +472,31 @@ def test_relaxation_energy_score_function():
     assert all_included_s < none_included_s  # good!
 
     # Tests for PaintingEnv.
-    utils.flush_cache()
-    utils.update_config({
-        "env": "painting",
-        "offline_data_method": "demo+replay",
-        "seed": 0,
-        "painting_train_families": ["box_and_shelf"],
-    })
-    env = PaintingEnv()
-    ablated = {"IsWet", "IsDry"}
-    initial_predicates = set()
-    name_to_pred = {}
-    for p in env.predicates:
-        if p.name in ablated:
-            name_to_pred[p.name] = p
-        else:
-            initial_predicates.add(p)
-    candidates = {p: 1.0 for p in name_to_pred.values()}
-    train_tasks = next(env.train_tasks_generator())
-    dataset = create_dataset(env, train_tasks)
-    atom_dataset = utils.create_ground_atom_dataset(dataset, env.predicates)
-    score_function = _RelaxationHeuristicEnergyBasedScoreFunction(
-        initial_predicates, atom_dataset, candidates, ["hadd"])
-    all_included_s = score_function.evaluate(set(candidates))
-    none_included_s = score_function.evaluate(set())
-
     # Comment out this test because it's flaky.
+    # utils.flush_cache()
+    # utils.update_config({
+    #     "env": "painting",
+    #     "offline_data_method": "demo+replay",
+    #     "seed": 0,
+    #     "painting_train_families": ["box_and_shelf"],
+    # })
+    # env = PaintingEnv()
+    # ablated = {"IsWet", "IsDry"}
+    # initial_predicates = set()
+    # name_to_pred = {}
+    # for p in env.predicates:
+    #     if p.name in ablated:
+    #         name_to_pred[p.name] = p
+    #     else:
+    #         initial_predicates.add(p)
+    # candidates = {p: 1.0 for p in name_to_pred.values()}
+    # train_tasks = next(env.train_tasks_generator())
+    # dataset = create_dataset(env, train_tasks)
+    # atom_dataset = utils.create_ground_atom_dataset(dataset, env.predicates)
+    # score_function = _RelaxationHeuristicEnergyBasedScoreFunction(
+    #     initial_predicates, atom_dataset, candidates, ["hadd"])
+    # all_included_s = score_function.evaluate(set(candidates))
+    # none_included_s = score_function.evaluate(set())
     # assert all_included_s < none_included_s  # hooray!
 
     # Cover edge case where there are no successors.

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -82,9 +82,9 @@ def test_nsrt_learning_approach():
                        sampler_learner="random",
                        learn_side_predicates=True)
 
+
 def test_neural_option_learning():
-    """Tests for NeuralOptionLearner class.
-    """
+    """Tests for NeuralOptionLearner class."""
     _test_approach(env_name="cover_multistep_options",
                    approach_name="nsrt_learning",
                    try_solving=False,

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -26,10 +26,13 @@ def _test_approach(env_name,
     utils.update_config({
         "timeout": 10,
         "max_samples_per_step": 10,
-        "neural_gaus_regressor_max_itr": 200,
-        "sampler_mlp_classifier_max_itr": 200,
-        "predicate_mlp_classifier_max_itr": 200,
-        "mlp_regressor_max_itr": 200,
+        "neural_gaus_regressor_max_itr": 100,
+        "sampler_mlp_classifier_max_itr": 100,
+        "predicate_mlp_classifier_max_itr": 100,
+        "mlp_regressor_max_itr": 100,
+        "num_train_tasks": 3,
+        "num_test_tasks": 3,
+        "offline_data_num_replays": 50,
         "excluded_predicates": excluded_predicates,
         "learn_side_predicates": learn_side_predicates,
         "option_learner": option_learner,
@@ -72,22 +75,16 @@ def _test_approach(env_name,
 def test_nsrt_learning_approach():
     """Tests for NSRTLearningApproach class."""
     _test_approach(env_name="blocks", approach_name="nsrt_learning")
-    with pytest.raises(NotImplementedError):  # bad sampler_learner
-        _test_approach(env_name="cover_multistep_options",
-                       approach_name="nsrt_learning",
-                       try_solving=False,
-                       sampler_learner="not a real sampler learner")
-    _test_approach(env_name="cover_multistep_options",
-                   approach_name="nsrt_learning",
-                   try_solving=False,
-                   sampler_learner="random")
     with pytest.raises(NotImplementedError):
         _test_approach(env_name="repeated_nextto",
                        approach_name="nsrt_learning",
                        try_solving=False,
                        sampler_learner="random",
                        learn_side_predicates=True)
-    # Test neural option learning.
+
+def test_neural_option_learning():
+    """Tests for NeuralOptionLearner class.
+    """
     _test_approach(env_name="cover_multistep_options",
                    approach_name="nsrt_learning",
                    try_solving=False,
@@ -178,13 +175,5 @@ def test_grammar_search_invention_approach():
     _test_approach(env_name="cover",
                    approach_name="grammar_search_invention",
                    excluded_predicates="Holding",
-                   try_solving=False,
-                   sampler_learner="random")
-    # Test that the pipeline doesn't crash when no predicates are learned
-    # involving a certain option argument (robot in this case).
-    utils.update_config({"grammar_search_max_predicates": 0})
-    _test_approach(env_name="blocks",
-                   approach_name="grammar_search_invention",
-                   excluded_predicates="GripperOpen",
                    try_solving=False,
                    sampler_learner="random")

--- a/tests/approaches/test_random_actions_approach.py
+++ b/tests/approaches/test_random_actions_approach.py
@@ -16,6 +16,7 @@ def test_random_actions_approach():
     task = next(env.train_tasks_generator())[0]
     approach = RandomActionsApproach(env.simulate, env.predicates, env.options,
                                      env.types, env.action_space)
+    assert not approach.is_learning_based
     approach.seed(123)
     policy = approach.solve(task, 500)
     actions = []

--- a/tests/approaches/test_random_options_approach.py
+++ b/tests/approaches/test_random_options_approach.py
@@ -41,6 +41,7 @@ def test_random_options_approach():
     approach = RandomOptionsApproach(_simulator, {Solved},
                                      {parameterized_option}, {cup_type},
                                      params_space)
+    assert not approach.is_learning_based
     task = Task(state, {Solved([cup])})
     approach.seed(123)
     policy = approach.solve(task, 500)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -55,56 +55,16 @@ def test_main():
     ]
     with pytest.raises(ValueError):
         main()  # invalid flag
-    sys.argv = [
-        "dummy", "--env", "cover", "--approach", "random_actions", "--seed",
-        "123", "--num_test_tasks", "5"
-    ]
-    main()
-    sys.argv = [
-        "dummy", "--env", "cover", "--approach", "random_options", "--seed",
-        "123", "--num_test_tasks", "5"
-    ]
-    main()
-    sys.argv = [
-        "dummy", "--env", "cover", "--approach", "oracle", "--seed", "123",
-        "--num_test_tasks", "5"
-    ]
-    main()
-    sys.argv = [
-        "dummy", "--env", "cluttered_table", "--approach", "random_actions",
-        "--seed", "123", "--num_test_tasks", "20"
-    ]
-    main()
-    sys.argv = [
-        "dummy", "--env", "blocks", "--approach", "random_actions", "--seed",
-        "123", "--num_test_tasks", "5"
-    ]
-    main()
-    sys.argv = [
-        "dummy", "--env", "blocks", "--approach", "random_options", "--seed",
-        "123", "--num_test_tasks", "5"
-    ]
-    main()
     video_dir = os.path.join(os.path.dirname(__file__), "_fake_videos")
-    sys.argv = [
-        "dummy", "--env", "cover", "--approach", "oracle", "--seed", "123",
-        "--make_videos", "--num_test_tasks", "1", "--video_dir", video_dir
-    ]
-    main()
-    shutil.rmtree(video_dir)
     results_dir = os.path.join(os.path.dirname(__file__), "_fake_results")
     sys.argv = [
         "dummy", "--env", "cover", "--approach", "oracle", "--seed", "123",
-        "--num_test_tasks", "1", "--results_dir", results_dir
+        "--make_videos", "--num_test_tasks", "1", "--video_dir", video_dir,
+        "--results_dir", results_dir
     ]
     main()
+    shutil.rmtree(video_dir)
     shutil.rmtree(results_dir)
-    # Try running main with a strong timeout.
-    sys.argv = [
-        "dummy", "--env", "cover", "--approach", "oracle", "--seed", "123",
-        "--timeout", "0.001", "--num_test_tasks", "5"
-    ]
-    main()
     # Run actual main approach, but without sampler learning.
     sys.argv = [
         "dummy", "--env", "cover", "--approach", "nsrt_learning", "--seed",
@@ -129,14 +89,6 @@ def test_main():
         "123"
     ]
     main()
-    # Try learning (with too low hyperparameters to actually work).
-    sys.argv = [
-        "dummy", "--env", "cover", "--approach", "nsrt_learning", "--seed",
-        "123", "--sampler_learner", "neural",
-        "--sampler_mlp_classifier_max_itr", "10",
-        "--neural_gaus_regressor_max_itr", "10", "--timeout", "0.01"
-    ]
-    main()  # correct usage
     # Try predicate exclusion.
     sys.argv = [
         "dummy", "--env", "cover", "--approach", "random_options", "--seed",
@@ -152,26 +104,9 @@ def test_main():
         main()  # can't exclude a goal predicate
     sys.argv = [
         "dummy", "--env", "cover", "--approach", "random_options", "--seed",
-        "123", "--excluded_predicates", "Holding,HandEmpty"
+        "123", "--excluded_predicates", "all", "--num_test_tasks", "5"
     ]
-    main()  # correct usage
-    sys.argv = [
-        "dummy", "--env", "cover", "--approach", "random_options", "--seed",
-        "123", "--excluded_predicates", "HandEmpty", "--num_test_tasks", "5"
-    ]
-    main()  # correct usage
-    sys.argv = [
-        "dummy", "--env", "cover", "--approach", "random_options", "--seed",
-        "123", "--excluded_predicates", "all", "--num_test_tasks", "5",
-        "--cover_initial_holding_prob", "0.99"
-    ]
-    main()  # correct usage
-    sys.argv = [
-        "dummy", "--env", "cover", "--approach", "random_options", "--seed",
-        "123", "--excluded_predicates", "all", "--num_test_tasks", "5",
-        "--cover_initial_holding_prob", "0"
-    ]
-    main()  # correct usage
+    main()
 
 
 def test_tamp_approach_failure():

--- a/tests/test_nsrt_learning.py
+++ b/tests/test_nsrt_learning.py
@@ -263,11 +263,13 @@ def test_nsrt_learning_specific_nsrts():
     nsrts = learn_nsrts_from_data(dataset, preds, sampler_learner="random")
     assert len(nsrts) == 0
     # Test max_rejection_sampling_tries = 0
-    utils.update_config({"min_data_for_nsrt": 0,
-                         "max_rejection_sampling_tries": 0,
-                         "seed": 1234,
-                         "sampler_mlp_classifier_max_itr": 1,
-                         "neural_gaus_regressor_max_itr": 1})
+    utils.update_config({
+        "min_data_for_nsrt": 0,
+        "max_rejection_sampling_tries": 0,
+        "seed": 1234,
+        "sampler_mlp_classifier_max_itr": 1,
+        "neural_gaus_regressor_max_itr": 1
+    })
     nsrts = learn_nsrts_from_data(dataset, preds, sampler_learner="neural")
     assert len(nsrts) == 2
     for nsrt in nsrts:

--- a/tests/test_nsrt_learning.py
+++ b/tests/test_nsrt_learning.py
@@ -1,6 +1,5 @@
 """Tests for NSRT learning."""
 
-import time
 from gym.spaces import Box
 import numpy as np
 # We need this unused import to prevent cyclic import issues when running

--- a/tests/test_sampler_learning.py
+++ b/tests/test_sampler_learning.py
@@ -82,9 +82,9 @@ def test_create_sampler_data():
 
 def test_learn_samplers_failure():
     """Tests for failure mode of learn_samplers()."""
-    option = ParameterizedOption(
-        "dummy", [], Box(0.1, 1, (1, )), lambda s, m, o, p: Action(p),
-        lambda s, m, o, p: False,
-        lambda s, m, o, p: False)
+    option = ParameterizedOption("dummy", [], Box(0.1, 1, (1, )),
+                                 lambda s, m, o, p: Action(p),
+                                 lambda s, m, o, p: False,
+                                 lambda s, m, o, p: False)
     with pytest.raises(NotImplementedError):  # bad sampler_learner
         learn_samplers([None], None, [(option, [])], "bad sampler learner")

--- a/tests/test_sampler_learning.py
+++ b/tests/test_sampler_learning.py
@@ -1,8 +1,10 @@
 """Tests for sampler learning."""
 
+import pytest
 from gym.spaces import Box
 import numpy as np
-from predicators.src.sampler_learning import _create_sampler_data
+from predicators.src.sampler_learning import _create_sampler_data, \
+    learn_samplers
 from predicators.src.structs import Type, Predicate, State, Action, \
     ParameterizedOption, LiftedAtom, Segment, LowLevelTrajectory
 from predicators.src import utils
@@ -76,3 +78,13 @@ def test_create_sampler_data():
         param_option, datastore_idx)
     assert len(positive_examples) == 1
     assert len(negative_examples) == 0
+
+
+def test_learn_samplers_failure():
+    """Tests for failure mode of learn_samplers()."""
+    option = ParameterizedOption(
+        "dummy", [], Box(0.1, 1, (1, )), lambda s, m, o, p: Action(p),
+        lambda s, m, o, p: False,
+        lambda s, m, o, p: False)
+    with pytest.raises(NotImplementedError):  # bad sampler_learner
+        learn_samplers([None], None, [(option, [])], "bad sampler learner")


### PR DESCRIPTION
Remove some tests which have outlived their usefulness, and generally
decrease hyperparameters for some of the slowest tests.

Before this PR, unit tests took about 200 seconds locally. After this
PR, unit tests take about 60 seconds locally.

PS: when invoking pytest, a useful parameter is `--durations=N`, which
will print out the names+times of the `N` slowest tests. `N = 20` is a
reasonable choice.