### PR TITLE
don't give approaches the simulator

### DIFF
--- a/analysis/grammar_search_analysis.py
+++ b/analysis/grammar_search_analysis.py
@@ -207,9 +207,8 @@ def _run_proxy_analysis_for_predicates(
     # Learn NSRTs and plan.
     if run_planning:
         utils.flush_cache()
-        approach = create_approach("nsrt_learning", env.simulate,
-                                   all_predicates, env.options, env.types,
-                                   env.action_space)
+        approach = create_approach("nsrt_learning", all_predicates,
+                                   env.options, env.types, env.action_space)
         approach.learn_from_offline_dataset(dataset)
         approach.seed(CFG.seed)
         planning_result = _run_testing(env, approach)

--- a/src/approaches/__init__.py
+++ b/src/approaches/__init__.py
@@ -36,32 +36,30 @@ __all__ = [
 ]
 
 
-def create_approach(name: str, simulator: Callable[[State, Action], State],
-                    initial_predicates: Set[Predicate],
+def create_approach(name: str, initial_predicates: Set[Predicate],
                     initial_options: Set[ParameterizedOption],
                     types: Set[Type], action_space: Box) -> BaseApproach:
     """Create an approach given its name."""
     if name == "oracle":
-        return OracleApproach(simulator, initial_predicates, initial_options,
-                              types, action_space)
+        return OracleApproach(initial_predicates, initial_options, types,
+                              action_space)
     if name == "random_actions":
-        return RandomActionsApproach(simulator, initial_predicates,
-                                     initial_options, types, action_space)
+        return RandomActionsApproach(initial_predicates, initial_options,
+                                     types, action_space)
     if name == "random_options":
-        return RandomOptionsApproach(simulator, initial_predicates,
-                                     initial_options, types, action_space)
+        return RandomOptionsApproach(initial_predicates, initial_options,
+                                     types, action_space)
     if name == "nsrt_learning":
-        return NSRTLearningApproach(simulator, initial_predicates,
-                                    initial_options, types, action_space)
+        return NSRTLearningApproach(initial_predicates, initial_options, types,
+                                    action_space)
     if name == "interactive_learning":
-        return InteractiveLearningApproach(simulator, initial_predicates,
-                                           initial_options, types,
-                                           action_space)
+        return InteractiveLearningApproach(initial_predicates, initial_options,
+                                           types, action_space)
     if name == "iterative_invention":
-        return IterativeInventionApproach(simulator, initial_predicates,
-                                          initial_options, types, action_space)
+        return IterativeInventionApproach(initial_predicates, initial_options,
+                                          types, action_space)
     if name == "grammar_search_invention":
-        return GrammarSearchInventionApproach(simulator, initial_predicates,
+        return GrammarSearchInventionApproach(initial_predicates,
                                               initial_options, types,
                                               action_space)
     raise NotImplementedError(f"Unknown approach: {name}")

--- a/src/approaches/base_approach.py
+++ b/src/approaches/base_approach.py
@@ -13,13 +13,11 @@ from predicators.src.settings import CFG
 class BaseApproach(abc.ABC):
     """Base approach."""
 
-    def __init__(self, simulator: Callable[[State, Action], State],
-                 initial_predicates: Set[Predicate],
+    def __init__(self, initial_predicates: Set[Predicate],
                  initial_options: Set[ParameterizedOption], types: Set[Type],
                  action_space: Box) -> None:
         """All approaches are initialized with only the necessary information
         about the environment."""
-        self._simulator = simulator
         self._initial_predicates = initial_predicates
         self._initial_options = initial_options
         self._types = types

--- a/src/approaches/grammar_search_invention_approach.py
+++ b/src/approaches/grammar_search_invention_approach.py
@@ -20,7 +20,7 @@ from predicators.src.nsrt_learning import segment_trajectory, \
     learn_strips_operators
 from predicators.src.planning import task_plan, task_plan_grounding
 from predicators.src.structs import State, Predicate, ParameterizedOption, \
-    Type, Action, Dataset, Object, GroundAtomTrajectory, STRIPSOperator, \
+    Type, Dataset, Object, GroundAtomTrajectory, STRIPSOperator, \
     OptionSpec, Segment, GroundAtom, _GroundSTRIPSOperator, DummyOption
 from predicators.src.settings import CFG
 
@@ -1254,11 +1254,10 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
     """An approach that invents predicates by searching over candidate sets,
     with the candidates proposed from a grammar."""
 
-    def __init__(self, simulator: Callable[[State, Action], State],
-                 initial_predicates: Set[Predicate],
+    def __init__(self, initial_predicates: Set[Predicate],
                  initial_options: Set[ParameterizedOption], types: Set[Type],
                  action_space: Box) -> None:
-        super().__init__(simulator, initial_predicates, initial_options, types,
+        super().__init__(initial_predicates, initial_options, types,
                          action_space)
         self._learned_predicates: Set[Predicate] = set()
         self._num_inventions = 0

--- a/src/approaches/iterative_invention_approach.py
+++ b/src/approaches/iterative_invention_approach.py
@@ -1,14 +1,13 @@
 """An approach that iteratively invents predicates."""
 
 from collections import defaultdict
-from typing import Set, Callable, List, Optional, Dict, Sequence, \
-    Any
+from typing import Set, List, Optional, Dict, Sequence, Any
 import numpy as np
 from gym.spaces import Box
 from predicators.src import utils
 from predicators.src.approaches import NSRTLearningApproach
-from predicators.src.structs import State, Predicate, ParameterizedOption, \
-    Type, Action, Dataset, Array, STRIPSOperator, Datastore, Segment, \
+from predicators.src.structs import Predicate, ParameterizedOption, \
+    Type, Dataset, Array, STRIPSOperator, Datastore, Segment, \
     LiftedAtom, GroundAtom, OptionSpec
 from predicators.src.torch_models import LearnedPredicateClassifier, \
     MLPClassifier
@@ -20,11 +19,10 @@ from predicators.src.settings import CFG
 class IterativeInventionApproach(NSRTLearningApproach):
     """An approach that iteratively invents predicates."""
 
-    def __init__(self, simulator: Callable[[State, Action], State],
-                 initial_predicates: Set[Predicate],
+    def __init__(self, initial_predicates: Set[Predicate],
                  initial_options: Set[ParameterizedOption], types: Set[Type],
                  action_space: Box) -> None:
-        super().__init__(simulator, initial_predicates, initial_options, types,
+        super().__init__(initial_predicates, initial_options, types,
                          action_space)
         self._learned_predicates: Set[Predicate] = set()
         self._num_inventions = 0

--- a/src/approaches/nsrt_learning_approach.py
+++ b/src/approaches/nsrt_learning_approach.py
@@ -4,12 +4,12 @@ In contrast to other approaches, this approach does not attempt to learn
 new predicates or options.
 """
 
-from typing import Callable, Set
+from typing import Set
 import dill as pkl
 from gym.spaces import Box
 from predicators.src.approaches import TAMPApproach
 from predicators.src.structs import Dataset, NSRT, ParameterizedOption, \
-    State, Action, Predicate, Type
+    Predicate, Type
 from predicators.src.nsrt_learning import learn_nsrts_from_data
 from predicators.src.settings import CFG
 from predicators.src import utils
@@ -18,11 +18,10 @@ from predicators.src import utils
 class NSRTLearningApproach(TAMPApproach):
     """A TAMP approach that learns NSRTs."""
 
-    def __init__(self, simulator: Callable[[State, Action], State],
-                 initial_predicates: Set[Predicate],
+    def __init__(self, initial_predicates: Set[Predicate],
                  initial_options: Set[ParameterizedOption], types: Set[Type],
                  action_space: Box) -> None:
-        super().__init__(simulator, initial_predicates, initial_options, types,
+        super().__init__(initial_predicates, initial_options, types,
                          action_space)
         self._nsrts: Set[NSRT] = set()
         self._dataset: Dataset = []

--- a/src/approaches/tamp_approach.py
+++ b/src/approaches/tamp_approach.py
@@ -19,14 +19,12 @@ from predicators.src import utils
 class TAMPApproach(BaseApproach):
     """TAMP approach."""
 
-    def __init__(self, simulator: Callable[[State, Action], State],
-                 initial_predicates: Set[Predicate],
+    def __init__(self, initial_predicates: Set[Predicate],
                  initial_options: Set[ParameterizedOption], types: Set[Type],
                  action_space: Box) -> None:
-        super().__init__(simulator, initial_predicates, initial_options, types,
+        super().__init__(initial_predicates, initial_options, types,
                          action_space)
-        self._option_model = create_option_model(CFG.option_model_name,
-                                                 self._simulator)
+        self._option_model = create_option_model(CFG.option_model_name)
         self._num_calls = 0
 
     def _solve(self, task: Task, timeout: int) -> Callable[[State], Action]:

--- a/src/datasets/demo_only.py
+++ b/src/datasets/demo_only.py
@@ -10,8 +10,8 @@ from predicators.src import utils
 
 def create_demo_data(env: BaseEnv, train_tasks: List[Task]) -> Dataset:
     """Create offline datasets by collecting demos."""
-    oracle_approach = create_approach("oracle", env.simulate, env.predicates,
-                                      env.options, env.types, env.action_space)
+    oracle_approach = create_approach("oracle", env.predicates, env.options,
+                                      env.types, env.action_space)
     dataset = []
     for task in train_tasks:
         policy = oracle_approach.solve(

--- a/src/datasets/demo_replay.py
+++ b/src/datasets/demo_replay.py
@@ -23,9 +23,9 @@ def create_demo_replay_data(env: BaseEnv,
     """
     if nonoptimal_only:
         # Oracle is used to check if replays are optimal.
-        oracle_approach = create_approach("oracle", env.simulate,
-                                          env.predicates, env.options,
-                                          env.types, env.action_space)
+        oracle_approach = create_approach("oracle", env.predicates,
+                                          env.options, env.types,
+                                          env.action_space)
     demo_dataset = create_demo_data(env, train_tasks)
     # We will sample from states uniformly at random.
     # The reason for doing it this way, rather than combining

--- a/src/main.py
+++ b/src/main.py
@@ -93,8 +93,8 @@ def main() -> None:
                 "Can't exclude a goal predicate!"
     else:
         preds = env.predicates
-    approach = create_approach(CFG.approach, env.simulate, preds, env.options,
-                               env.types, env.action_space)
+    approach = create_approach(CFG.approach, preds, env.options, env.types,
+                               env.action_space)
     # If approach is learning-based, get training datasets and do learning,
     # testing after each learning call. Otherwise, just do testing.
     if approach.is_learning_based:

--- a/src/settings.py
+++ b/src/settings.py
@@ -62,7 +62,6 @@ class GlobalSettings:
     random_options_max_tries = 100
 
     # SeSamE parameters
-    option_model_name = "default"
     max_num_steps_option_rollout = 1000
     max_skeletons_optimized = 8  # if 1, can only solve downward refinable tasks
     max_samples_per_step = 10  # max effort on sampling a single skeleton
@@ -192,6 +191,14 @@ class GlobalSettings:
                     # For the repeated_nextto environment, too many
                     # replays makes learning slow.
                     "repeated_nextto": 50,
+                })[args.get("env", "")],
+
+            # The name of the option model used by the agent.
+            option_model_name=defaultdict(
+                lambda: "oracle",
+                {
+                    # For the BEHAVIOR environment, use a special option model.
+                    "behavior": "behavior_oracle",
                 })[args.get("env", "")],
         )
 

--- a/tests/approaches/test_base_approach.py
+++ b/tests/approaches/test_base_approach.py
@@ -62,8 +62,7 @@ def test_base_approach():
                             _initiable=None,
                             _terminal=None)
     }
-    approach = _DummyApproach(_simulator, predicates, options, types,
-                              action_space)
+    approach = _DummyApproach(predicates, options, types, action_space)
     assert not approach.is_learning_based
     assert approach.learn_from_offline_dataset([]) is None
     goal = {pred1([cup, plate1])}
@@ -89,9 +88,9 @@ def test_create_approach():
             "seed": 123,
             "excluded_predicates": ""
         })
-        approach = create_approach(name, env.simulate, env.predicates,
-                                   env.options, env.types, env.action_space)
+        approach = create_approach(name, env.predicates, env.options,
+                                   env.types, env.action_space)
         assert isinstance(approach, BaseApproach)
     with pytest.raises(NotImplementedError):
-        create_approach("Not a real approach", env.simulate, env.predicates,
-                        env.options, env.types, env.action_space)
+        create_approach("Not a real approach", env.predicates, env.options,
+                        env.types, env.action_space)

--- a/tests/approaches/test_interactive_approach.py
+++ b/tests/approaches/test_interactive_approach.py
@@ -84,9 +84,8 @@ def test_interactive_learning_approach():
         "num_test_tasks": 5,
     })
     env = CoverEnv()
-    approach = _DummyInteractiveLearningApproach(env.simulate, env.predicates,
-                                                 env.options, env.types,
-                                                 env.action_space)
+    approach = _DummyInteractiveLearningApproach(env.predicates, env.options,
+                                                 env.types, env.action_space)
     train_tasks = env.get_train_tasks()
     dataset = create_dataset(env, train_tasks)
     assert approach.is_learning_based
@@ -124,9 +123,8 @@ def test_interactive_learning_approach_no_ground_atoms():
         "num_test_tasks": 5,
     })
     env = CoverEnv()
-    approach = _DummyInteractiveLearningApproach(env.simulate, env.predicates,
-                                                 env.options, env.types,
-                                                 env.action_space)
+    approach = _DummyInteractiveLearningApproach(env.predicates, env.options,
+                                                 env.types, env.action_space)
     train_tasks = env.get_train_tasks()
     dataset = create_dataset(env, train_tasks)
     assert approach.is_learning_based

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -50,8 +50,8 @@ def _test_approach(env_name,
             "Can't exclude a goal predicate!"
     else:
         preds = env.predicates
-    approach = create_approach(approach_name, env.simulate, preds, env.options,
-                               env.types, env.action_space)
+    approach = create_approach(approach_name, preds, env.options, env.types,
+                               env.action_space)
     train_tasks = env.get_train_tasks()
     dataset = create_dataset(env, train_tasks)
     assert approach.is_learning_based
@@ -64,8 +64,8 @@ def _test_approach(env_name,
     # We won't check the policy here because we don't want unit tests to
     # have to train very good models, since that would be slow.
     # Now test loading NSRTs & predicates.
-    approach2 = create_approach(approach_name, env.simulate, preds,
-                                env.options, env.types, env.action_space)
+    approach2 = create_approach(approach_name, preds, env.options, env.types,
+                                env.action_space)
     approach2.load()
     if try_solving:
         policy = approach2.solve(task, timeout=CFG.timeout)

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -107,8 +107,8 @@ def test_oracle_approach_cover():
     utils.update_config({"num_train_tasks": 5, "num_test_tasks": 5})
     env = CoverEnv()
     env.seed(123)
-    approach = OracleApproach(env.simulate, env.predicates, env.options,
-                              env.types, env.action_space)
+    approach = OracleApproach(env.predicates, env.options, env.types,
+                              env.action_space)
     assert not approach.is_learning_based
     random_action = Action(env.action_space.sample())
     approach.seed(123)
@@ -132,8 +132,8 @@ def test_oracle_approach_cover_typed_options():
     utils.update_config({"num_train_tasks": 5, "num_test_tasks": 5})
     env = CoverEnvTypedOptions()
     env.seed(123)
-    approach = OracleApproach(env.simulate, env.predicates, env.options,
-                              env.types, env.action_space)
+    approach = OracleApproach(env.predicates, env.options, env.types,
+                              env.action_space)
     assert not approach.is_learning_based
     random_action = Action(env.action_space.sample())
     approach.seed(123)
@@ -157,8 +157,8 @@ def test_oracle_approach_cover_hierarchical_types():
     utils.update_config({"num_train_tasks": 5, "num_test_tasks": 5})
     env = CoverEnvHierarchicalTypes()
     env.seed(123)
-    approach = OracleApproach(env.simulate, env.predicates, env.options,
-                              env.types, env.action_space)
+    approach = OracleApproach(env.predicates, env.options, env.types,
+                              env.action_space)
     assert not approach.is_learning_based
     random_action = Action(env.action_space.sample())
     approach.seed(123)
@@ -187,8 +187,8 @@ def test_oracle_approach_cover_multistep_options():
     })
     env = CoverMultistepOptions()
     env.seed(123)
-    approach = OracleApproach(env.simulate, env.predicates, env.options,
-                              env.types, env.action_space)
+    approach = OracleApproach(env.predicates, env.options, env.types,
+                              env.action_space)
     assert not approach.is_learning_based
     random_action = Action(env.action_space.sample())
     approach.seed(123)
@@ -214,8 +214,8 @@ def test_oracle_approach_cover_multistep_options():
     })
     env = CoverMultistepOptions()
     env.seed(123)
-    approach = OracleApproach(env.simulate, env.predicates, env.options,
-                              env.types, env.action_space)
+    approach = OracleApproach(env.predicates, env.options, env.types,
+                              env.action_space)
     assert not approach.is_learning_based
     random_action = Action(env.action_space.sample())
     approach.seed(123)
@@ -235,8 +235,8 @@ def test_oracle_approach_cover_multistep_options():
     })
     env = CoverMultistepOptions()
     env.seed(123)
-    approach = OracleApproach(env.simulate, env.predicates, env.options,
-                              env.types, env.action_space)
+    approach = OracleApproach(env.predicates, env.options, env.types,
+                              env.action_space)
     assert not approach.is_learning_based
     random_action = Action(env.action_space.sample())
     approach.seed(123)
@@ -264,8 +264,8 @@ def test_oracle_approach_cover_multistep_options_fixed_tasks():
     })
     env = CoverMultistepOptionsFixedTasks()
     env.seed(123)
-    approach = OracleApproach(env.simulate, env.predicates, env.options,
-                              env.types, env.action_space)
+    approach = OracleApproach(env.predicates, env.options, env.types,
+                              env.action_space)
     assert not approach.is_learning_based
     random_action = Action(env.action_space.sample())
     approach.seed(123)
@@ -368,8 +368,8 @@ def test_oracle_approach_cluttered_table(place_version=False):
         })
         env = ClutteredTablePlaceEnv()
     env.seed(123)
-    approach = OracleApproach(env.simulate, env.predicates, env.options,
-                              env.types, env.action_space)
+    approach = OracleApproach(env.predicates, env.options, env.types,
+                              env.action_space)
     assert not approach.is_learning_based
     approach.seed(123)
     train_task = env.get_train_tasks()[0]
@@ -399,8 +399,8 @@ def test_oracle_approach_blocks():
     })
     env = BlocksEnv()
     env.seed(123)
-    approach = OracleApproach(env.simulate, env.predicates, env.options,
-                              env.types, env.action_space)
+    approach = OracleApproach(env.predicates, env.options, env.types,
+                              env.action_space)
     assert not approach.is_learning_based
     approach.seed(123)
     # Test a couple of train tasks so that we get at least one which
@@ -422,8 +422,8 @@ def test_oracle_approach_painting():
     })
     env = PaintingEnv()
     env.seed(123)
-    approach = OracleApproach(env.simulate, env.predicates, env.options,
-                              env.types, env.action_space)
+    approach = OracleApproach(env.predicates, env.options, env.types,
+                              env.action_space)
     assert not approach.is_learning_based
     approach.seed(123)
     for train_task in env.get_train_tasks()[:2]:
@@ -443,8 +443,8 @@ def test_oracle_approach_playroom():
     })
     env = PlayroomEnv()
     env.seed(123)
-    approach = OracleApproach(env.simulate, env.predicates, env.options,
-                              env.types, env.action_space)
+    approach = OracleApproach(env.predicates, env.options, env.types,
+                              env.action_space)
     assert not approach.is_learning_based
     approach.seed(123)
     for train_task in env.get_train_tasks()[:2]:
@@ -510,8 +510,8 @@ def test_oracle_approach_repeated_nextto():
     })
     env = RepeatedNextToEnv()
     env.seed(123)
-    approach = OracleApproach(env.simulate, env.predicates, env.options,
-                              env.types, env.action_space)
+    approach = OracleApproach(env.predicates, env.options, env.types,
+                              env.action_space)
     assert not approach.is_learning_based
     approach.seed(123)
     for train_task in env.get_train_tasks()[:3]:

--- a/tests/approaches/test_random_actions_approach.py
+++ b/tests/approaches/test_random_actions_approach.py
@@ -14,8 +14,8 @@ def test_random_actions_approach():
     })
     env = CoverEnv()
     task = env.get_train_tasks()[0]
-    approach = RandomActionsApproach(env.simulate, env.predicates, env.options,
-                                     env.types, env.action_space)
+    approach = RandomActionsApproach(env.predicates, env.options, env.types,
+                                     env.action_space)
     assert not approach.is_learning_based
     approach.seed(123)
     policy = approach.solve(task, 500)

--- a/tests/approaches/test_random_options_approach.py
+++ b/tests/approaches/test_random_options_approach.py
@@ -38,9 +38,8 @@ def test_random_options_approach():
         return s[o[0]][0] > 7.5
 
     Solved = Predicate("Solved", [cup_type], _solved_classifier)
-    approach = RandomOptionsApproach(_simulator, {Solved},
-                                     {parameterized_option}, {cup_type},
-                                     params_space)
+    approach = RandomOptionsApproach({Solved}, {parameterized_option},
+                                     {cup_type}, params_space)
     assert not approach.is_learning_based
     task = Task(state, {Solved([cup])})
     approach.seed(123)
@@ -67,9 +66,8 @@ def test_random_options_approach():
                                                 _policy,
                                                 lambda _1, _2, _3, _4: False,
                                                 _terminal)
-    approach = RandomOptionsApproach(_simulator, {Solved},
-                                     {parameterized_option2}, {cup_type},
-                                     params_space)
+    approach = RandomOptionsApproach({Solved}, {parameterized_option2},
+                                     {cup_type}, params_space)
     task = Task(state, {Solved([cup])})
     approach.seed(123)
     policy = approach.solve(task, 500)
@@ -79,9 +77,8 @@ def test_random_options_approach():
     parameterized_option3 = ParameterizedOption("Move", [], params_space,
                                                 _policy, _initiable,
                                                 lambda _1, _2, _3, _4: True)
-    approach = RandomOptionsApproach(_simulator, {Solved},
-                                     {parameterized_option3}, {cup_type},
-                                     params_space)
+    approach = RandomOptionsApproach({Solved}, {parameterized_option3},
+                                     {cup_type}, params_space)
     task = Task(state, {Solved([cup])})
     approach.seed(123)
     policy = approach.solve(task, 500)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -121,8 +121,8 @@ def test_tamp_approach_failure():
         "make_videos": False,
     })
     env = CoverEnv()
-    approach = _DummyApproach(env.simulate, env.predicates, env.options,
-                              env.types, env.action_space)
+    approach = _DummyApproach(env.predicates, env.options, env.types,
+                              env.action_space)
     assert not approach.is_learning_based
     task = env.get_train_tasks()[0]
     approach.solve(task, timeout=500)
@@ -140,8 +140,8 @@ def test_env_failure():
         "cover_initial_holding_prob": 0.0,
     })
     env = _DummyCoverEnv()
-    approach = create_approach("random_actions", env.simulate, env.predicates,
-                               env.options, env.types, env.action_space)
+    approach = create_approach("random_actions", env.predicates, env.options,
+                               env.types, env.action_space)
     assert not approach.is_learning_based
     task = env.get_train_tasks()[0]
     approach.solve(task, timeout=500)

--- a/tests/test_option_model.py
+++ b/tests/test_option_model.py
@@ -2,7 +2,6 @@
 
 import pytest
 from gym.spaces import Box
-from predicators.src.envs import CoverEnv
 from predicators.src.structs import State, Action, Type, ParameterizedOption
 from predicators.src.option_model import create_option_model
 from predicators.src import utils

--- a/tests/test_option_model.py
+++ b/tests/test_option_model.py
@@ -10,6 +10,7 @@ from predicators.src import utils
 
 def test_default_option_model():
     """Tests for the default option model."""
+    utils.update_config({"env": "cover"})
     type1 = Type("type1", ["feat1", "feat2"])
     type2 = Type("type2", ["feat3", "feat4", "feat5"])
     obj3 = type1("obj3")
@@ -57,7 +58,8 @@ def test_default_option_model():
         obj4: [8, 9, 10],
         obj9: [11, 12, 13]
     })
-    model = create_option_model("default", _simulate)
+    model = create_option_model("oracle")
+    model._simulator = _simulate  # pylint:disable=protected-access
     next_state = model.get_next_state(state, option1)
     assert abs(next_state.get(obj1, "feat3") - 55) < 1e-6
     with pytest.raises(AssertionError):  # option2 is not initiable
@@ -76,6 +78,5 @@ def test_option_model_notimplemented():
         "approach": "nsrt_learning",
         "seed": 123
     })
-    env = CoverEnv()
     with pytest.raises(NotImplementedError):
-        create_option_model("not a real option model", env.simulate)
+        create_option_model("not a real option model")

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -20,7 +20,7 @@ def test_sesame_plan():
     env = CoverEnv()
     nsrts = get_gt_nsrts(env.predicates, env.options)
     task = env.get_train_tasks()[0]
-    option_model = create_option_model(CFG.option_model_name, env.simulate)
+    option_model = create_option_model(CFG.option_model_name)
     plan, metrics = sesame_plan(task,
                                 option_model,
                                 nsrts,
@@ -93,9 +93,9 @@ def test_sesame_plan_failures():
     utils.update_config({"env": "cover"})
     env = CoverEnv()
     env.seed(123)
-    option_model = create_option_model(CFG.option_model_name, env.simulate)
-    approach = OracleApproach(env.simulate, env.predicates, env.options,
-                              env.types, env.action_space)
+    option_model = create_option_model(CFG.option_model_name)
+    approach = OracleApproach(env.predicates, env.options, env.types,
+                              env.action_space)
     approach.seed(123)
     task = env.get_train_tasks()[0]
     trivial_task = Task(task.init, set())
@@ -154,7 +154,7 @@ def test_sesame_plan_uninitiable_option():
     utils.update_config({"env": "cover"})
     env = CoverEnv()
     env.seed(123)
-    option_model = create_option_model(CFG.option_model_name, env.simulate)
+    option_model = create_option_model(CFG.option_model_name)
     initiable = lambda s, m, o, p: False
     nsrts = get_gt_nsrts(env.predicates, env.options)
     old_option = next(iter(env.options))
@@ -236,7 +236,8 @@ def test_planning_determinism():
     goal = {asleep([robby]), asleep([robin]), cried([robby]), cried([robin])}
     task1 = Task(State({robby: [0, 0], robin: [0, 0]}), goal)
     task2 = Task(State({robin: [0, 0], robby: [0, 0]}), goal)
-    option_model = create_option_model("default", _simulator)
+    option_model = create_option_model("oracle")
+    option_model._simulator = _simulator  # pylint:disable=protected-access
     # Check that sesame_plan is deterministic, over both NSRTs and objects.
     plan1 = [(act.name, act.objects)
              for act in sesame_plan(task1,


### PR DESCRIPTION
The only places the simulator is now used are:
* option_model.py, within OracleOptionModel
* demo_only.py, for making demos
* demo_replay.py, for making replays
* demo_replay.py, for optionally filtering out optimal replays
* main.py, for evaluation
* interactive_learning_approach.py, a temporary hack to generate
rollouts, which will be fixed in a future PR