### PR TITLE
change ground atoms query and response to allow multiple atoms 

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -212,7 +212,7 @@ def get_allowed_query_type_names() -> Set[str]:
     """Get the set of names of query types that the teacher is allowed to
     answer, computed based on the configuration CFG."""
     if CFG.approach in ("interactive_learning", "unittest"):
-        return {"GroundAtomHoldsQuery"}
+        return {"GroundAtomsHoldQuery"}
     return set()
 
 

--- a/tests/test_online_learning.py
+++ b/tests/test_online_learning.py
@@ -3,10 +3,10 @@
 import pytest
 from predicators.src.approaches import BaseApproach
 from predicators.src.structs import Action, InteractionRequest, \
-    InteractionResult
+    InteractionResult, Predicate, GroundAtom
 from predicators.src.main import _run_pipeline
 from predicators.src.envs import create_env
-from predicators.src.teacher import GroundAtomHoldsQuery
+from predicators.src.teacher import GroundAtomsHoldQuery
 from predicators.src import utils
 from predicators.src.settings import CFG
 
@@ -32,7 +32,9 @@ class _MockApproach(BaseApproach):
 
     def get_interaction_requests(self):
         act_policy = lambda s: Action(self._action_space.sample())
-        query_policy1 = lambda s: GroundAtomHoldsQuery("HandEmpty", [])
+        HandEmpty = Predicate("HandEmpty", [], lambda s, o: False)
+        hand_empty_atom = GroundAtom(HandEmpty, [])
+        query_policy1 = lambda s: GroundAtomsHoldQuery({hand_empty_atom})
         termination_function1 = lambda s: True  # terminate immediately
         request1 = InteractionRequest(0, act_policy, query_policy1,
                                       termination_function1)
@@ -51,9 +53,12 @@ class _MockApproach(BaseApproach):
         assert len(result1.states) == 1
         assert len(result2.states) == max_steps + 1
         response1 = result1.responses[0]
-        assert response1.query.predicate_name == "HandEmpty"
-        assert response1.query.objects == []
-        assert response1.holds
+        assert len(response1.query.ground_atoms) == 1
+        query_atom = next(iter(response1.query.ground_atoms))
+        assert query_atom.predicate.name == "HandEmpty"
+        assert query_atom.objects == []
+        assert len(response1.holds) == 1
+        assert next(iter(response1.holds.values()))
         # request2's queries were all None, so the responses should be too.
         assert result2.responses == [None for _ in range(max_steps + 1)]
         assert self._dummy_saved

--- a/tests/test_teacher.py
+++ b/tests/test_teacher.py
@@ -8,7 +8,7 @@ from predicators.src.structs import GroundAtom
 from predicators.src import utils
 
 
-def test_GroundAtomHolds():
+def test_GroundAtomsHold():
     """Tests for answering queries of type GroundAtomsHoldQuery."""
     utils.update_config({"env": "cover", "approach": "unittest"})
     teacher = Teacher()

--- a/tests/test_teacher.py
+++ b/tests/test_teacher.py
@@ -1,14 +1,15 @@
 """Test cases for teacher."""
 
-import pytest
-from predicators.src.teacher import Teacher, GroundAtomHoldsQuery, \
-    GroundAtomHoldsResponse
+from predicators.src.teacher import Teacher, GroundAtomsHoldQuery, \
+    GroundAtomsHoldResponse
 from predicators.src.envs import create_env
+from predicators.src.ground_truth_nsrts import _get_predicates_by_names
+from predicators.src.structs import GroundAtom
 from predicators.src import utils
 
 
 def test_GroundAtomHolds():
-    """Tests for answering queries of type GroundAtomHoldsQuery."""
+    """Tests for answering queries of type GroundAtomsHoldQuery."""
     utils.update_config({"env": "cover", "approach": "unittest"})
     teacher = Teacher()
     env = create_env("cover")
@@ -17,16 +18,33 @@ def test_GroundAtomHolds():
     target_type = [t for t in env.types if t.name == "target"][0]
     block = block_type("block0")
     target = target_type("target0")
-    query = GroundAtomHoldsQuery("IsBlock", [target])
-    with pytest.raises(AssertionError):  # wrong object types
-        teacher.answer_query(state, query)
-    query = GroundAtomHoldsQuery("IsBlock", [block])
+    Covers, IsBlock = _get_predicates_by_names("cover", ["Covers", "IsBlock"])
+    Covers = utils.strip_predicate(Covers)
+    IsBlock = utils.strip_predicate(IsBlock)
+    is_block_block = GroundAtom(IsBlock, [block])
+    query = GroundAtomsHoldQuery({is_block_block})
     response = teacher.answer_query(state, query)
-    assert isinstance(response, GroundAtomHoldsResponse)
+    assert isinstance(response, GroundAtomsHoldResponse)
     assert response.query is query
-    assert response.holds
-    query = GroundAtomHoldsQuery("Covers", [block, target])
+    assert len(response.holds) == 1
+    assert response.holds[is_block_block]
+    covers_block_target = GroundAtom(Covers, [block, target])
+    query = GroundAtomsHoldQuery({covers_block_target})
     response = teacher.answer_query(state, query)
-    assert isinstance(response, GroundAtomHoldsResponse)
+    assert isinstance(response, GroundAtomsHoldResponse)
     assert response.query is query
-    assert not response.holds
+    assert len(response.holds) == 1
+    assert not response.holds[covers_block_target]
+    query = GroundAtomsHoldQuery({covers_block_target})
+    response = teacher.answer_query(state, query)
+    assert isinstance(response, GroundAtomsHoldResponse)
+    assert response.query is query
+    assert len(response.holds) == 1
+    assert not response.holds[covers_block_target]
+    query = GroundAtomsHoldQuery({is_block_block, covers_block_target})
+    response = teacher.answer_query(state, query)
+    assert isinstance(response, GroundAtomsHoldResponse)
+    assert response.query is query
+    assert len(response.holds) == 2
+    assert response.holds[is_block_block]
+    assert not response.holds[covers_block_target]


### PR DESCRIPTION
also change to GroundAtoms themselves instead of (str, objects) for consistency with data+ground_atoms.