### PR TITLE
more refactoring of interactive approach

### DIFF
--- a/src/approaches/interactive_learning_approach.py
+++ b/src/approaches/interactive_learning_approach.py
@@ -13,7 +13,7 @@ from predicators.src.torch_models import LearnedPredicateClassifier, \
     MLPClassifier
 from predicators.src.utils import get_object_combinations
 from predicators.src.teacher import GroundAtomsHoldQuery, \
-    GroundAtomsHoldResponse
+    GroundAtomsHoldResponse, Query
 from predicators.src.settings import CFG
 
 
@@ -35,6 +35,8 @@ class InteractiveLearningApproach(NSRTLearningApproach):
     def _get_current_predicates(self) -> Set[Predicate]:
         return self._initial_predicates | self._predicates_to_learn
 
+    ###################### Semi-supervised learning #########################
+
     def learn_from_offline_dataset(self, dataset: Dataset) -> None:
         # First, go through the dataset's annotations and figure out the
         # set of predicates to learn. Note that their classifiers were
@@ -48,120 +50,6 @@ class InteractiveLearningApproach(NSRTLearningApproach):
         self._relearn_predicates_and_nsrts(dataset, online_learning_cycle=None)
         # Save dataset, to be used for online interaction.
         self._dataset = dataset
-
-    def get_interaction_requests(self) -> List[InteractionRequest]:
-        # We will create a single interaction request.
-        # Determine the train task that we will be using.
-        train_task_idx = self._select_interaction_train_task_idx()
-        # Determine the action policy and termination function.
-        act_policy, termination_function = self._create_interaction_action_strategy(train_task_idx)
-        # Determine the query policy.
-        query_policy = self._create_query_policy(train_task_idx)
-        return [
-            InteractionRequest(train_task_idx, act_policy, query_policy,
-                               termination_function)
-        ] 
-
-    def _select_interaction_train_task_idx(self) -> int:
-        # At the moment, we only have one way to select a train task idx:
-        # choose one uniformly at random. In the future, we may want to
-        # try other strategies. But one nice thing about random selection
-        # is that we're not making a hard commitment to the agent having
-        # control over which train task it gets to use.
-        return self._rng.choice(len(self._train_tasks))
-
-    def _create_interaction_action_strategy(self, train_task_idx: int) -> Tuple[Callable[[State], Action], Callable[[State], bool]]:
-        """Returns an action policy and a termination function."""
-        if CFG.interactive_action_strategy == "glib":
-            return self._create_glib_interaction_strategy(train_task_idx)
-        raise NotImplementedError("Unrecognized interactive action strategy:"
-                                  f" {CFG.interactive_action_strategy}")
-
-    def _create_query_policy(self, train_task_idx: int) -> Callable[[State], Optional[Query]]Callable[[State], Optional[Query]]:
-        """Returns a query policy."""
-        if CFG.interactive_query_policy == "strict_best_seen":
-            return self._create_best_seen_query_policy(strict=True)
-        if CFG.interactive_query_policy == "nonstrict_best_seen":
-            return self._create_best_seen_query_policy(strict=False)
-        raise NotImplementedError("Unrecognized query policy:"
-                                  f" {CFG.interactive_query_policy}")
-
-    def _create_glib_interaction_strategy(self, train_task_idx: int) -> Tuple[Callable[[State], Action], Callable[[State], bool]]:
-        """Find the most interesting reachable ground goal and plan to it."""
-        init = self._train_tasks[train_task_idx].init
-        # Detect and filter out static predicates.
-        static_preds = utils.get_static_preds(self._nsrts,
-                                              self._predicates_to_learn)
-        preds = self._predicates_to_learn - static_preds
-        # Find acting policy for the request.
-        task_list = glib_sample(init, preds, self._dataset)
-        assert task_list
-        task, act_policy = self._find_first_solvable(task_list)
-        assert task.init is init
-
-        def _termination_function(s: State) -> bool:
-            # Stop the episode if we reach the goal that we babbled.
-            return all(goal_atom.holds(s) for goal_atom in task.goal)
-
-        return act_policy, _termination_function
-
-        def _query_policy(s: State) -> Optional[GroundAtomsHoldQuery]:
-            # Decide whether to ask about each possible atom.
-            ground_atoms = utils.all_possible_ground_atoms(
-                s, self._predicates_to_learn)
-            atoms_to_query = set()
-            for atom in ground_atoms:
-                score = score_atom(self._dataset, atom)
-                # Ask about this atom if it is the best seen so far.
-                if score > self._best_score:
-                    atoms_to_query.add(atom)
-                    self._best_score = score
-            return GroundAtomsHoldQuery(atoms_to_query)
-
-        def _termination_function(s: State) -> bool:
-            # Stop the episode if we reach the goal that we babbled.
-            return all(goal_atom.holds(s) for goal_atom in task.goal)
-
-        return [
-            InteractionRequest(train_task_idx, act_policy, _query_policy,
-                               _termination_function)
-        ]
-
-    def learn_from_interaction_results(
-            self, results: Sequence[InteractionResult]) -> None:
-        assert len(results) == 1
-        result = results[0]
-        for state, response in zip(result.states, result.responses):
-            assert isinstance(response, GroundAtomsHoldResponse)
-            for query_atom, atom_holds in response.holds.items():
-                # Still need a way to use negative examples.
-                if not atom_holds:
-                    continue
-                # Add this atom because it's a positive example.
-                # Note: these pragma no covers are very temporary; we will
-                # remove them in a future PR where we change the score function
-                # to use >= instead of >, among other things. But for the sake
-                # of a pure refactor, we're leaving it alone for now.
-                traj = LowLevelTrajectory([state], [])  # pragma: no cover
-                self._dataset.append(traj, [{query_atom}])  # pragma: no cover
-        self._relearn_predicates_and_nsrts(
-            self._dataset, online_learning_cycle=self._online_learning_cycle)
-        self._online_learning_cycle += 1
-
-    def _find_first_solvable(
-            self,
-            task_list: List[Task]) -> Tuple[Task, Callable[[State], Action]]:
-        for task in task_list:
-            try:
-                print("Solving for policy...")
-                policy = self.solve(task, timeout=CFG.timeout)
-                return task, policy
-            except (ApproachTimeout, ApproachFailure) \
-                    as e:  # pragma: no cover
-                print(f"Approach failed to solve with error: {e}")
-                continue
-        raise ApproachFailure("Failed to sample a task that approach "
-                              "can solve.")  # pragma: no cover
 
     def _relearn_predicates_and_nsrts(
             self, dataset: Dataset,
@@ -214,47 +102,159 @@ class InteractiveLearningApproach(NSRTLearningApproach):
         # Learn NSRTs via superclass
         self._learn_nsrts(dataset.trajectories, online_learning_cycle)
 
+    ########################## Active learning ##############################
 
-def glib_sample(
-    initial_state: State,
-    predicates: Set[Predicate],
-    dataset: Dataset,
-) -> List[Task]:
-    """Sample some tasks via the GLIB approach."""
-    print("Sampling a task using GLIB approach...")
-    assert CFG.interactive_atom_type_babbled == "ground"
-    rng = np.random.default_rng(CFG.seed)
-    ground_atoms = utils.all_possible_ground_atoms(initial_state, predicates)
-    goals = []  # list of (goal, score) tuples
-    for _ in range(CFG.interactive_num_babbles):
-        # Sample num atoms to babble
-        num_atoms = 1 + rng.choice(CFG.interactive_max_num_atoms_babbled)
-        # Sample goal (a set of atoms)
-        idxs = rng.choice(np.arange(len(ground_atoms)),
-                          size=(num_atoms, ),
-                          replace=False)
-        goal = {ground_atoms[i] for i in idxs}
-        goals.append((goal, score_goal(dataset, goal)))
-    goals.sort(key=lambda tup: tup[1], reverse=True)
-    return [Task(initial_state, g) for (g, _) in \
-            goals[:CFG.interactive_num_tasks_babbled]]
+    def get_interaction_requests(self) -> List[InteractionRequest]:
+        # We will create a single interaction request.
+        # Determine the train task that we will be using.
+        train_task_idx = self._select_interaction_train_task_idx()
+        # Determine the action policy and termination function.
+        act_policy, termination_function = \
+            self._create_interaction_action_strategy(train_task_idx)
+        # Determine the query policy.
+        query_policy = self._create_query_policy(train_task_idx)
+        return [
+            InteractionRequest(train_task_idx, act_policy, query_policy,
+                               termination_function)
+        ]
 
+    def _score_atom_set(self, atom_set: Set[GroundAtom],
+                        state: State) -> float:
+        """Score an atom set based on how much we would like to know the values
+        of all the atoms in the set in the given state.
 
-def score_goal(dataset: Dataset, goal: Set[GroundAtom]) -> float:
-    """Score a goal as inversely proportional to the number of examples seen
-    during training."""
-    count = 1  # Avoid division by 0
-    for ground_atom_traj in dataset.annotations:
-        for ground_atom_set in ground_atom_traj:
-            count += 1 if goal.issubset(ground_atom_set) else 0
-    return 1.0 / count
+        Higher scores are better.
+        """
+        del state  # not currently used, but will be by future score functions
+        if CFG.interactive_score_function == "frequency":
+            return self._score_atom_set_frequency(atom_set)
+        raise NotImplementedError("Unrecognized interactive_score_function:"
+                                  f" {CFG.interactive_score_function}.")
 
+    def _select_interaction_train_task_idx(self) -> int:
+        # At the moment, we only have one way to select a train task idx:
+        # choose one uniformly at random. In the future, we may want to
+        # try other strategies. But one nice thing about random selection
+        # is that we're not making a hard commitment to the agent having
+        # control over which train task it gets to use.
+        return self._rng.choice(len(self._train_tasks))
 
-def score_atom(dataset: Dataset, atom: GroundAtom) -> float:
-    """Score an atom as inversely proportional to the number of examples seen
-    during training."""
-    count = 1  # Avoid division by 0
-    for ground_atom_traj in dataset.annotations:
-        for ground_atom_set in ground_atom_traj:
-            count += 1 if atom in ground_atom_set else 0
-    return 1.0 / count
+    def _create_interaction_action_strategy(
+        self, train_task_idx: int
+    ) -> Tuple[Callable[[State], Action], Callable[[State], bool]]:
+        """Returns an action policy and a termination function."""
+        if CFG.interactive_action_strategy == "glib":
+            return self._create_glib_interaction_strategy(train_task_idx)
+        raise NotImplementedError("Unrecognized interactive action strategy:"
+                                  f" {CFG.interactive_action_strategy}")
+
+    def _create_query_policy(
+            self, train_task_idx: int) -> Callable[[State], Optional[Query]]:
+        """Returns a query policy."""
+        del train_task_idx  # unused right now, but future policies may use
+        if CFG.interactive_query_policy == "strict_best_seen":
+            return self._create_best_seen_query_policy(strict=True)
+        if CFG.interactive_query_policy == "nonstrict_best_seen":
+            return self._create_best_seen_query_policy(strict=False)
+        raise NotImplementedError("Unrecognized query policy:"
+                                  f" {CFG.interactive_query_policy}")
+
+    def _create_glib_interaction_strategy(
+        self, train_task_idx: int
+    ) -> Tuple[Callable[[State], Action], Callable[[State], bool]]:
+        """Find the most interesting reachable ground goal and plan to it."""
+        init = self._train_tasks[train_task_idx].init
+        # Detect and filter out static predicates.
+        static_preds = utils.get_static_preds(self._nsrts,
+                                              self._predicates_to_learn)
+        preds = self._predicates_to_learn - static_preds
+        # Sample possible goals to plan toward.
+        ground_atom_universe = utils.all_possible_ground_atoms(init, preds)
+        possible_goals = utils.sample_subsets(
+            ground_atom_universe,
+            num_samples=CFG.interactive_num_babbles,
+            max_set_size=CFG.interactive_max_num_atoms_babbled,
+            rng=self._rng)
+        # Sort the possible goals based on how interesting they are.
+        # Note: we're using _score_atom_set_frequency here instead of
+        # _score_atom_set because _score_atom_set in general could depend
+        # on the current state. While babbling goals, we don't have any
+        # current state because we don't know what the state will be if and
+        # when we get to the goal.
+        goal_list = sorted(possible_goals,
+                           key=self._score_atom_set_frequency,
+                           reverse=True)  # largest to smallest
+        task_list = [Task(init, goal) for goal in goal_list]
+        task, act_policy = self._find_first_solvable(task_list)
+        assert task.init is init
+
+        def _termination_function(s: State) -> bool:
+            # Stop the episode if we reach the goal that we babbled.
+            return all(goal_atom.holds(s) for goal_atom in task.goal)
+
+        return act_policy, _termination_function
+
+    def _create_best_seen_query_policy(
+            self, strict: bool) -> Callable[[State], Optional[Query]]:
+        """Only query if the atom has the best score seen so far."""
+
+        def _query_policy(s: State) -> Optional[GroundAtomsHoldQuery]:
+            # Decide whether to ask about each possible atom.
+            ground_atoms = utils.all_possible_ground_atoms(
+                s, self._predicates_to_learn)
+            atoms_to_query = set()
+            for atom in ground_atoms:
+                score = self._score_atom_set({atom}, s)
+                # Ask about this atom if it is the best seen so far.
+                if (strict and score > self._best_score) or \
+                   (not strict and score >= self._best_score):
+                    atoms_to_query.add(atom)
+                    self._best_score = score
+            return GroundAtomsHoldQuery(atoms_to_query)
+
+        return _query_policy
+
+    def learn_from_interaction_results(
+            self, results: Sequence[InteractionResult]) -> None:
+        assert len(results) == 1
+        result = results[0]
+        for state, response in zip(result.states, result.responses):
+            assert isinstance(response, GroundAtomsHoldResponse)
+            for query_atom, atom_holds in response.holds.items():
+                # Still need a way to use negative examples.
+                if not atom_holds:
+                    continue
+                # Add this atom because it's a positive example.
+                # Note: these pragma no covers are very temporary; we will
+                # remove them in a future PR where we change the score function
+                # to use >= instead of >, among other things. But for the sake
+                # of a pure refactor, we're leaving it alone for now.
+                traj = LowLevelTrajectory([state], [])  # pragma: no cover
+                self._dataset.append(traj, [{query_atom}])  # pragma: no cover
+        self._relearn_predicates_and_nsrts(
+            self._dataset, online_learning_cycle=self._online_learning_cycle)
+        self._online_learning_cycle += 1
+
+    def _find_first_solvable(
+            self,
+            task_list: List[Task]) -> Tuple[Task, Callable[[State], Action]]:
+        for task in task_list:
+            try:
+                print("Solving for policy...")
+                policy = self.solve(task, timeout=CFG.timeout)
+                return task, policy
+            except (ApproachTimeout, ApproachFailure) \
+                    as e:  # pragma: no cover
+                print(f"Approach failed to solve with error: {e}")
+                continue
+        raise ApproachFailure("Failed to sample a task that approach "
+                              "can solve.")  # pragma: no cover
+
+    def _score_atom_set_frequency(self, atom_set: Set[GroundAtom]) -> float:
+        """Score an atom set as inversely proportional to the number of
+        examples seen during training."""
+        count = 1  # Avoid division by 0
+        for ground_atom_traj in self._dataset.annotations:
+            for ground_atom_set in ground_atom_traj:
+                count += 1 if atom_set.issubset(ground_atom_set) else 0
+        return 1.0 / count

--- a/src/approaches/interactive_learning_approach.py
+++ b/src/approaches/interactive_learning_approach.py
@@ -129,7 +129,7 @@ class InteractiveLearningApproach(NSRTLearningApproach):
         act_policy, termination_function = \
             self._create_interaction_action_strategy(train_task_idx)
         # Determine the query policy.
-        query_policy = self._create_query_policy(train_task_idx)
+        query_policy = self._create_interaction_query_policy(train_task_idx)
         return [
             InteractionRequest(train_task_idx, act_policy, query_policy,
                                termination_function)
@@ -165,7 +165,7 @@ class InteractiveLearningApproach(NSRTLearningApproach):
         raise NotImplementedError("Unrecognized interactive_action_strategy:"
                                   f" {CFG.interactive_action_strategy}")
 
-    def _create_query_policy(
+    def _create_interaction_query_policy(
             self, train_task_idx: int) -> Callable[[State], Optional[Query]]:
         """Returns a query policy."""
         del train_task_idx  # unused right now, but future policies may use

--- a/src/settings.py
+++ b/src/settings.py
@@ -117,10 +117,11 @@ class GlobalSettings:
     predicate_mlp_classifier_max_itr = 1000
 
     # interactive learning parameters
-    interactive_num_babbles = 10
-    interactive_max_num_atoms_babbled = 1
-    interactive_num_tasks_babbled = 5
-    interactive_atom_type_babbled = "ground"
+    interactive_action_strategy = "glib"
+    interactive_query_policy = "strict_best_seen"
+    interactive_score_function = "frequency"
+    interactive_num_babbles = 10  # for action strategy glib
+    interactive_max_num_atoms_babbled = 1  # for action strategy glib
 
     # grammar search invention parameters
     grammar_search_grammar_includes_givens = True

--- a/src/utils.py
+++ b/src/utils.py
@@ -847,12 +847,14 @@ def all_possible_ground_atoms(state: State,
 _T = TypeVar("_T")  # element of a set
 
 
-def sample_subsets(universe: Sequence[_T], num_samples: int, max_set_size: int,
+def sample_subsets(universe: Sequence[_T], num_samples: int, min_set_size: int,
+                   max_set_size: int,
                    rng: np.random.Generator) -> List[Set[_T]]:
     """Sample multiple subsets from a universe."""
     samples = []
+    assert min_set_size <= len(universe), "Not enough elements in universe"
     for _ in range(num_samples):
-        set_size = 1 + rng.choice(max_set_size)
+        set_size = rng.integers(min_set_size, max_set_size + 1)
         idxs = rng.choice(np.arange(len(universe)),
                           size=set_size,
                           replace=False)

--- a/src/utils.py
+++ b/src/utils.py
@@ -849,9 +849,8 @@ _T = TypeVar("_T")  # element of a set
 
 def sample_subsets(universe: Sequence[_T], num_samples: int, min_set_size: int,
                    max_set_size: int,
-                   rng: np.random.Generator) -> Iteratore[Set[_T]]:
+                   rng: np.random.Generator) -> Iterator[Set[_T]]:
     """Sample multiple subsets from a universe."""
-    samples = []
     assert min_set_size <= max_set_size
     assert max_set_size <= len(universe), "Not enough elements in universe"
     for _ in range(num_samples):

--- a/src/utils.py
+++ b/src/utils.py
@@ -849,18 +849,18 @@ _T = TypeVar("_T")  # element of a set
 
 def sample_subsets(universe: Sequence[_T], num_samples: int, min_set_size: int,
                    max_set_size: int,
-                   rng: np.random.Generator) -> List[Set[_T]]:
+                   rng: np.random.Generator) -> Iteratore[Set[_T]]:
     """Sample multiple subsets from a universe."""
     samples = []
-    assert min_set_size <= len(universe), "Not enough elements in universe"
+    assert min_set_size <= max_set_size
+    assert max_set_size <= len(universe), "Not enough elements in universe"
     for _ in range(num_samples):
         set_size = rng.integers(min_set_size, max_set_size + 1)
         idxs = rng.choice(np.arange(len(universe)),
                           size=set_size,
                           replace=False)
         sample = {universe[i] for i in idxs}
-        samples.append(sample)
-    return samples
+        yield sample
 
 
 def create_ground_atom_dataset(

--- a/src/utils.py
+++ b/src/utils.py
@@ -844,6 +844,23 @@ def all_possible_ground_atoms(state: State,
     return sorted(ground_atoms)
 
 
+_T = TypeVar("_T")  # element of a set
+
+
+def sample_subsets(universe: Sequence[_T], num_samples: int, max_set_size: int,
+                   rng: np.random.Generator) -> List[Set[_T]]:
+    """Sample multiple subsets from a universe."""
+    samples = []
+    for _ in range(num_samples):
+        set_size = 1 + rng.choice(max_set_size)
+        idxs = rng.choice(np.arange(len(universe)),
+                          size=set_size,
+                          replace=False)
+        sample = {universe[i] for i in idxs}
+        samples.append(sample)
+    return samples
+
+
 def create_ground_atom_dataset(
         trajectories: Sequence[LowLevelTrajectory],
         predicates: Set[Predicate]) -> List[GroundAtomTrajectory]:

--- a/tests/approaches/test_interactive_approach.py
+++ b/tests/approaches/test_interactive_approach.py
@@ -1,5 +1,6 @@
 """Test cases for the interactive learning approach."""
 
+import pytest
 from predicators.src.approaches import InteractiveLearningApproach, \
     ApproachTimeout, ApproachFailure
 from predicators.src.datasets import create_dataset
@@ -15,17 +16,26 @@ def test_interactive_learning_approach():
     utils.update_config({"env": "cover"})
     utils.update_config({
         "approach": "interactive_learning",
+        "interactive_action_strategy": "glib",
+        "interactive_query_policy": "strict_best_seen",
+        "interactive_score_function": "frequency",
+        "interactive_num_babbles": 10,
         "offline_data_method": "demo+ground_atoms",
         "excluded_predicates": "IsBlock,Covers",
         "timeout": 10,
         "max_samples_per_step": 10,
         "seed": 123,
+        # These need to be large enough that the classifier for Covers is good;
+        # otherwise, incorrect operators can lead to glib failing.
+        "teacher_dataset_label_ratio": 1.0,
+        "predicate_mlp_classifier_max_itr": 1000,
         "sampler_mlp_classifier_max_itr": 200,
-        "predicate_mlp_classifier_max_itr": 200,
         "neural_gaus_regressor_max_itr": 200,
         "num_online_learning_cycles": 1,
         "num_train_tasks": 5,
         "num_test_tasks": 5,
+        "cover_initial_holding_prob": 0.0,
+        "min_data_for_nsrt": 0,
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
@@ -40,7 +50,42 @@ def test_interactive_learning_approach():
     dataset = create_dataset(env, train_tasks)
     assert approach.is_learning_based
     approach.learn_from_offline_dataset(dataset)
+    # Cover unrecognized interactive_action_strategy.
+    utils.update_config({
+        "interactive_action_strategy": "not a real action strategy",
+        "interactive_query_policy": "strict_best_seen",
+        "interactive_score_function": "frequency",
+    })
+    with pytest.raises(NotImplementedError) as e:
+        approach.get_interaction_requests()
+    assert "Unrecognized interactive_action_strategy" in str(e)
+    # Cover unrecognized interactive_query_policy.
+    utils.update_config({
+        "interactive_action_strategy": "glib",
+        "interactive_query_policy": "not a real query policy",
+        "interactive_score_function": "frequency",
+    })
+    with pytest.raises(NotImplementedError) as e:
+        approach.get_interaction_requests()
+    assert "Unrecognized interactive_query_policy" in str(e)
+    # Successfully generate interaction requests.
+    utils.update_config({
+        "interactive_action_strategy": "glib",
+        "interactive_query_policy": "strict_best_seen",
+        "interactive_score_function": "not a real score function",
+    })
     interaction_requests = approach.get_interaction_requests()
+    # Cover unrecognized interactive_score_function.
+    with pytest.raises(NotImplementedError) as e:
+        _generate_interaction_results(env.simulate, teacher, train_tasks,
+                                      interaction_requests)
+    assert "Unrecognized interactive_score_function" in str(e)
+    # Successfully generate interaction results.
+    utils.update_config({
+        "interactive_action_strategy": "glib",
+        "interactive_query_policy": "strict_best_seen",
+        "interactive_score_function": "frequency",
+    })
     interaction_results = _generate_interaction_results(
         env.simulate, teacher, train_tasks, interaction_requests)
     approach.learn_from_interaction_results(interaction_results)
@@ -50,4 +95,4 @@ def test_interactive_learning_approach():
         except (ApproachTimeout, ApproachFailure):  # pragma: no cover
             pass
         # We won't check the policy here because we don't want unit tests to
-        # have to train very good models, since that would be slow.
+        # have to train very good models, since that would be slow.    

--- a/tests/approaches/test_interactive_approach.py
+++ b/tests/approaches/test_interactive_approach.py
@@ -1,5 +1,6 @@
 """Test cases for the interactive learning approach."""
 
+import pytest
 from predicators.src.approaches import InteractiveLearningApproach, \
     ApproachTimeout, ApproachFailure
 from predicators.src.datasets import create_dataset
@@ -50,3 +51,33 @@ def test_interactive_learning_approach():
             pass
         # We won't check the policy here because we don't want unit tests to
         # have to train very good models, since that would be slow.
+    # Cover unrecognized interactive_action_strategy.
+    utils.update_config({
+        "interactive_action_strategy": "not a real action strategy",
+        "interactive_query_policy": "strict_best_seen",
+        "interactive_score_function": "frequency",
+    })
+    with pytest.raises(NotImplementedError) as e:
+        approach.get_interaction_requests()
+    assert "Unrecognized interactive_action_strategy" in str(e)
+    # Cover unrecognized interactive_query_policy.
+    utils.update_config({
+        "interactive_action_strategy": "glib",
+        "interactive_query_policy": "not a real query policy",
+        "interactive_score_function": "frequency",
+    })
+    with pytest.raises(NotImplementedError) as e:
+        approach.get_interaction_requests()
+    assert "Unrecognized interactive_query_policy" in str(e)
+    # Cover unrecognized interactive_score_function.
+    utils.update_config({
+        "interactive_action_strategy":
+        "glib",
+        "interactive_query_policy":
+        "strict_best_seen",
+        "interactive_score_function":
+        "not a real score function",
+    })
+    with pytest.raises(NotImplementedError) as e:
+        approach._score_atom_set(set(), train_tasks[0].init)  # pylint:disable=protected-access
+    assert "Unrecognized interactive_score_function" in str(e)

--- a/tests/approaches/test_interactive_approach.py
+++ b/tests/approaches/test_interactive_approach.py
@@ -24,18 +24,22 @@ def test_interactive_learning_approach():
         "excluded_predicates": "IsBlock,Covers",
         "timeout": 10,
         "max_samples_per_step": 10,
+        "max_skeletons_optimized": 8,
         "seed": 123,
-        # These need to be large enough that the classifier for Covers is good;
-        # otherwise, incorrect operators can lead to glib failing.
+        # These settings need to be large enough that Covers is learned
+        # correctly for active learning to work consistently.
         "teacher_dataset_label_ratio": 1.0,
         "predicate_mlp_classifier_max_itr": 1000,
-        "sampler_mlp_classifier_max_itr": 200,
-        "neural_gaus_regressor_max_itr": 200,
+        "sampler_mlp_classifier_max_itr": 1000,
+        "neural_gaus_regressor_max_itr": 1000,
+        "learning_rate": 1e-3,
+        "mlp_classifier_n_iter_no_change": 5000,
+        "option_learner": "no_learning",
+        "sampler_learner": "neural",
         "num_online_learning_cycles": 1,
-        "num_train_tasks": 5,
+        "num_train_tasks": 15,
         "num_test_tasks": 5,
-        "cover_initial_holding_prob": 0.0,
-        "min_data_for_nsrt": 0,
+        "cover_initial_holding_prob": 0.75,
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
@@ -70,9 +74,12 @@ def test_interactive_learning_approach():
     assert "Unrecognized interactive_query_policy" in str(e)
     # Successfully generate interaction requests.
     utils.update_config({
-        "interactive_action_strategy": "glib",
-        "interactive_query_policy": "strict_best_seen",
-        "interactive_score_function": "not a real score function",
+        "interactive_action_strategy":
+        "glib",
+        "interactive_query_policy":
+        "strict_best_seen",
+        "interactive_score_function":
+        "not a real score function",
     })
     interaction_requests = approach.get_interaction_requests()
     # Cover unrecognized interactive_score_function.
@@ -95,4 +102,4 @@ def test_interactive_learning_approach():
         except (ApproachTimeout, ApproachFailure):  # pragma: no cover
             pass
         # We won't check the policy here because we don't want unit tests to
-        # have to train very good models, since that would be slow.    
+        # have to train very good models, since that would be slow.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -366,11 +366,22 @@ def test_sample_subsets():
     min_set_size = 1
     max_set_size = 2
     rng = np.random.default_rng(0)
-    samples = utils.sample_subsets(universe, num_samples, min_set_size,
-                                   max_set_size, rng)
+    samples = list(
+        utils.sample_subsets(universe, num_samples, min_set_size, max_set_size,
+                             rng))
     assert len(samples) == 5
     assert {len(s) for s in samples} == {1, 2}
     assert all(s.issubset(set(universe)) for s in samples)
+    assert not list(
+        utils.sample_subsets(universe, 0, min_set_size, max_set_size, rng))
+    assert list(utils.sample_subsets(
+        [], num_samples, 0, 0, rng)) == [set() for _ in range(num_samples)]
+    with pytest.raises(AssertionError):
+        next(utils.sample_subsets(universe, num_samples, min_set_size, 0, rng))
+    with pytest.raises(AssertionError):
+        next(
+            utils.sample_subsets([], num_samples, min_set_size, max_set_size,
+                                 rng))
 
 
 def test_abstract():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -359,6 +359,20 @@ def test_strip_task():
     assert not new_goal_atom2.holds(state)
 
 
+def test_sample_subsets():
+    """Tests for sample_subsets()."""
+    universe = list(range(10))
+    num_samples = 5
+    min_set_size = 1
+    max_set_size = 2
+    rng = np.random.default_rng(0)
+    samples = utils.sample_subsets(universe, num_samples, min_set_size,
+                                   max_set_size, rng)
+    assert len(samples) == 5
+    assert {len(s) for s in samples} == {1, 2}
+    assert all(s.issubset(set(universe)) for s in samples)
+
+
 def test_abstract():
     """Tests for abstract() and wrap_atom_predicates()."""
     cup_type = Type("cup_type", ["feat1"])


### PR DESCRIPTION
A number of refactors to the active learning part of interactive learning, in preparation for implementing new choices of different subparts.

* `CFG.interactive_action_strategy` controls how we want to set up the exploration policy and termination function
* `CFG.interactive_query_policy` controls how we want to decide what atoms to query in each state
* `CFG.interactive_score_function` controls the score function used in the query policy to determine what atoms are worth querying about

Each of these only has one default choice right now, but I expect we'll implement more options for each in the not too distant future.

Two other minor refactors:
* Combined the two previously separate score functions into one (`_score_atom_set`)
* Refactored `glib_sample` into a generic `sample_subsets` utility and the other parts. One minor functional change here: previously we had two separate parameters, which controlled how many goals to babble, and then how many of those goals to return before trying out each one with task planning. I removed the second parameter, so now we just specify how many goals we want to babble, and then we try all of them in the worst case. (This is how we did it in GLIB iirc.)