### PR TITLE
Saving videos of not-fully-solved plans 

### DIFF
--- a/src/args.py
+++ b/src/args.py
@@ -15,6 +15,7 @@ def create_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--seed", required=True, type=int)
     parser.add_argument("--timeout", default=10, type=float)
     parser.add_argument("--make_videos", action="store_true")
+    parser.add_argument("--make_failed_videos", action="store_true")
     parser.add_argument("--load_approach", action="store_true")
     parser.add_argument("--remake_data", action="store_true")
     parser.add_argument("--experiment_id", default="", type=str)

--- a/src/main.py
+++ b/src/main.py
@@ -150,7 +150,12 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
             if len(e.progress_per_skeleton) > 0:
                 # sort by length of plan
                 best_progress = sorted(e.progress_per_skeleton,
-                                    key=lambda x: len(x[1]))
+                                       key=lambda x: len(x[1]))
+                print("Number of skeletons: ", len(best_progress))
+                # for p in best_progress:
+                #     sk, plan, trajs, fail_msg = p
+                #     print("DEBUG: ")
+                #     print("Plan: ", plan)
                 skeleton, plan, trajectories, fail_message = best_progress[-1]
                 print(f"Task {i+1} / {len(test_tasks)}: Approach failed to "
                       f"solve with error: {e, fail_message}")
@@ -163,7 +168,6 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
                         else:
                             states = traj.states[:-1]
                         for s in states:
-                            print(s)
                             failed_video.extend(env.render(s, task))
                     failed_outfile = f"{utils.get_config_path_str()}__task{i+1}_failed.mp4"
                     utils.save_video(failed_outfile, failed_video)

--- a/src/main.py
+++ b/src/main.py
@@ -151,16 +151,11 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
                 # sort by length of plan
                 best_progress = sorted(e.progress_per_skeleton,
                                        key=lambda x: len(x[1]))
-                print("Number of skeletons: ", len(best_progress))
-                # for p in best_progress:
-                #     sk, plan, trajs, fail_msg = p
-                #     print("DEBUG: ")
-                #     print("Plan: ", plan)
+                # can change this to save a video for each skeleton
                 skeleton, plan, trajectories, fail_message = best_progress[-1]
                 print(f"Task {i+1} / {len(test_tasks)}: Approach failed to "
                       f"solve with error: {e, fail_message}")
                 if CFG.make_failed_videos:
-                    # could also loop through and save a video for each skeleton
                     failed_video: Video = []
                     for j, traj in enumerate(trajectories):
                         if j == len(trajectories) - 1:

--- a/src/main.py
+++ b/src/main.py
@@ -167,10 +167,6 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
                     failed_outfile = f"{utils.get_config_path_str()}__task{i+1}_failed.mp4"
                     utils.save_video(failed_outfile, failed_video)
             continue
-        # except (ApproachTimeout, ApproachFailure) as e:
-        #     print(f"Task {i+1} / {len(test_tasks)}: Approach failed to "
-        #           f"solve with error: {e}")
-        #     continue
         num_found_policy += 1
         try:
             _, video, solved = utils.run_policy_on_task(

--- a/src/main.py
+++ b/src/main.py
@@ -152,14 +152,19 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
             if len(e.progress_per_skeleton) > 0:
                 best_progress = max(e.progress_per_skeleton,
                                     key=lambda x: len(x[1]))
+                skeleton, plan, trajectories = best_progress
                 if CFG.make_failed_videos:
                     # could also loop through and save a video for each skeleton
-                    video: Video = []
-                    for traj in best_progress[2]:
-                        for s in traj.states:
-                            video.extend(env.render(s, task))
-                    outfile = f"{utils.get_config_path_str()}__task{i}_failed.mp4"
-                    utils.save_video(outfile, video)
+                    failed_video: Video = []
+                    for i, traj in enumerate(trajectories):
+                        if i == len(trajectories) - 1:
+                            states = traj.states
+                        else:
+                            states = traj.states[:-1]
+                        for s in states:
+                            failed_video.extend(env.render(s, task))
+                    failed_outfile = f"{utils.get_config_path_str()}__task{i}_failed.mp4"
+                    utils.save_video(failed_outfile, failed_video)
             continue
         # except (ApproachTimeout, ApproachFailure) as e:
         #     print(f"Task {i+1} / {len(test_tasks)}: Approach failed to "

--- a/src/option_model.py
+++ b/src/option_model.py
@@ -43,12 +43,16 @@ class _DefaultOptionModel(_OptionModelBase):
     """A default option model that just runs options through the simulator to
     figure out the next state."""
 
-    def get_next_state(self, state: State, option: _Option) -> State:
+    def get_next_traj(self, state: State, option: _Option) -> State:
         traj = utils.option_to_trajectory(
             state,
             self._simulator,
             option,
             max_num_steps=CFG.max_num_steps_option_rollout)
+        return traj
+
+    def get_next_state(self, state: State, option: _Option) -> State:
+        traj = self.get_next_traj(state, option)
         return traj.states[-1]
 
 

--- a/src/planning.py
+++ b/src/planning.py
@@ -102,7 +102,7 @@ def sesame_plan(
                         metrics["plan_length"] = len(plan)
                         return plan, metrics
                 except LowLevelSearchFailure as f:
-                    progress_per_skeleton.append((skeleton, f.furthest_plan, f.furthest_traj))
+                    progress_per_skeleton.append((skeleton, f.furthest_plan, f.furthest_traj, f))
                     # print("Length of furthest plan: ", len(t.furthest_plan))
                     # raise ApproachTimeout()
         except _DiscoveredFailureException as e:
@@ -427,6 +427,6 @@ class ApproachFailureWithProgress(Exception):
     of (skeleton, furthest_plan_reached_in_this_skeleton, corresponding_state-
     action-trajectory_of_this_furthest_plan) tuples. The intention of this is to
     provide debugging data to the calling function."""
-    def __init__(self, message: str, progress_per_skeleton: Tuple[Tuple[List[_GroundNSRT], List[Collection[GroundAtom]]], List[_Option], List[LowLevelTrajectory]]):
+    def __init__(self, message: str, progress_per_skeleton: Tuple[Tuple[List[_GroundNSRT], List[Collection[GroundAtom]]], List[_Option], List[LowLevelTrajectory], str]):
         super().__init__(message)
         self.progress_per_skeleton = progress_per_skeleton

--- a/src/planning.py
+++ b/src/planning.py
@@ -103,8 +103,6 @@ def sesame_plan(
                         return plan, metrics
                 except LowLevelSearchFailure as f:
                     progress_per_skeleton.append((skeleton, f.furthest_plan, f.furthest_traj, f))
-                    # print("Length of furthest plan: ", len(t.furthest_plan))
-                    # raise ApproachTimeout()
         except _DiscoveredFailureException as e:
             metrics["num_failures_discovered"] += 1
             new_predicates, ground_nsrts = _update_nsrts_with_failure(
@@ -268,7 +266,6 @@ def _run_low_level_search(task: Task, option_model: _OptionModelBase,
             furthest_traj = max(current_traj, furthest_traj, key=len)
             raise LowLevelSearchFailure("Low-level search timeout!",
                                         furthest_plan, furthest_traj)
-            # raise ApproachTimeout("Planning timed out in backtracking!")
         assert num_tries[cur_idx] < CFG.max_samples_per_step
         # Good debug point #2: if you have a skeleton that you think is
         # reasonable, but sampling isn't working, print num_tries here to
@@ -284,7 +281,6 @@ def _run_low_level_search(task: Task, option_model: _OptionModelBase,
             try:
                 next_traj = option_model.get_next_traj(state, option)
                 next_state = next_traj.states[-1]
-                # next_state = option_model.get_next_state(state, option)
                 discovered_failures[cur_idx] = None  # no failure occurred
             except EnvironmentFailure as e:
                 can_continue_on = False

--- a/src/planning.py
+++ b/src/planning.py
@@ -273,9 +273,6 @@ def _run_low_level_search(task: Task, option_model: _OptionModelBase,
         # Good debug point #2: if you have a skeleton that you think is
         # reasonable, but sampling isn't working, print num_tries here to
         # see at what step the backtracking search is getting stuck.
-        print("num_tries: ", num_tries)
-        print("len furthest_plan: ", len(furthest_plan))
-        print("len plan: ", len([p for p in plan if p is not DummyOption]))
         num_tries[cur_idx] += 1
         state = traj[cur_idx]
         nsrt = skeleton[cur_idx]
@@ -336,7 +333,6 @@ def _run_low_level_search(task: Task, option_model: _OptionModelBase,
             # Go back to re-do the step we just did. If necessary, backtrack.
             cur_idx -= 1
             assert cur_idx >= 0
-
 
             while num_tries[cur_idx] == CFG.max_samples_per_step:
                 num_tries[cur_idx] = 0


### PR DESCRIPTION
Adds a flag that enables saving videos of plans that did not solve the goal to help debug planning failures. For each NSRT skeleton, it saves the refined plan that made the most progress towards the goal as measured by number of options in the plan (not number of goal conditions fulfilled– maybe we should change it to this.). 

Still need to write tests. 