### PR TITLE
display better error message when PYTHONHASHSEED is not set

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -49,7 +49,7 @@ from predicators.src import utils
 from predicators.src.teacher import Teacher, Response
 
 
-assert os.environ["PYTHONHASHSEED"] == "0", \
+assert os.environ.get("PYTHONHASHSEED") == "0", \
         "Please add `export PYTHONHASHSEED=0` to your bash profile!"
 
 


### PR DESCRIPTION
before, we would raise a KeyError if PYTHONHASHSEED isn't set at all, which isn't as helpful as the assert message.