### PR TITLE
reset_config instead of update_config in tests

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1273,7 +1273,8 @@ def update_config(args: Dict[str, Any]) -> None:
             CFG.__setattr__(k, v)
 
 
-def reset_config(args: Dict[str, Any], default_seed: int = 123) -> None:
+def reset_config(args: Optional[Dict[str, Any]] = None,
+                 default_seed: int = 123) -> None:
     """Reset to the default CFG, overriding with anything in args.
 
     This utility is meant for use in testing only.
@@ -1292,7 +1293,8 @@ def reset_config(args: Dict[str, Any], default_seed: int = 123) -> None:
         for k, v in GlobalSettings.__dict__.items() if not k.startswith("_")
     }
     arg_dict.update(vars(default_args))
-    arg_dict.update(args)
+    if args is not None:
+        arg_dict.update(args)
     update_config(arg_dict)
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1252,10 +1252,7 @@ def save_video(outfile: str, video: Video) -> None:
 
 def update_config(args: Dict[str, Any]) -> None:
     """Args is a dictionary of new arguments to add to the config CFG."""
-    arg_specific_settings = GlobalSettings.get_arg_specific_settings({
-        **args,
-        **CFG.__dict__
-    })
+    arg_specific_settings = GlobalSettings.get_arg_specific_settings(args)
     # Only override attributes, don't create new ones.
     allowed_args = set(CFG.__dict__) | set(arg_specific_settings)
     parser = create_arg_parser()

--- a/src/utils.py
+++ b/src/utils.py
@@ -1274,7 +1274,10 @@ def update_config(args: Dict[str, Any]) -> None:
 
 
 def reset_config(args: Dict[str, Any], default_seed: int = 123) -> None:
-    """Reset to the default CFG, overriding with anything in args."""
+    """Reset to the default CFG, overriding with anything in args.
+
+    This utility is meant for use in testing only.
+    """
     parser = create_arg_parser()
     default_args = parser.parse_args([
         "--env",

--- a/tests/approaches/test_base_approach.py
+++ b/tests/approaches/test_base_approach.py
@@ -28,9 +28,7 @@ class _DummyApproach(BaseApproach):
 
 def test_base_approach():
     """Tests for BaseApproach class."""
-    utils.update_config({
-        "seed": 123,
-    })
+    utils.reset_config({})
     cup_type = Type("cup_type", ["feat1"])
     plate_type = Type("plate_type", ["feat1", "feat2"])
     pred1 = Predicate("On", [cup_type, plate_type], _classifier=None)
@@ -85,11 +83,9 @@ def test_create_approach():
             "random_actions", "random_options", "oracle", "nsrt_learning",
             "interactive_learning", "iterative_invention"
     ]:
-        utils.update_config({
+        utils.reset_config({
             "env": "cover",
             "approach": name,
-            "seed": 123,
-            "excluded_predicates": ""
         })
         approach = create_approach(name, env.predicates, env.options,
                                    env.types, env.action_space, train_tasks)

--- a/tests/approaches/test_base_approach.py
+++ b/tests/approaches/test_base_approach.py
@@ -28,7 +28,7 @@ class _DummyApproach(BaseApproach):
 
 def test_base_approach():
     """Tests for BaseApproach class."""
-    utils.reset_config({})
+    utils.reset_config()
     cup_type = Type("cup_type", ["feat1"])
     plate_type = Type("plate_type", ["feat1", "feat2"])
     pred1 = Predicate("On", [cup_type, plate_type], _classifier=None)

--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -28,7 +28,7 @@ from predicators.src import utils
 
 def test_predicate_grammar():
     """Tests for _PredicateGrammar class."""
-    utils.update_config({"env": "cover"})
+    utils.reset_config({"env": "cover"})
     env = CoverEnv()
     train_task = env.get_train_tasks()[0]
     state = train_task.init
@@ -60,7 +60,7 @@ def test_predicate_grammar():
     assert len(forall_grammar.generate(max_num=100)) == 12
     # Test CFG.grammar_search_predicate_cost_upper_bound.
     default = CFG.grammar_search_predicate_cost_upper_bound
-    utils.update_config({"grammar_search_predicate_cost_upper_bound": 0})
+    utils.reset_config({"grammar_search_predicate_cost_upper_bound": 0})
     assert len(single_ineq_grammar.generate(max_num=10)) == 0
     # With an empty dataset, all predicates should look the same, so zero
     # predicates should be enumerated. The reason that it's zero and not one
@@ -73,7 +73,7 @@ def test_predicate_grammar():
     # Reset to default just in case.
     utils.update_config({"grammar_search_predicate_cost_upper_bound": default})
     # Test debug grammar.
-    utils.update_config({"env": "unittest"})
+    utils.reset_config({"env": "unittest"})
     utils.update_config({"grammar_search_use_handcoded_debug_grammar": True})
     debug_grammar = _create_grammar(dataset, set())
     assert len(debug_grammar.generate(max_num=10)) == 2
@@ -245,7 +245,7 @@ def test_predicate_search_heuristic_base_classes():
         set(), [], {}, [])
     with pytest.raises(NotImplementedError):
         op_learning_score_function.evaluate(set())
-    utils.update_config({"env": "cover", "cover_initial_holding_prob": 0.0})
+    utils.reset_config({"env": "cover", "cover_initial_holding_prob": 0.0})
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
     state = train_tasks[0].init
@@ -280,10 +280,9 @@ def test_predicate_search_heuristic_base_classes():
 def test_prediction_error_score_function():
     """Tests for _PredictionErrorScoreFunction()."""
     # Tests for CoverEnv.
-    utils.update_config({
+    utils.reset_config({
         "env": "cover",
         "offline_data_method": "demo+replay",
-        "seed": 123,
         "num_train_tasks": 5,
         "cover_initial_holding_prob": 0.0,
     })
@@ -313,10 +312,9 @@ def test_prediction_error_score_function():
 
     # Tests for BlocksEnv.
     utils.flush_cache()
-    utils.update_config({
+    utils.reset_config({
         "env": "blocks",
         "offline_data_method": "demo+replay",
-        "seed": 123,
         "num_train_tasks": 5,
     })
     env = BlocksEnv()
@@ -350,10 +348,9 @@ def test_prediction_error_score_function():
 def test_hadd_match_score_function():
     """Tests for _RelaxationHeuristicMatchBasedScoreFunction() with hAdd.."""
     # We know that this score function is bad, and this test shows why.
-    utils.update_config({
+    utils.reset_config({
         "env": "cover",
         "offline_data_method": "demo+replay",
-        "seed": 123,
         "num_train_tasks": 5,
         "cover_initial_holding_prob": 0.0,
     })
@@ -381,12 +378,9 @@ def test_hadd_match_score_function():
 def test_relaxation_energy_score_function():
     """Tests for _RelaxationHeuristicEnergyBasedScoreFunction()."""
     # Tests for CoverEnv.
-    utils.update_config({
+    utils.reset_config({
         "env": "cover",
-    })
-    utils.update_config({
         "offline_data_method": "demo+replay",
-        "seed": 123,
         "num_train_tasks": 5,
         "cover_initial_holding_prob": 0.0,
     })
@@ -443,10 +437,9 @@ def test_relaxation_energy_score_function():
 
     # Tests for BlocksEnv.
     utils.flush_cache()
-    utils.update_config({
+    utils.reset_config({
         "env": "blocks",
         "offline_data_method": "demo+replay",
-        "seed": 123,
         "num_train_tasks": 5,
     })
     env = BlocksEnv()
@@ -499,10 +492,9 @@ def test_relaxation_energy_score_function():
     # Tests for PaintingEnv.
     # Comment out this test because it's flaky.
     # utils.flush_cache()
-    # utils.update_config({
+    # utils.reset_config({
     #     "env": "painting",
     #     "offline_data_method": "demo+replay",
-    #     "seed": 123,
     #     "painting_train_families": ["box_and_shelf"],
     # })
     # env = PaintingEnv()
@@ -573,12 +565,9 @@ def test_exact_energy_score_function():
     # Just test this on BlocksEnv, since that's a known problem case
     # for hadd_energy_lookaheaddepth*.
     utils.flush_cache()
-    utils.update_config({
+    utils.reset_config({
         "env": "blocks",
-    })
-    utils.update_config({
         "offline_data_method": "demo+replay",
-        "seed": 123,
         "num_train_tasks": 2,
     })
     env = BlocksEnv()
@@ -634,12 +623,9 @@ def test_count_score_functions():
     _ExactHeuristicCountBasedScoreFunction."""
 
     utils.flush_cache()
-    utils.update_config({
+    utils.reset_config({
         "env": "cover",
-    })
-    utils.update_config({
         "offline_data_method": "demo+replay",
-        "seed": 123,
         "num_train_tasks": 5,
         "offline_data_num_replays": 50,
         "min_data_for_nsrt": 0,
@@ -682,12 +668,9 @@ def test_branching_factor_score_function():
     """Tests for _BranchingFactorScoreFunction()."""
     # We know that this score function is bad, because it prefers predicates
     # that make segmentation collapse demo actions into one.
-    utils.update_config({
+    utils.reset_config({
         "env": "cover",
-    })
-    utils.update_config({
         "offline_data_method": "demo+replay",
-        "seed": 123,
         "num_train_tasks": 2,
         "offline_data_num_replays": 500,
         "min_data_for_nsrt": 3,
@@ -730,12 +713,9 @@ def test_task_planning_score_function():
     # We know that this score function is bad, because it's way too
     # optimistic: it thinks that any valid sequence of operators can
     # be refined into a plan. This unit test illustrates that pitfall.
-    utils.update_config({
+    utils.reset_config({
         "env": "cover",
-    })
-    utils.update_config({
         "offline_data_method": "demo+replay",
-        "seed": 123,
         "num_train_tasks": 5,
         "cover_initial_holding_prob": 0.0,
     })
@@ -767,25 +747,18 @@ def test_task_planning_score_function():
     assert score_function.evaluate(set()) == len(train_tasks) * 1e7
     assert score_function.evaluate({Holding, HandEmpty}) == \
         2 * CFG.grammar_search_pred_complexity_weight + len(train_tasks) * 1e7
-    # Set this back to avoid screwing up other tests...
-    utils.update_config({
-        "min_data_for_nsrt": 3,
-    })
 
 
 def test_expected_nodes_score_function():
     """Tests for _ExpectedNodesScoreFunction()."""
-    utils.update_config({
-        "env": "cover",
-    })
     # Cover cases where the number of training tasks is less than or greater
     # than the max number of demos.
     max_num_demos = 5
-    utils.update_config({
+    utils.reset_config({
+        "env":
+        "cover",
         "offline_data_method":
         "demo+replay",
-        "seed":
-        123,
         "grammar_search_max_demos":
         max_num_demos,
         "task_planning_heuristic":
@@ -826,12 +799,3 @@ def test_expected_nodes_score_function():
         })
         all_included_s = score_function.evaluate({Holding, HandEmpty})
         assert all_included_s >= ub * min(num_train_tasks, max_num_demos)
-    # Revert, to avoid interfering with other tests.
-    utils.update_config({
-        "min_data_for_nsrt":
-        3,
-        "num_train_tasks":
-        15,
-        "grammar_search_expected_nodes_include_suspicious_score":
-        False,
-    })

--- a/tests/approaches/test_interactive_approach.py
+++ b/tests/approaches/test_interactive_approach.py
@@ -12,14 +12,12 @@ from predicators.src import utils
 
 def test_interactive_learning_approach():
     """Test for InteractiveLearningApproach class, entire pipeline."""
-    utils.update_config({"env": "cover"})
-    utils.update_config({
+    utils.reset_config({
+        "env": "cover",
         "approach": "interactive_learning",
         "offline_data_method": "demo+ground_atoms",
         "excluded_predicates": "IsBlock,Covers",
         "timeout": 10,
-        "max_samples_per_step": 10,
-        "seed": 123,
         "sampler_mlp_classifier_max_itr": 200,
         "predicate_mlp_classifier_max_itr": 200,
         "neural_gaus_regressor_max_itr": 200,

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -15,17 +15,15 @@ def _test_approach(env_name,
                    check_solution=False,
                    sampler_learner="neural",
                    option_learner="no_learning",
-                   learn_side_predicates=False):
+                   learn_side_predicates=False,
+                   additional_settings=None):
     """Integration test for the given approach."""
+    if additional_settings is None:
+        additional_settings = {}
     utils.flush_cache()  # Some extremely nasty bugs arise without this.
-    utils.update_config({
+    utils.reset_config({
         "env": env_name,
         "approach": approach_name,
-        "seed": 123
-    })
-    utils.update_config({
-        "timeout": 10,
-        "max_samples_per_step": 10,
         "neural_gaus_regressor_max_itr": 100,
         "sampler_mlp_classifier_max_itr": 100,
         "predicate_mlp_classifier_max_itr": 100,
@@ -38,6 +36,7 @@ def _test_approach(env_name,
         "option_learner": option_learner,
         "sampler_learner": sampler_learner,
         "cover_initial_holding_prob": 0.0,
+        **additional_settings,
     })
     env = create_env(env_name)
     assert env.goal_predicates.issubset(env.predicates)
@@ -142,7 +141,7 @@ def test_grammar_search_invention_approach():
     Keeping this here because we can't import test files in github
     checks.
     """
-    utils.update_config({
+    additional_settings = {
         "grammar_search_true_pos_weight": 10,
         "grammar_search_false_pos_weight": 1,
         "grammar_search_operator_size_weight": 1e-2,
@@ -150,31 +149,34 @@ def test_grammar_search_invention_approach():
         "grammar_search_predicate_cost_upper_bound": 6,
         "grammar_search_score_function": "prediction_error",
         "grammar_search_search_algorithm": "hill_climbing",
-    })
+    }
     _test_approach(env_name="cover",
                    approach_name="grammar_search_invention",
                    excluded_predicates="Holding",
                    try_solving=False,
-                   sampler_learner="random")
+                   sampler_learner="random",
+                   additional_settings=additional_settings)
     # Test approach with unrecognized search algorithm.
-    utils.update_config({
+    additional_settings = {
         "grammar_search_search_algorithm": "not a real search algorithm",
         "grammar_search_gbfs_num_evals": 10,
-    })
+    }
     with pytest.raises(Exception) as e:
         _test_approach(env_name="cover",
                        approach_name="grammar_search_invention",
                        excluded_predicates="Holding",
                        try_solving=False,
-                       sampler_learner="random")
+                       sampler_learner="random",
+                       additional_settings=additional_settings)
     assert "Unrecognized grammar_search_search_algorithm" in str(e.value)
     # Test approach with gbfs.
-    utils.update_config({
+    additional_settings = {
         "grammar_search_search_algorithm": "gbfs",
         "grammar_search_gbfs_num_evals": 10,
-    })
+    }
     _test_approach(env_name="cover",
                    approach_name="grammar_search_invention",
                    excluded_predicates="Holding",
                    try_solving=False,
-                   sampler_learner="random")
+                   sampler_learner="random",
+                   additional_settings=additional_settings)

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -15,8 +15,11 @@ from predicators.src import utils
 
 def test_cover_get_gt_nsrts():
     """Tests for get_gt_nsrts in CoverEnv."""
-    utils.update_config({"env": "cover"})
-    utils.update_config({"num_train_tasks": 5, "num_test_tasks": 5})
+    utils.reset_config({
+        "env": "cover",
+        "num_train_tasks": 5,
+        "num_test_tasks": 5
+    })
     # All predicates and options
     env = CoverEnv()
     nsrts = get_gt_nsrts(env.predicates, env.options)
@@ -56,7 +59,7 @@ def test_cover_get_gt_nsrts():
 
 def test_get_gt_nsrts():
     """Test get_gt_nsrts alone."""
-    utils.update_config({"env": "not a real environment"})
+    utils.reset_config({"env": "not a real environment"})
     with pytest.raises(NotImplementedError):
         get_gt_nsrts(set(), set())
 
@@ -96,15 +99,18 @@ def test_check_nsrt_parameters():
         "repeated_nextto": RepeatedNextToEnv()
     }
     for name, env in envs.items():
-        utils.update_config({"env": name})
+        utils.reset_config({"env": name})
         nsrts = get_gt_nsrts(env.predicates, env.options)
         _check_nsrt_parameters(nsrts)
 
 
 def test_oracle_approach_cover():
     """Tests for OracleApproach class with CoverEnv."""
-    utils.update_config({"env": "cover"})
-    utils.update_config({"num_train_tasks": 5, "num_test_tasks": 5})
+    utils.reset_config({
+        "env": "cover",
+        "num_train_tasks": 5,
+        "num_test_tasks": 5
+    })
     env = CoverEnv()
     env.seed(123)
     train_tasks = env.get_train_tasks()
@@ -129,8 +135,11 @@ def test_oracle_approach_cover():
 
 def test_oracle_approach_cover_typed_options():
     """Tests for OracleApproach class with CoverEnvTypedOptions."""
-    utils.update_config({"env": "cover_typed_options"})
-    utils.update_config({"num_train_tasks": 5, "num_test_tasks": 5})
+    utils.reset_config({
+        "env": "cover_typed_options",
+        "num_train_tasks": 5,
+        "num_test_tasks": 5
+    })
     env = CoverEnvTypedOptions()
     env.seed(123)
     train_tasks = env.get_train_tasks()
@@ -155,8 +164,11 @@ def test_oracle_approach_cover_typed_options():
 
 def test_oracle_approach_cover_hierarchical_types():
     """Tests for OracleApproach class with CoverEnvHierarchicalTypes."""
-    utils.update_config({"env": "cover_hierarchical_types"})
-    utils.update_config({"num_train_tasks": 5, "num_test_tasks": 5})
+    utils.reset_config({
+        "env": "cover_hierarchical_types",
+        "num_train_tasks": 5,
+        "num_test_tasks": 5
+    })
     env = CoverEnvHierarchicalTypes()
     env.seed(123)
     train_tasks = env.get_train_tasks()
@@ -181,8 +193,8 @@ def test_oracle_approach_cover_hierarchical_types():
 
 def test_oracle_approach_cover_multistep_options():
     """Tests for OracleApproach class with CoverMultistepOptions."""
-    utils.update_config({"env": "cover_multistep_options"})
-    utils.update_config({
+    utils.reset_config({
+        "env": "cover_multistep_options",
         "cover_multistep_use_learned_equivalents": False,
         "cover_multistep_degenerate_oracle_samplers": False,
         "num_train_tasks": 5,
@@ -208,8 +220,8 @@ def test_oracle_approach_cover_multistep_options():
         # Test that a repeated random action fails.
         assert not utils.policy_solves_task(lambda s: random_action, task,
                                             env.simulate)
-    utils.update_config({"env": "cover_multistep_options"})
-    utils.update_config({
+    utils.reset_config({
+        "env": "cover_multistep_options",
         "cover_multistep_use_learned_equivalents": True,
         "cover_multistep_degenerate_oracle_samplers": False,
         "sampler_learner": "neural",
@@ -230,8 +242,7 @@ def test_oracle_approach_cover_multistep_options():
     for task in env.get_test_tasks():
         policy = approach.solve(task, timeout=500)
         assert utils.policy_solves_task(policy, task, env.simulate)
-        # Test cover_multistep_degenerate_oracle_samplers.
-        utils.update_config({"env": "cover_multistep_options"})
+    # Test cover_multistep_degenerate_oracle_samplers.
     utils.update_config({
         "cover_multistep_use_learned_equivalents": False,
         "cover_multistep_degenerate_oracle_samplers": True,
@@ -262,8 +273,8 @@ def test_oracle_approach_cover_multistep_options():
 
 def test_oracle_approach_cover_multistep_options_fixed_tasks():
     """Tests for OracleApproach class with CoverMultistepOptionsFixedTasks."""
-    utils.update_config({"env": "cover_multistep_options_fixed_tasks"})
-    utils.update_config({
+    utils.reset_config({
+        "env": "cover_multistep_options_fixed_tasks",
         "cover_multistep_use_learned_equivalents": True,
         "num_train_tasks": 5,
         "num_test_tasks": 5
@@ -293,7 +304,7 @@ def test_oracle_approach_cover_multistep_options_fixed_tasks():
 def test_cluttered_table_get_gt_nsrts(place_version=False):
     """Tests for get_gt_nsrts in ClutteredTableEnv."""
     if not place_version:
-        utils.update_config({
+        utils.reset_config({
             "env": "cluttered_table",
             "num_train_tasks": 5,
             "num_test_tasks": 5
@@ -301,7 +312,7 @@ def test_cluttered_table_get_gt_nsrts(place_version=False):
         # All predicates and options
         env = ClutteredTableEnv()
     else:
-        utils.update_config({
+        utils.reset_config({
             "env": "cluttered_table_place",
             "num_train_tasks": 5,
             "num_test_tasks": 5
@@ -363,10 +374,10 @@ def test_cluttered_table_place_get_gt_nsrts():
 def test_oracle_approach_cluttered_table(place_version=False):
     """Tests for OracleApproach class with ClutteredTableEnv."""
     if not place_version:
-        utils.update_config({"env": "cluttered_table"})
+        utils.reset_config({"env": "cluttered_table"})
         env = ClutteredTableEnv()
     else:
-        utils.update_config({
+        utils.reset_config({
             "env": "cluttered_table_place",
             "cluttered_table_num_cans_train": 3,
             "cluttered_table_num_cans_test": 3,
@@ -386,11 +397,6 @@ def test_oracle_approach_cluttered_table(place_version=False):
     for test_task in env.get_test_tasks()[:5]:
         policy = approach.solve(test_task, timeout=500)
         assert utils.policy_solves_task(policy, test_task, env.simulate)
-    # Reset can settings here so other tests use the defaults
-    utils.update_config({
-        "cluttered_table_num_cans_train": 5,
-        "cluttered_table_num_cans_test": 10,
-    })
 
 
 def test_oracle_approach_cluttered_table_place():
@@ -400,7 +406,7 @@ def test_oracle_approach_cluttered_table_place():
 
 def test_oracle_approach_blocks():
     """Tests for OracleApproach class with BlocksEnv."""
-    utils.update_config({
+    utils.reset_config({
         "env": "blocks",
         "num_train_tasks": 5,
         "num_test_tasks": 5
@@ -424,7 +430,7 @@ def test_oracle_approach_blocks():
 
 def test_oracle_approach_painting():
     """Tests for OracleApproach class with PaintingEnv."""
-    utils.update_config({
+    utils.reset_config({
         "env": "painting",
         "num_train_tasks": 5,
         "num_test_tasks": 5
@@ -446,7 +452,7 @@ def test_oracle_approach_painting():
 
 def test_oracle_approach_playroom():
     """Tests for OracleApproach class with PlayroomEnv."""
-    utils.update_config({
+    utils.reset_config({
         "env": "playroom",
         "num_train_tasks": 5,
         "num_test_tasks": 5
@@ -515,7 +521,7 @@ def test_oracle_approach_playroom():
 
 def test_oracle_approach_repeated_nextto():
     """Tests for OracleApproach class with RepeatedNextToEnv."""
-    utils.update_config({
+    utils.reset_config({
         "env": "repeated_nextto",
         "num_train_tasks": 5,
         "num_test_tasks": 5

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -244,7 +244,8 @@ def test_oracle_approach_cover_multistep_options():
         assert utils.policy_solves_task(policy, task, env.simulate)
     # Test cover_multistep_degenerate_oracle_samplers.
     utils.update_config({
-        "cover_multistep_use_learned_equivalents": False,
+        "env": "cover_multistep_options",
+        "cover_multistep_use_learned_equivalents": True,
         "cover_multistep_degenerate_oracle_samplers": True,
         "num_train_tasks": 5,
         "num_test_tasks": 5,

--- a/tests/approaches/test_random_actions_approach.py
+++ b/tests/approaches/test_random_actions_approach.py
@@ -7,10 +7,9 @@ from predicators.src import utils
 
 def test_random_actions_approach():
     """Tests for RandomActionsApproach class."""
-    utils.update_config({
+    utils.reset_config({
         "env": "cover",
         "approach": "random_actions",
-        "seed": 123
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()

--- a/tests/approaches/test_random_options_approach.py
+++ b/tests/approaches/test_random_options_approach.py
@@ -9,7 +9,7 @@ from predicators.src import utils
 
 def test_random_options_approach():
     """Tests for RandomOptionsApproach class."""
-    utils.update_config({"env": "cover"})
+    utils.reset_config({"env": "cover"})
     cup_type = Type("cup_type", ["feat1"])
     cup = cup_type("cup")
     state = State({cup: [0.5]})

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -13,17 +13,12 @@ def test_demo_dataset():
     """Test demo-only dataset creation with Covers env."""
     # Test that data does not contain options since
     # option_learner is not "no_learning"
-    utils.update_config({
-        "env": "cover",
-        "approach": "random_actions",
-    })
-    utils.update_config({
+    utils.reset_config({
         "env": "cover",
         "approach": "random_actions",
         "offline_data_method": "demo",
         "offline_data_planning_timeout": 500,
         "option_learner": "arbitrary_dummy",
-        "seed": 123,
         "num_train_tasks": 7,
     })
     env = CoverEnv()
@@ -37,13 +32,12 @@ def test_demo_dataset():
         for action in traj.actions:
             assert not action.has_option()
     # Test that data contains options since option_learner is "no_learning"
-    utils.update_config({
+    utils.reset_config({
         "env": "cover",
         "approach": "random_actions",
         "offline_data_method": "demo",
         "offline_data_planning_timeout": 500,
         "option_learner": "no_learning",
-        "seed": 123,
         "num_train_tasks": 7,
     })
     env = CoverEnv()
@@ -69,14 +63,13 @@ def test_demo_replay_dataset():
     """Test demo+replay dataset creation with Covers env."""
     # Test that data contains options since
     # option_learner is "no_learning"
-    utils.update_config({
+    utils.reset_config({
         "env": "cover",
         "approach": "random_actions",
         "offline_data_method": "demo+replay",
         "offline_data_planning_timeout": 500,
         "offline_data_num_replays": 3,
         "option_learner": "no_learning",
-        "seed": 123,
         "num_train_tasks": 5,
     })
     env = CoverEnv()
@@ -93,14 +86,13 @@ def test_demo_replay_dataset():
     assert num_demos == 5
     # Test that data does not contain options since
     # option_learner is not "no_learning"
-    utils.update_config({
+    utils.reset_config({
         "env": "cover",
         "approach": "random_actions",
         "offline_data_method": "demo+replay",
         "offline_data_planning_timeout": 500,
         "offline_data_num_replays": 3,
         "option_learner": "arbitrary_dummy",
-        "seed": 123,
         "num_train_tasks": 5,
     })
     env = CoverEnv()
@@ -116,13 +108,12 @@ def test_demo_replay_dataset():
             assert not action.has_option()
     assert num_demos == 5
     # Test cluttered table data collection
-    utils.update_config({
+    utils.reset_config({
         "env": "cluttered_table",
         "approach": "random_actions",
         "offline_data_method": "demo+replay",
         "offline_data_planning_timeout": 500,
         "offline_data_num_replays": 10,
-        "seed": 123,
         "num_train_tasks": 5,
     })
     env = ClutteredTableEnv()
@@ -138,14 +129,13 @@ def test_demo_nonoptimal_replay_dataset():
     # cover some failures to plan from the replays, but not so low that
     # planning always fails. Also the number of replays is set high enough
     # that we consistently cover the failure case.
-    utils.update_config({
+    utils.reset_config({
         "env": "cover",
         "approach": "random_actions",
         "offline_data_method": "demo+nonoptimalreplay",
         "offline_data_planning_timeout": 1e-1,
         "offline_data_num_replays": 50,
         "option_learner": "no_learning",
-        "seed": 123,
         "num_train_tasks": 5,
     })
     env = CoverEnv()
@@ -158,14 +148,13 @@ def test_demo_nonoptimal_replay_dataset():
 
 def test_dataset_with_annotations():
     """Test the creation of a Dataset with annotations."""
-    utils.update_config({
+    utils.reset_config({
         "env": "cover",
         "approach": "random_actions",
         "offline_data_method": "demo+replay",
         "offline_data_planning_timeout": 500,
         "offline_data_num_replays": 3,
         "option_learner": "no_learning",
-        "seed": 123,
         "num_train_tasks": 5,
     })
     env = CoverEnv()
@@ -187,8 +176,8 @@ def test_dataset_with_annotations():
 
 def test_ground_atom_dataset():
     """Test creation of demo+ground_atoms dataset."""
-    utils.update_config({"env": "cover"})
-    utils.update_config({
+    utils.reset_config({
+        "env": "cover",
         "approach": "interactive_learning",
         "num_train_tasks": 15,
         "offline_data_method": "demo+ground_atoms",

--- a/tests/envs/test_base_env.py
+++ b/tests/envs/test_base_env.py
@@ -7,7 +7,7 @@ from predicators.src import utils
 
 def test_create_env():
     """Tests for create_env() and get_cached_env_instance()."""
-    utils.reset_config({})
+    utils.reset_config()
     for name in [
             "cover",
             "cover_typed_options",

--- a/tests/envs/test_base_env.py
+++ b/tests/envs/test_base_env.py
@@ -7,7 +7,7 @@ from predicators.src import utils
 
 def test_create_env():
     """Tests for create_env() and get_cached_env_instance()."""
-    utils.update_config({"seed": 123})
+    utils.reset_config({})
     for name in [
             "cover",
             "cover_typed_options",

--- a/tests/envs/test_blocks.py
+++ b/tests/envs/test_blocks.py
@@ -7,7 +7,7 @@ from predicators.src import utils
 
 def test_blocks():
     """Tests for BlocksEnv class."""
-    utils.update_config({"env": "blocks"})
+    utils.reset_config({"env": "blocks"})
     env = BlocksEnv()
     env.seed(123)
     clear = env._block_is_clear  # pylint: disable=protected-access
@@ -51,7 +51,7 @@ def test_blocks():
 
 def test_blocks_failure_cases():
     """Tests for the cases where simulate() is a no-op."""
-    utils.update_config({"env": "blocks"})
+    utils.reset_config({"env": "blocks"})
     env = BlocksEnv()
     env.seed(123)
     Pick = [o for o in env.options if o.name == "Pick"][0]

--- a/tests/envs/test_cluttered_table.py
+++ b/tests/envs/test_cluttered_table.py
@@ -10,10 +10,10 @@ from predicators.src.structs import Action, GroundAtom
 def test_cluttered_table(place_version=False):
     """Tests for ClutteredTableEnv class."""
     if not place_version:
-        utils.update_config({"env": "cluttered_table"})
+        utils.reset_config({"env": "cluttered_table"})
         env = ClutteredTableEnv()
     else:
-        utils.update_config({"env": "cluttered_table_place"})
+        utils.reset_config({"env": "cluttered_table_place"})
         env = ClutteredTablePlaceEnv()
     env.seed(123)
     for task in env.get_train_tasks():

--- a/tests/envs/test_cover.py
+++ b/tests/envs/test_cover.py
@@ -10,7 +10,7 @@ from predicators.src import utils
 
 def test_cover():
     """Tests for CoverEnv class."""
-    utils.update_config({"env": "cover", "cover_initial_holding_prob": 0.0})
+    utils.reset_config({"env": "cover", "cover_initial_holding_prob": 0.0})
     env = CoverEnv()
     env.seed(123)
     for task in env.get_train_tasks():
@@ -103,13 +103,11 @@ def test_cover():
             assert sum(
                 task.init.get(obj, "grasp") != -1 for obj in task.init
                 if obj.type.name == "block") == 1
-    # Revert to 0.0 for other tests.
-    utils.update_config({"cover_initial_holding_prob": 0.0})
 
 
 def test_cover_typed_options():
     """Tests for CoverEnvTypedOptions class."""
-    utils.update_config({"env": "cover", "cover_initial_holding_prob": 0.0})
+    utils.reset_config({"env": "cover", "cover_initial_holding_prob": 0.0})
     env = CoverEnvTypedOptions()
     env.seed(123)
     for task in env.get_train_tasks():
@@ -183,7 +181,7 @@ def test_cover_typed_options():
 
 def test_cover_multistep_options():
     """Tests for CoverMultistepOptions."""
-    utils.update_config({
+    utils.reset_config({
         "env": "cover_multistep_options",
         "num_train_tasks": 10,
         "num_test_tasks": 10
@@ -487,7 +485,7 @@ def test_cover_multistep_options():
 
 def test_cover_multistep_options_fixed_tasks():
     """Tests for CoverMultistepOptionsFixedTasks."""
-    utils.update_config({
+    utils.reset_config({
         "env": "cover_multistep_options_fixed_tasks",
         "num_train_tasks": 10,
         "num_test_tasks": 10

--- a/tests/envs/test_painting.py
+++ b/tests/envs/test_painting.py
@@ -8,7 +8,7 @@ from predicators.src import utils
 
 def test_painting():
     """Tests for PaintingEnv class."""
-    utils.update_config({
+    utils.reset_config({
         "env": "painting",
     })
     env = PaintingEnv()
@@ -62,10 +62,9 @@ def test_painting():
 def test_painting_failure_cases():
     """Tests for the cases where simulate() is a no-op or
     EnvironmentFailure."""
-    utils.update_config({
+    utils.reset_config({
         "env": "painting",
         "approach": "nsrt_learning",
-        "seed": 123,
         "painting_initial_holding_prob": 1.0,
         "painting_lid_open_prob": 0.0,
     })

--- a/tests/envs/test_playroom.py
+++ b/tests/envs/test_playroom.py
@@ -12,7 +12,7 @@ from predicators.src.structs import Action, State
 
 def test_playroom():
     """Tests for PlayroomEnv class properties."""
-    utils.update_config({"env": "playroom"})
+    utils.reset_config({"env": "playroom"})
     env = PlayroomEnv()
     env.seed(123)
     for task in env.get_train_tasks():
@@ -39,7 +39,7 @@ def test_playroom():
 
 def test_playroom_failure_cases():
     """Tests for the cases where simulate() is a no-op."""
-    utils.update_config({"env": "playroom"})
+    utils.reset_config({"env": "playroom"})
     env = PlayroomEnv()
     env.seed(123)
     On = [o for o in env.predicates if o.name == "On"][0]
@@ -139,7 +139,7 @@ def test_playroom_failure_cases():
 def test_playroom_simulate_blocks():
     """Tests for the cases where simulate() allows the robot to interact with
     blocks."""
-    utils.update_config({"env": "playroom"})
+    utils.reset_config({"env": "playroom"})
     env = PlayroomEnv()
     env.seed(123)
     block_type = [t for t in env.types if t.name == "block"][0]
@@ -192,7 +192,7 @@ def test_playroom_simulate_blocks():
 def test_playroom_simulate_doors_and_dial():
     """Tests for the cases where simulate() allows the robot to interact with
     doors and the dial."""
-    utils.update_config({"env": "playroom"})
+    utils.reset_config({"env": "playroom"})
     env = PlayroomEnv()
     env.seed(123)
     door_type = [t for t in env.types if t.name == "door"][0]
@@ -306,7 +306,7 @@ def test_playroom_simulate_doors_and_dial():
 
 def test_playroom_options():
     """Tests for predicate option policies."""
-    utils.update_config({"env": "playroom"})
+    utils.reset_config({"env": "playroom"})
     env = PlayroomEnv()
     env.seed(123)
     robot_type = [t for t in env.types if t.name == "robot"][0]
@@ -394,7 +394,7 @@ def test_playroom_options():
 
 def test_playroom_action_sequence_video():
     """Test to sanity check rendering."""
-    utils.update_config({"env": "playroom"})
+    utils.reset_config({"env": "playroom"})
     env = PlayroomEnv()
     env.seed(123)
     # Run through a specific plan of low-level actions.

--- a/tests/envs/test_repeated_nextto.py
+++ b/tests/envs/test_repeated_nextto.py
@@ -8,10 +8,9 @@ from predicators.src import utils
 
 def test_repeated_nextto():
     """Tests for RepeatedNextTo class."""
-    utils.update_config({"env": "repeated_nextto", "seed": 123})
+    utils.reset_config({"env": "repeated_nextto"})
     env = RepeatedNextToEnv()
     env.seed(123)
-    utils.update_config({"env": "repeated_nextto"})
     for task in env.get_train_tasks():
         for obj in task.init:
             assert len(obj.type.feature_names) == len(task.init[obj])
@@ -47,10 +46,9 @@ def test_repeated_nextto():
 
 def test_repeated_nextto_simulate():
     """Tests for the simulate() function."""
-    utils.update_config({
+    utils.reset_config({
         "env": "repeated_nextto",
         "approach": "nsrt_learning",
-        "seed": 123
     })
     env = RepeatedNextToEnv()
     env.seed(123)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -111,10 +111,9 @@ def test_main():
 
 def test_tamp_approach_failure():
     """Test coverage for ApproachFailure in run_testing()."""
-    utils.update_config({
+    utils.reset_config({
         "env": "cover",
         "approach": "nsrt_learning",
-        "seed": 123,
         "timeout": 10,
         "make_videos": False,
     })
@@ -130,10 +129,9 @@ def test_tamp_approach_failure():
 
 def test_env_failure():
     """Test coverage for EnvironmentFailure in run_testing()."""
-    utils.update_config({
+    utils.reset_config({
         "env": "cover",
         "approach": "random_actions",
-        "seed": 123,
         "timeout": 10,
         "make_videos": False,
         "cover_initial_holding_prob": 0.0,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -57,7 +57,7 @@ def test_neural_gaussian_regressor():
 
 def test_mlp_classifier():
     """Tests for MLPClassifier."""
-    utils.reset_config({})
+    utils.reset_config()
     input_size = 3
     num_class_samples = 5
     X = np.concatenate([

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,8 +9,7 @@ from predicators.src import utils
 
 def test_basic_mlp_regressor():
     """Tests for MLPRegressor."""
-    utils.update_config({
-        "seed": 123,
+    utils.reset_config({
         "mlp_regressor_max_itr": 100,
         "mlp_regressor_clip_gradients": True
     })
@@ -38,7 +37,7 @@ def test_basic_mlp_regressor():
 
 def test_neural_gaussian_regressor():
     """Tests for NeuralGaussianRegressor."""
-    utils.update_config({"seed": 123, "neural_gaus_regressor_max_itr": 100})
+    utils.reset_config({"neural_gaus_regressor_max_itr": 100})
     input_size = 3
     output_size = 2
     num_samples = 5
@@ -58,7 +57,7 @@ def test_neural_gaussian_regressor():
 
 def test_mlp_classifier():
     """Tests for MLPClassifier."""
-    utils.update_config({"seed": 123})
+    utils.reset_config({})
     input_size = 3
     num_class_samples = 5
     X = np.concatenate([
@@ -76,7 +75,7 @@ def test_mlp_classifier():
     assert prediction
     # Test for early stopping
     start_time = time.time()
-    utils.update_config({
+    utils.reset_config({
         "mlp_classifier_n_iter_no_change": 1,
         "learning_rate": 1e-2
     })

--- a/tests/test_nsrt_learning.py
+++ b/tests/test_nsrt_learning.py
@@ -272,5 +272,5 @@ def test_nsrt_learning_specific_nsrts():
     for nsrt in nsrts:
         for _ in range(10):
             sampled_params = nsrt.ground([cup0, cup1]).sample_option(
-                    state1, np.random.default_rng(123)).params
+                state1, np.random.default_rng(123)).params
             assert option1.parent.params_space.contains(sampled_params)

--- a/tests/test_nsrt_learning.py
+++ b/tests/test_nsrt_learning.py
@@ -75,7 +75,7 @@ def test_segment_trajectory():
 
 def test_learn_strips_operators():
     """Tests for learn_strips_operators()."""
-    utils.update_config({"min_data_for_nsrt": 0})
+    utils.reset_config({"min_data_for_nsrt": 0})
     known_option_segments, unknown_option_segments = test_segment_trajectory()
     known_option_pnads = learn_strips_operators(known_option_segments)
     known_option_ops = [pnad.op for pnad in known_option_pnads]
@@ -99,9 +99,8 @@ def test_learn_strips_operators():
 
 def test_nsrt_learning_specific_nsrts():
     """Tests with a specific desired set of NSRTs."""
-    utils.update_config({
+    utils.reset_config({
         "min_data_for_nsrt": 0,
-        "seed": 123,
         "sampler_mlp_classifier_max_itr": 1000,
         "neural_gaus_regressor_max_itr": 1000
     })
@@ -265,7 +264,6 @@ def test_nsrt_learning_specific_nsrts():
     utils.update_config({
         "min_data_for_nsrt": 0,
         "max_rejection_sampling_tries": 0,
-        "seed": 1234,
         "sampler_mlp_classifier_max_itr": 1,
         "neural_gaus_regressor_max_itr": 1
     })

--- a/tests/test_nsrt_learning.py
+++ b/tests/test_nsrt_learning.py
@@ -178,7 +178,7 @@ def test_nsrt_learning_specific_nsrts():
     preds = {pred0}
     state1 = State({cup0: [0.4], cup1: [0.8], cup2: [0.1]})
     option1 = ParameterizedOption(
-        "dummy", [], Box(0.1, 1, (1, )), lambda s, m, o, p: Action(p),
+        "dummy", [], Box(0.1, 0.5, (1, )), lambda s, m, o, p: Action(p),
         utils.always_initiable, utils.onestep_terminal).ground([],
                                                                np.array([0.3]))
     action1 = option1.policy(state1)
@@ -186,9 +186,9 @@ def test_nsrt_learning_specific_nsrts():
     next_state1 = State({cup0: [0.9], cup1: [0.2], cup2: [0.5]})
     state2 = State({cup4: [0.9], cup5: [0.2], cup2: [0.5], cup3: [0.5]})
     option2 = ParameterizedOption(
-        "dummy", [], Box(0.1, 1, (1, )), lambda s, m, o, p: Action(p),
+        "dummy", [], Box(0.1, 0.5, (1, )), lambda s, m, o, p: Action(p),
         utils.always_initiable, utils.onestep_terminal).ground([],
-                                                               np.array([0.7]))
+                                                               np.array([0.5]))
     action2 = option2.policy(state2)
     action2.set_option(option2)
     next_state2 = State({cup4: [0.5], cup5: [0.5], cup2: [1.0], cup3: [0.1]})
@@ -271,6 +271,6 @@ def test_nsrt_learning_specific_nsrts():
     assert len(nsrts) == 2
     for nsrt in nsrts:
         for _ in range(10):
-            assert option1.parent.params_space.contains(
-                nsrt.ground([cup0, cup1]).sample_option(
-                    state1, np.random.default_rng(123)).params)
+            sampled_params = nsrt.ground([cup0, cup1]).sample_option(
+                    state1, np.random.default_rng(123)).params
+            assert option1.parent.params_space.contains(sampled_params)

--- a/tests/test_online_learning.py
+++ b/tests/test_online_learning.py
@@ -74,16 +74,11 @@ class _MockApproach(BaseApproach):
 def test_interaction():
     """Tests for sending InteractionRequest objects to main.py and receiving
     InteractionResult objects in return."""
-    utils.update_config({
+    utils.reset_config({
         "env": "cover",
         "cover_initial_holding_prob": 0.0,
         "approach": "unittest",
-        "excluded_predicates": "",
-        "experiment_id": "",
-        "load_data": False,
-        "load_approach": False,
         "timeout": 1,
-        "make_videos": False,
         "num_train_tasks": 2,
         "num_test_tasks": 1,
         "num_online_learning_cycles": 1

--- a/tests/test_option_learning.py
+++ b/tests/test_option_learning.py
@@ -17,15 +17,9 @@ from predicators.src import utils
 
 def test_known_options_option_learner():
     """Tests for _KnownOptionsOptionLearner."""
-    utils.update_config({
+    utils.reset_config({
         "env": "cover",
         "approach": "nsrt_learning",
-        "seed": 123
-    })
-    utils.update_config({
-        "env": "cover",
-        "approach": "nsrt_learning",
-        "seed": 123,
         "num_train_tasks": 3,
         "option_learner": "no_learning"
     })
@@ -58,26 +52,13 @@ def test_known_options_option_learner():
             option_learner.update_segment_from_option_spec(segment, spec)
             assert segment.has_option()
             assert segment.get_option() == option
-    # Reset configuration.
-    utils.update_config({
-        "env": "cover",
-        "approach": "nsrt_learning",
-        "seed": 123,
-        "option_learner": "no_learning"
-    })
 
 
 def test_oracle_option_learner_cover():
     """Tests for _OracleOptionLearner for the cover environment."""
-    utils.update_config({
+    utils.reset_config({
         "env": "cover",
         "approach": "nsrt_learning",
-        "seed": 123
-    })
-    utils.update_config({
-        "env": "cover",
-        "approach": "nsrt_learning",
-        "seed": 123,
         "num_train_tasks": 3,
         "option_learner": "oracle"
     })
@@ -112,23 +93,11 @@ def test_oracle_option_learner_cover():
             # In cover env, param == action array.
             assert option.parent == PickPlace
             assert np.allclose(option.params, segment.actions[0].arr)
-    # Reset configuration.
-    utils.update_config({
-        "env": "cover",
-        "approach": "nsrt_learning",
-        "seed": 123,
-        "option_learner": "no_learning"
-    })
 
 
 def test_oracle_option_learner_blocks():
     """Tests for _OracleOptionLearner for the blocks environment."""
-    utils.update_config({
-        "env": "blocks",
-        "approach": "nsrt_learning",
-        "seed": 123
-    })
-    utils.update_config({
+    utils.reset_config({
         "env": "blocks",
         "approach": "nsrt_learning",
         "seed": 123,
@@ -172,19 +141,12 @@ def test_oracle_option_learner_blocks():
             option = segment.get_option()
             assert option.parent in (Pick, Stack, PutOnTable)
             assert [obj.type for obj in option.objects] == option.parent.types
-    # Reset configuration.
-    utils.update_config({
-        "env": "blocks",
-        "approach": "nsrt_learning",
-        "seed": 123,
-        "option_learner": "no_learning"
-    })
 
 
 def test_learned_neural_parameterized_option():
     """Tests for _LearnedNeuralParameterizedOption()."""
     # Create a _LearnedNeuralParameterizedOption() for the cover Pick operator.
-    utils.update_config({
+    utils.reset_config({
         "env": "cover_multistep_options",
         "option_learner": "neural",
         "mlp_regressor_max_itr": 10,
@@ -252,24 +214,11 @@ def test_learned_neural_parameterized_option():
 
 def test_create_option_learner():
     """Tests for create_option_learner()."""
-    utils.update_config({
-        "env": "not a real env",
-        "approach": "nsrt_learning",
-        "seed": 123
-    })
-    utils.update_config({
+    utils.reset_config({
         "env": "blocks",
         "approach": "nsrt_learning",
-        "seed": 123,
         "num_train_tasks": 3,
         "option_learner": "not a real option learner"
     })
     with pytest.raises(NotImplementedError):
         create_option_learner()
-    # Reset configuration.
-    utils.update_config({
-        "env": "blocks",
-        "approach": "nsrt_learning",
-        "seed": 123,
-        "option_learner": "no_learning"
-    })

--- a/tests/test_option_model.py
+++ b/tests/test_option_model.py
@@ -9,7 +9,7 @@ from predicators.src import utils
 
 def test_default_option_model():
     """Tests for the default option model."""
-    utils.update_config({"env": "cover"})
+    utils.reset_config({"env": "cover"})
     type1 = Type("type1", ["feat1", "feat2"])
     type2 = Type("type2", ["feat3", "feat4", "feat5"])
     obj3 = type1("obj3")
@@ -72,10 +72,9 @@ def test_default_option_model():
 
 def test_option_model_notimplemented():
     """Tests for various NotImplementedErrors."""
-    utils.update_config({
+    utils.reset_config({
         "env": "cover",
         "approach": "nsrt_learning",
-        "seed": 123
     })
     with pytest.raises(NotImplementedError):
         create_option_model("not a real option model")

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -16,7 +16,7 @@ from predicators.src.option_model import create_option_model
 
 def test_sesame_plan():
     """Tests for sesame_plan()."""
-    utils.update_config({"env": "cover"})
+    utils.reset_config({"env": "cover"})
     env = CoverEnv()
     nsrts = get_gt_nsrts(env.predicates, env.options)
     task = env.get_train_tasks()[0]
@@ -35,7 +35,7 @@ def test_sesame_plan():
 
 def test_task_plan():
     """Tests for task_plan()."""
-    utils.update_config({
+    utils.reset_config({
         "env": "cover",
         "max_skeletons_optimized": 3,
     })
@@ -90,7 +90,7 @@ def test_task_plan():
 def test_sesame_plan_failures():
     """Tests for failures in the planner using the OracleApproach on
     CoverEnv."""
-    utils.update_config({"env": "cover"})
+    utils.reset_config({"env": "cover"})
     env = CoverEnv()
     env.seed(123)
     train_tasks = env.get_train_tasks()
@@ -152,7 +152,7 @@ def test_sesame_plan_uninitiable_option():
     """Tests planning in the presence of an option whose initiation set is
     nontrivial."""
     # pylint: disable=protected-access
-    utils.update_config({"env": "cover"})
+    utils.reset_config({"env": "cover"})
     env = CoverEnv()
     env.seed(123)
     option_model = create_option_model(CFG.option_model_name)
@@ -185,7 +185,7 @@ def test_sesame_plan_uninitiable_option():
 def test_planning_determinism():
     """Tests that planning is deterministic when there are multiple ways of
     achieving a goal."""
-    utils.update_config({"env": "cover"})
+    utils.reset_config({"env": "cover"})
     robot_type = Type("robot_type", ["asleep", "cried"])
     robot_var = robot_type("?robot")
     robby = robot_type("robby")

--- a/tests/test_sampler_learning.py
+++ b/tests/test_sampler_learning.py
@@ -12,10 +12,9 @@ from predicators.src import utils
 
 def test_create_sampler_data():
     """Tests for _create_sampler_data()."""
-    utils.update_config({"env": "cover"})
-    utils.update_config({
+    utils.reset_config({
+        "env": "cover",
         "min_data_for_nsrt": 0,
-        "seed": 123,
         "num_train_tasks": 15,
     })
     # Create two datastores

--- a/tests/test_teacher.py
+++ b/tests/test_teacher.py
@@ -10,7 +10,7 @@ from predicators.src import utils
 
 def test_GroundAtomsHold():
     """Tests for answering queries of type GroundAtomsHoldQuery."""
-    utils.update_config({"env": "cover", "approach": "unittest"})
+    utils.reset_config({"env": "cover", "approach": "unittest"})
     teacher = Teacher()
     env = create_env("cover")
     state = env.get_train_tasks()[0].init

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -126,7 +126,7 @@ def test_overlap():
 
 def test_get_static_preds():
     """Tests for get_static_preds()."""
-    utils.update_config({"env": "cover"})
+    utils.reset_config({"env": "cover"})
     env = CoverEnv()
     nsrts = get_gt_nsrts(env.predicates, env.options)
     static_preds = utils.get_static_preds(nsrts, env.predicates)
@@ -135,7 +135,7 @@ def test_get_static_preds():
 
 def test_get_static_atoms():
     """Tests for get_static_atoms()."""
-    utils.update_config({"env": "cover"})
+    utils.reset_config({"env": "cover"})
     env = CoverEnv()
     nsrts = get_gt_nsrts(env.predicates, env.options)
     task = env.get_train_tasks()[0]
@@ -1340,7 +1340,7 @@ def test_create_task_planning_heuristic():
 
 def test_create_pddl():
     """Tests for create_pddl_domain() and create_pddl_problem()."""
-    utils.update_config({"env": "cover"})
+    utils.reset_config({"env": "cover"})
     # All predicates and options
     env = CoverEnv()
     nsrts = get_gt_nsrts(env.predicates, env.options)
@@ -1409,7 +1409,7 @@ def test_save_video():
     """Tests for save_video()."""
     dirname = "_fake_tmp_video_dir"
     filename = "video.mp4"
-    utils.update_config({"video_dir": dirname})
+    utils.reset_config({"video_dir": dirname})
     rng = np.random.default_rng(123)
     video = [rng.integers(255, size=(3, 3), dtype=np.uint8) for _ in range(3)]
     utils.save_video(filename, video)
@@ -1419,7 +1419,7 @@ def test_save_video():
 
 def test_get_config_path_str():
     """Tests for get_config_path_str()."""
-    utils.update_config({
+    utils.reset_config({
         "env": "dummyenv",
         "approach": "dummyapproach",
         "seed": 321,
@@ -1434,7 +1434,7 @@ def test_get_approach_save_path_str():
     """Tests for get_approach_save_path_str()."""
     dirname = "_fake_tmp_approach_dir"
     old_approach_dir = CFG.approach_dir
-    utils.update_config({
+    utils.reset_config({
         "env": "test_env",
         "approach": "test_approach",
         "seed": 123,
@@ -1445,7 +1445,7 @@ def test_get_approach_save_path_str():
     save_path = utils.get_approach_save_path_str()
     assert save_path == dirname + ("/test_env__test_approach__123__"
                                    "test_pred1,test_pred2__baz.saved")
-    utils.update_config({
+    utils.reset_config({
         "env": "test_env",
         "approach": "test_approach",
         "seed": 123,
@@ -1456,7 +1456,7 @@ def test_get_approach_save_path_str():
     save_path = utils.get_approach_save_path_str()
     assert save_path == dirname + "/test_env__test_approach__123____.saved"
     os.rmdir(dirname)
-    utils.update_config({"approach_dir": old_approach_dir})
+    utils.reset_config({"approach_dir": old_approach_dir})
 
 
 def test_update_config():
@@ -1479,12 +1479,34 @@ def test_update_config():
     assert CFG.seed == 321
     with pytest.raises(ValueError):
         utils.update_config({"not a real setting name": 0})
+
+
+def test_reset_config():
+    """Tests for reset_config()."""
+    utils.reset_config({
+        "env": "cover",
+        "approach": "random_actions",
+        "seed": 123,
+    })
+    assert CFG.env == "cover"
+    assert CFG.approach == "random_actions"
+    assert CFG.seed == 123
+    utils.reset_config({
+        "env": "dummyenv",
+        "approach": "dummyapproach",
+        "seed": 321,
+    })
+    assert CFG.env == "dummyenv"
+    assert CFG.approach == "dummyapproach"
+    assert CFG.seed == 321
+    with pytest.raises(ValueError):
+        utils.reset_config({"not a real setting name": 0})
     # Test that default seed gets set automatically.
     del CFG.seed
     assert "seed" not in CFG.__dict__
     with pytest.raises(AttributeError):
         _ = CFG.seed
-    utils.update_config({"env": "cover"})
+    utils.reset_config({"env": "cover"})
     assert CFG.seed == 123
 
 
@@ -1742,12 +1764,12 @@ def test_create_video_from_partial_refinements():
                               np.zeros(PickPlace.params_space.shape,
                                        dtype=np.float32))
     partial_refinements = [([], [option])]
-    utils.update_config({"failure_video_mode": "not a real video mode"})
+    utils.reset_config({"failure_video_mode": "not a real video mode"})
     with pytest.raises(NotImplementedError):
         utils.create_video_from_partial_refinements(task, env.simulate,
                                                     env.render,
                                                     partial_refinements)
-    utils.update_config({"env": "cover", "failure_video_mode": "longest_only"})
+    utils.reset_config({"env": "cover", "failure_video_mode": "longest_only"})
     video = utils.create_video_from_partial_refinements(
         task, env.simulate, env.render, partial_refinements)
     assert len(video) == 2
@@ -1769,7 +1791,7 @@ def test_env_failure():
 def test_parse_config_excluded_predicates():
     """Tests for parse_config_excluded_predicates()."""
     # Test excluding nothing.
-    utils.update_config({
+    utils.reset_config({
         "env": "cover",
         "excluded_predicates": "",
     })
@@ -1780,7 +1802,7 @@ def test_parse_config_excluded_predicates():
     ]
     assert not excluded
     # Test excluding specific predicates.
-    utils.update_config({
+    utils.reset_config({
         "excluded_predicates": "IsBlock,HandEmpty",
     })
     included, excluded = utils.parse_config_excluded_predicates(env)
@@ -1788,7 +1810,7 @@ def test_parse_config_excluded_predicates():
                   for p in included) == ["Covers", "Holding", "IsTarget"]
     assert sorted(p.name for p in excluded) == ["HandEmpty", "IsBlock"]
     # Test excluding all (non-goal) predicates.
-    utils.update_config({
+    utils.reset_config({
         "excluded_predicates": "all",
     })
     included, excluded = utils.parse_config_excluded_predicates(env)
@@ -1797,7 +1819,7 @@ def test_parse_config_excluded_predicates():
         "HandEmpty", "Holding", "IsBlock", "IsTarget"
     ]
     # Can exclude goal predicates when offline_data_method is demo+ground_atoms.
-    utils.update_config({
+    utils.reset_config({
         "offline_data_method": "demo+ground_atoms",
         "excluded_predicates": "Covers",
     })
@@ -1807,7 +1829,7 @@ def test_parse_config_excluded_predicates():
     ]
     assert sorted(p.name for p in excluded) == ["Covers"]
     # Cannot exclude goal predicates otherwise..
-    utils.update_config({
+    utils.reset_config({
         "offline_data_method": "demo",
         "excluded_predicates": "Covers",
     })


### PR DESCRIPTION
this will hopefully put an end to the nightmare of unit tests interfering with each other. we should now use `reset_config` instead of `update_config` in all tests.

I went through all of the tests that previously used `update_config` and removed superfluous things like `seed: 123` (which happens automatically), multiple consecutive calls to `update_config` to deal with the `get_arg_specific_settings` stuff, and calls to `update_config` at the end of unit tests.