### PR TITLE
add assertion + test

### DIFF
--- a/src/datasets/ground_atom_data.py
+++ b/src/datasets/ground_atom_data.py
@@ -27,6 +27,7 @@ def create_ground_atom_data(env: BaseEnv, base_dataset: Dataset,
     labeleds = {p: 0 for p in annotating_predicates}
     totals = {p: 0 for p in annotating_predicates}
     annotations: List[List[Set[GroundAtom]]] = []
+    annotated_preds = set()
     for traj in base_dataset.trajectories:
         ground_atoms_traj: List[Set[GroundAtom]] = []
         for s in traj.states:
@@ -42,9 +43,12 @@ def create_ground_atom_data(env: BaseEnv, base_dataset: Dataset,
                         stripped_ga = GroundAtom(stripped_pred, ga.objects)
                         subset_atoms.add(stripped_ga)
                         labeleds[pred] += 1
+                        annotated_preds.add(pred)
                     totals[pred] += 1
             ground_atoms_traj.append(subset_atoms)
         assert len(traj.states) == len(ground_atoms_traj)
         annotations.append(ground_atoms_traj)
     assert len(annotations) == len(base_dataset.trajectories)
+    assert annotated_preds == annotating_predicates, \
+        "Not all predicates are seen in the dataset"
     return Dataset(base_dataset.trajectories, annotations)

--- a/tests/approaches/test_interactive_approach.py
+++ b/tests/approaches/test_interactive_approach.py
@@ -119,3 +119,10 @@ def test_interactive_learning_approach():
     with pytest.raises(NotImplementedError) as e:
         approach._score_atom_set(set(), train_tasks[0].init)  # pylint:disable=protected-access
     assert "Unrecognized interactive_score_function" in str(e)
+    # Test assertion that all predicates are seen in the data
+    utils.update_config({
+        "approach": "interactive_learning",
+        "teacher_dataset_label_ratio": 0.0,
+    })
+    with pytest.raises(AssertionError):
+        create_dataset(env, train_tasks)


### PR DESCRIPTION
Assert that all the predicates we want to learn about (aka the annotating predicates) are all "seen" (commented on by the teacher) in the demo+ground_atoms dataset, in preparation for almost-active-learning-only experiments where only a few training tasks are annotated but we make sure that the robot knows about all the predicates