### PR TITLE
change min data for nsrt and painting num train objs 

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -46,7 +46,7 @@ class GlobalSettings:
     # painting env parameters
     painting_initial_holding_prob = 0.5
     painting_lid_open_prob = 0.3
-    painting_num_objs_train = [2]
+    painting_num_objs_train = [2, 3]
     painting_num_objs_test = [3, 4]
 
     # behavior env parameters
@@ -87,7 +87,7 @@ class GlobalSettings:
     teacher_dataset_label_ratio = 1.0
 
     # NSRT learning parameters
-    min_data_for_nsrt = 3
+    min_data_for_nsrt = 0
     learn_side_predicates = False
 
     # torch model parameters


### PR DESCRIPTION
things I tested:
* `python src/main.py --env painting --approach nsrt_learning --seed 0`
* `python src/main.py --env painting --approach nsrt_learning --seed 0 --offline_data_method demo`
* `python src/main.py --env cover --approach grammar_search_invention --seed 0 --offline_data_method demo`
* `python src/main.py --env cover --approach grammar_search_invention --seed 0 --offline_data_method demo --excluded_predicates all`
* `python src/main.py --env painting --approach grammar_search_invention --seed 0 --offline_data_method demo --excluded_predicates all --grammar_search_use_handcoded_debug_grammar True --grammar_search_expected_nodes_allow_noops True`