### PR TITLE
add option for suspicious multistep effects score in expected_nodes score function

### DIFF
--- a/analysis/grammar_search_analysis.py
+++ b/analysis/grammar_search_analysis.py
@@ -8,7 +8,7 @@ import os
 from typing import Dict, DefaultDict, Set, List, Tuple, Sequence
 import pandas as pd
 from predicators.src.datasets import create_dataset
-from predicators.src.envs import create_env, BaseEnv
+from predicators.src.envs import create_env, BaseEnv, CoverEnv
 from predicators.src.approaches import create_approach
 from predicators.src.approaches.grammar_search_invention_approach import \
     _create_score_function, _ForallClassifier, _SingleAttributeCompareClassifier
@@ -34,14 +34,7 @@ def _run_proxy_analysis(env_names: List[str], score_function_names: List[str],
             for block in state:
                 if block.type.name != "block":
                     continue
-                block_pose = state.get(block, "pose")
-                block_width = state.get(block, "width")
-                target_pose = state.get(target, "pose")
-                target_width = state.get(target, "width")
-                if (block_pose-block_width/2 <=
-                    target_pose-target_width/2) and \
-                    (block_pose+block_width/2 >=
-                     target_pose+target_width/2):
+                if CoverEnv._Covers_holds(state, [block, target]):  # pylint:disable=protected-access
                     return False
             return True
 

--- a/analysis/grammar_search_analysis.py
+++ b/analysis/grammar_search_analysis.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from operator import le
 import glob
 import os
-from typing import Dict, DefaultDict, Set, List, Tuple
+from typing import Dict, DefaultDict, Set, List, Tuple, Sequence
 import pandas as pd
 from predicators.src.datasets import create_dataset
 from predicators.src.envs import create_env, BaseEnv
@@ -15,7 +15,7 @@ from predicators.src.approaches.grammar_search_invention_approach import \
 from predicators.src.ground_truth_nsrts import _get_predicates_by_names
 from predicators.src.main import _run_testing
 from predicators.src import utils
-from predicators.src.structs import Predicate, Dataset
+from predicators.src.structs import Predicate, Dataset, State, Object
 from predicators.src.settings import CFG
 
 
@@ -29,7 +29,7 @@ def _run_proxy_analysis(env_names: List[str], score_function_names: List[str],
         targ_type = Covers.types[1]
         NotHandEmpty = HandEmpty.get_negation()
 
-        def Clear_classifier(state, objects):
+        def _Clear_holds(state: State, objects: Sequence[Object]) -> bool:
             target, = objects
             for block in state:
                 if block.type.name != "block":
@@ -45,7 +45,7 @@ def _run_proxy_analysis(env_names: List[str], score_function_names: List[str],
                     return False
             return True
 
-        Clear = Predicate("Clear", [targ_type], Clear_classifier)
+        Clear = Predicate("Clear", [targ_type], _Clear_holds)
         covers_pred_sets: List[Set[Predicate]] = [
             set(),
             {HandEmpty},

--- a/src/approaches/grammar_search_invention_approach.py
+++ b/src/approaches/grammar_search_invention_approach.py
@@ -827,7 +827,7 @@ class _ExpectedNodesScoreFunction(_OperatorLearningBasedScoreFunction):
     @staticmethod
     def _get_refinement_prob(
             demo_atoms_sequence: Sequence[Set[GroundAtom]],
-            plan_atoms_sequence: Sequence[Collection[GroundAtom]],
+            plan_atoms_sequence: Sequence[Set[GroundAtom]],
             demo_multistep_effects: Set[FrozenSet[GroundAtom]]) -> float:
         """Estimate the probability that plan_atoms_sequence is refinable using
         the demonstration demo_atoms_sequence."""
@@ -860,7 +860,7 @@ class _ExpectedNodesScoreFunction(_OperatorLearningBasedScoreFunction):
 
     @staticmethod
     def _compute_demo_multistep_effects(
-            pruned_atom_data: List[GroundAtomTrajectory]
+        pruned_atom_data: List[GroundAtomTrajectory]
     ) -> Set[FrozenSet[GroundAtom]]:
         seen_demos = 0
         demo_multistep_effects = set()

--- a/src/approaches/grammar_search_invention_approach.py
+++ b/src/approaches/grammar_search_invention_approach.py
@@ -826,9 +826,11 @@ class _ExpectedNodesScoreFunction(_OperatorLearningBasedScoreFunction):
 
     @staticmethod
     def _get_refinement_prob(
-            demo_atoms_sequence: Sequence[Set[GroundAtom]],
-            plan_atoms_sequence: Sequence[Set[GroundAtom]],
-            demo_multistep_effects: Set[FrozenSet[GroundAtom]]) -> float:
+        demo_atoms_sequence: Sequence[Set[GroundAtom]],
+        plan_atoms_sequence: Sequence[Set[GroundAtom]],
+        demo_multistep_effects: Set[Tuple[FrozenSet[GroundAtom],
+                                          FrozenSet[GroundAtom]]]
+    ) -> float:
         """Estimate the probability that plan_atoms_sequence is refinable using
         the demonstration demo_atoms_sequence."""
         # Make a soft assumption that the demonstrations are optimal,
@@ -848,13 +850,11 @@ class _ExpectedNodesScoreFunction(_OperatorLearningBasedScoreFunction):
                     plan_del_eff = frozenset(atoms_i - atoms_j)
                     if not any(
                             utils.unify_preconds_effects_options(
-                                frozenset(), frozenset(),
-                                plan_add_eff, demo_add_eff,
-                                plan_del_eff, demo_del_eff,
+                                frozenset(), frozenset(), plan_add_eff,
+                                demo_add_eff, plan_del_eff, demo_del_eff,
                                 DummyOption.parent, DummyOption.parent,
-                                tuple(), tuple())[0]
-                            for demo_add_eff, demo_del_eff
-                            in demo_multistep_effects):
+                                tuple(), tuple())[0] for demo_add_eff,
+                            demo_del_eff in demo_multistep_effects):
                         num_suspicious_eff += 1
             p = CFG.grammar_search_expected_nodes_optimal_demo_prob
             # Add the number of suspicious effects to the exponent.

--- a/src/approaches/grammar_search_invention_approach.py
+++ b/src/approaches/grammar_search_invention_approach.py
@@ -742,9 +742,10 @@ class _ExpectedNodesScoreFunction(_OperatorLearningBasedScoreFunction):
     than the demos, then the likelihood of the predicates/operators goes down
     as that difference gets larger.
 
-    We also anticipate incorporating "suspicious" transitions as another way
-    to estimate the probability that a skeleton is refinable, but this is not
-    yet implemented.
+    We optionally also include into this likelihood the number of
+    "suspicious" multistep effects in the atoms sequence induced by the
+    skeleton. "Suspicious" means that a particular set of multistep
+    effects was never seen in the demonstrations.
     """
 
     def _evaluate_with_operators(self,
@@ -755,6 +756,11 @@ class _ExpectedNodesScoreFunction(_OperatorLearningBasedScoreFunction):
                                  option_specs: List[OptionSpec]) -> float:
         del segments  # unused
         score = 0.0
+        demo_multistep_effects = set()
+        if CFG.grammar_search_expected_nodes_include_suspicious_score:
+            # Go through the demos in advance and compute the multistep effects.
+            demo_multistep_effects = self._compute_demo_multistep_effects(
+                pruned_atom_data)
         seen_demos = 0
         for traj, atoms_sequence in pruned_atom_data:
             if seen_demos >= CFG.grammar_search_max_demos:
@@ -788,7 +794,8 @@ class _ExpectedNodesScoreFunction(_OperatorLearningBasedScoreFunction):
                     assert goal.issubset(plan_atoms_sequence[-1])
                     # Estimate the probability that this skeleton is refinable.
                     refinement_prob = self._get_refinement_prob(
-                        atoms_sequence, plan_atoms_sequence)
+                        atoms_sequence, plan_atoms_sequence,
+                        demo_multistep_effects)
                     # Get the number of nodes that have been created so far.
                     num_nodes = metrics["num_nodes_created"]
                     # This contribution to the expected number of nodes is for
@@ -820,14 +827,56 @@ class _ExpectedNodesScoreFunction(_OperatorLearningBasedScoreFunction):
     @staticmethod
     def _get_refinement_prob(
             demo_atoms_sequence: Sequence[Set[GroundAtom]],
-            plan_atoms_sequence: Sequence[Collection[GroundAtom]]) -> float:
+            plan_atoms_sequence: Sequence[Collection[GroundAtom]],
+            demo_multistep_effects: Set[FrozenSet[GroundAtom]]) -> float:
         """Estimate the probability that plan_atoms_sequence is refinable using
         the demonstration demo_atoms_sequence."""
-        # Make a soft assumption that the demonstrations are optimal.
+        # Make a soft assumption that the demonstrations are optimal,
+        # using a geometric distribution.
         demo_len = len(demo_atoms_sequence)
         plan_len = len(plan_atoms_sequence)
+        # The exponent is the difference in plan lengths.
+        exponent = abs(demo_len - plan_len)
+        if CFG.grammar_search_expected_nodes_include_suspicious_score:
+            # Handle suspicious effect scoring via unification.
+            num_suspicious_eff = 0
+            for i in range(len(plan_atoms_sequence) - 1):
+                for j in range(i + 1, len(plan_atoms_sequence)):
+                    atoms_i = plan_atoms_sequence[i]
+                    atoms_j = plan_atoms_sequence[j]
+                    for plan_eff in [
+                            frozenset(atoms_i - atoms_j),
+                            frozenset(atoms_j - atoms_i)
+                    ]:
+                        if not any(
+                                utils.unify(demo_eff, plan_eff)[0]
+                                for demo_eff in demo_multistep_effects):
+                            num_suspicious_eff += 1
+            p = CFG.grammar_search_expected_nodes_optimal_demo_prob
+            # Add the number of suspicious effects to the exponent.
+            exponent += num_suspicious_eff
         p = CFG.grammar_search_expected_nodes_optimal_demo_prob
-        return p * (1 - p)**abs(demo_len - plan_len)
+        return p * (1 - p)**exponent
+
+    @staticmethod
+    def _compute_demo_multistep_effects(
+            pruned_atom_data: List[GroundAtomTrajectory]
+    ) -> Set[FrozenSet[GroundAtom]]:
+        seen_demos = 0
+        demo_multistep_effects = set()
+        for traj, atoms_sequence in pruned_atom_data:
+            if seen_demos >= CFG.grammar_search_max_demos:
+                break
+            if not traj.is_demo:
+                continue
+            seen_demos += 1
+            for i in range(len(atoms_sequence) - 1):
+                for j in range(i + 1, len(atoms_sequence)):
+                    atoms_i = atoms_sequence[i]
+                    atoms_j = atoms_sequence[j]
+                    demo_multistep_effects.add(frozenset(atoms_i - atoms_j))
+                    demo_multistep_effects.add(frozenset(atoms_j - atoms_i))
+        return demo_multistep_effects
 
 
 @dataclass(frozen=True, eq=False, repr=False)
@@ -1036,13 +1085,14 @@ class _HeuristicCountBasedScoreFunction(_HeuristicBasedScoreFunction):
                 # some state in the demos, and thus is not suspicious.
                 if is_demo and successor == frozenset(next_atoms):
                     continue
-                if self._is_suspicious(successor, demo_atom_sets):
-                    score += CFG.grammar_search_suspicious_penalty
+                if self._state_is_suspicious(successor, demo_atom_sets):
+                    score += CFG.grammar_search_suspicious_state_penalty
         return score
 
     @staticmethod
-    def _is_suspicious(successor: FrozenSet[GroundAtom],
-                       demo_atom_sets: Set[FrozenSet[GroundAtom]]) -> bool:
+    def _state_is_suspicious(
+            successor: FrozenSet[GroundAtom],
+            demo_atom_sets: Set[FrozenSet[GroundAtom]]) -> bool:
         for demo_atoms in demo_atom_sets:
             suc, _ = utils.unify(successor, demo_atoms)
             if suc:

--- a/src/planning.py
+++ b/src/planning.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 import heapq as hq
 from itertools import islice
 import time
-from typing import Collection, List, Set, Optional, Tuple, Iterator, Sequence
+from typing import List, Set, Optional, Tuple, Iterator, Sequence
 from dataclasses import dataclass
 import numpy as np
 from predicators.src.approaches import ApproachFailure, ApproachTimeout
@@ -27,9 +27,9 @@ _NOT_CAUSES_FAILURE = "NotCausesFailure"
 @dataclass(repr=False, eq=False)
 class _Node:
     """A node for the search over skeletons."""
-    atoms: Collection[GroundAtom]
+    atoms: Set[GroundAtom]
     skeleton: List[_GroundNSRT]
-    atoms_sequence: List[Collection[GroundAtom]]  # expected state sequence
+    atoms_sequence: List[Set[GroundAtom]]  # expected state sequence
     parent: Optional[_Node]
 
 
@@ -145,7 +145,7 @@ def task_plan(
     heuristic: _TaskPlanningHeuristic,
     seed: int,
     timeout: float,
-) -> Iterator[Tuple[List[_GroundNSRT], List[Collection[GroundAtom]], Metrics]]:
+) -> Iterator[Tuple[List[_GroundNSRT], List[Set[GroundAtom]], Metrics]]:
     """Run only the task planning portion of SeSamE. A* search is run, and
     skeletons that achieve the goal symbolically are yielded. Specifically,
     yields a tuple of (skeleton, atoms sequence, metrics dictionary).
@@ -179,7 +179,7 @@ def _skeleton_generator(
     task: Task, ground_nsrts: List[_GroundNSRT], init_atoms: Set[GroundAtom],
     heuristic: _TaskPlanningHeuristic, seed: int, timeout: float,
     metrics: Metrics
-) -> Iterator[Tuple[List[_GroundNSRT], List[Collection[GroundAtom]]]]:
+) -> Iterator[Tuple[List[_GroundNSRT], List[Set[GroundAtom]]]]:
     """A* search over skeletons (sequences of ground NSRTs).
     Iterates over pairs of (skeleton, atoms sequence).
     """
@@ -232,8 +232,7 @@ def _skeleton_generator(
 
 def _run_low_level_search(task: Task, option_model: _OptionModelBase,
                           skeleton: List[_GroundNSRT],
-                          atoms_sequence: List[Collection[GroundAtom]],
-                          seed: int,
+                          atoms_sequence: List[Set[GroundAtom]], seed: int,
                           timeout: float) -> Optional[List[_Option]]:
     """Backtracking search over continuous values."""
     start_time = time.time()

--- a/src/settings.py
+++ b/src/settings.py
@@ -153,10 +153,11 @@ class GlobalSettings:
     grammar_search_gbfs_num_evals = 1000
     grammar_search_off_demo_count_penalty = 1.0
     grammar_search_on_demo_count_penalty = 10.0
-    grammar_search_suspicious_penalty = 10.0
+    grammar_search_suspicious_state_penalty = 10.0
     grammar_search_expected_nodes_upper_bound = 1e5
     grammar_search_expected_nodes_optimal_demo_prob = 1 - 1e-5
     grammar_search_expected_nodes_backtracking_cost = 1e3
+    grammar_search_expected_nodes_include_suspicious_score = False
 
     @staticmethod
     def get_arg_specific_settings(args: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -775,6 +775,7 @@ def test_expected_nodes_score_function():
             "num_train_tasks": num_train_tasks,
             "min_data_for_nsrt": 0,
             "cover_initial_holding_prob": 0.0,
+            "grammar_search_expected_nodes_include_suspicious_score": True,
         })
         env = CoverEnv()
         name_to_pred = {p.name: p for p in env.predicates}
@@ -806,4 +807,5 @@ def test_expected_nodes_score_function():
         "min_data_for_nsrt": 3,
         "grammar_search_max_demos": max_num_demos,
         "num_train_tasks": 15,
+        "grammar_search_expected_nodes_include_suspicious_score": False,
     })

--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -765,17 +765,24 @@ def test_expected_nodes_score_function():
     # Cover cases where the number of training tasks is less than or greater
     # than the max number of demos.
     max_num_demos = 5
+    utils.update_config({
+        "offline_data_method":
+        "demo+replay",
+        "seed":
+        123,
+        "grammar_search_max_demos":
+        max_num_demos,
+        "task_planning_heuristic":
+        "lmcut",
+        "cover_initial_holding_prob":
+        0.0,
+        "grammar_search_expected_nodes_include_suspicious_score":
+        True,
+    })
     for num_train_tasks in [2, 15]:
         utils.update_config({
-            "env": "cover",
-            "offline_data_method": "demo+replay",
-            "seed": 0,
-            "grammar_search_max_demos": max_num_demos,
-            "task_planning_heuristic": "lmcut",
             "num_train_tasks": num_train_tasks,
             "min_data_for_nsrt": 0,
-            "cover_initial_holding_prob": 0.0,
-            "grammar_search_expected_nodes_include_suspicious_score": True,
         })
         env = CoverEnv()
         name_to_pred = {p.name: p for p in env.predicates}
@@ -802,10 +809,12 @@ def test_expected_nodes_score_function():
         })
         all_included_s = score_function.evaluate({Holding, HandEmpty})
         assert all_included_s >= ub * min(num_train_tasks, max_num_demos)
-    # Revert to default to avoid interfering with other tests.
+    # Revert, to avoid interfering with other tests.
     utils.update_config({
-        "min_data_for_nsrt": 3,
-        "grammar_search_max_demos": max_num_demos,
-        "num_train_tasks": 15,
-        "grammar_search_expected_nodes_include_suspicious_score": False,
+        "min_data_for_nsrt":
+        3,
+        "num_train_tasks":
+        15,
+        "grammar_search_expected_nodes_include_suspicious_score":
+        False,
     })


### PR DESCRIPTION
It's a bit hard to test this right now, but I was able to see some improvement from it. Specifically, what I did was run the analysis script on Cover with the following change:
`expected_planning_time += p * num_nodes` -> `expected_planning_time += p`
I made this change because in our current envs, the number of nodes is helping the score function a lot, making suspicious scores unnecessary.

Results without suspicious scoring:
```
Evaluating predicates: frozenset(), with total cost 0
	Total score: 534026.0908040795 computed in 0.072 seconds
Evaluating predicates: frozenset({HandEmpty}), with total cost 1.0
	Total score: 534026.0906951863 computed in 0.114 seconds
Evaluating predicates: frozenset({Holding}), with total cost 1.0
	Total score: 13071.029276505998 computed in 0.139 seconds
*** Evaluating predicates: frozenset({HandEmpty, Holding}), with total cost 2.0
	Total score: 82.17972948588978 computed in 0.160 seconds
Evaluating predicates: frozenset({HandEmpty, Clear, Holding}), with total cost 3.0
	Total score: 82.17985818755962 computed in 0.135 seconds ***
Evaluating predicates: frozenset({NOT-HandEmpty}), with total cost 1.0
	Total score: 13071.159739185763 computed in 0.127 seconds
Evaluating predicates: frozenset({NOT-HandEmpty, HandEmpty}), with total cost 2.0
	Total score: 13071.159947090002 computed in 0.139 seconds
```
In particular, note that there is no improvement from adding in the Clear predicate to {HandEmpty, Holding}, because you get plans of the same length as the demos even without Clear (you just might stupidly place what you're holding onto a target that needs to be kept free for later).

Results with suspicious scoring:
```
Evaluating predicates: frozenset(), with total cost 0
	Total score: 2316024.9189511305 computed in 0.089 seconds
Evaluating predicates: frozenset({HandEmpty}), with total cost 1.0
	Total score: 2909930.812771448 computed in 0.152 seconds
Evaluating predicates: frozenset({Holding}), with total cost 1.0
	Total score: 722045.9403480866 computed in 0.218 seconds
*** Evaluating predicates: frozenset({HandEmpty, Holding}), with total cost 2.0
	Total score: 6094.929471400891 computed in 0.289 seconds
Evaluating predicates: frozenset({HandEmpty, Clear, Holding}), with total cost 3.0
	Total score: 95.049599498305 computed in 0.269 seconds ***
Evaluating predicates: frozenset({NOT-HandEmpty}), with total cost 1.0
	Total score: 13084.029559696703 computed in 0.168 seconds
Evaluating predicates: frozenset({NOT-HandEmpty, HandEmpty}), with total cost 2.0
	Total score: 13084.029559700068 computed in 0.218 seconds
```
Here, we can see that almost nothing looks suspicious (for the first refinable skeleton at least) under the optimal predicate set, but transitions that make two blocks be on the same target look suspicious under the predicate set that's missing Clear.