### PR TITLE
fixes to cover_regrasp

### DIFF
--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -205,6 +205,10 @@ def _get_cover_gt_nsrts() -> Set[NSRT]:
         LiftedAtom(Covers, [block, target])
     }
     delete_effects = {LiftedAtom(Holding, holding_predicate_args)}
+    if CFG.env == "cover_regrasp":
+        Clear, = _get_predicates_by_names("cover_regrasp", ["Clear"])
+        preconditions.add(LiftedAtom(Clear, [target]))
+        delete_effects.add(LiftedAtom(Clear, [target]))
 
     if CFG.env in ("cover", "cover_hierarchical_types", "cover_regrasp"):
         option = PickPlace
@@ -299,11 +303,12 @@ def _get_cover_gt_nsrts() -> Set[NSRT]:
 
         def place_on_table_sampler(state: State, rng: np.random.Generator,
                                    objs: Sequence[Object]) -> Array:
-            del state  # unused
+            # Always at the current location.
+            del rng  # this sampler is deterministic
             assert len(objs) == 1
-            lb = 0.0
-            ub = 1.0
-            return np.array(rng.uniform(lb, ub, size=(1, )), dtype=np.float32)
+            held_obj = objs[0]
+            x = state.get(held_obj, "pose") + state.get(held_obj, "grasp")
+            return np.array([x], dtype=np.float32)
 
         place_on_table_nsrt = NSRT("PlaceOnTable", parameters,
                                    preconditions, add_effects, delete_effects,

--- a/tests/envs/test_cover.py
+++ b/tests/envs/test_cover.py
@@ -191,14 +191,24 @@ def test_cover_regrasp():
     for task in env.get_test_tasks():
         for obj in task.init:
             assert len(obj.type.feature_names) == len(task.init[obj])
-    # Predicates should be {IsBlock, IsTarget, Covers, HandEmpty, Holding}.
-    assert len(env.predicates) == 5
+    # Predicates should be same as CoverEnv, plus Clear.
+    assert len(env.predicates) == 6
     # Options should be {PickPlace}.
     assert len(env.options) == 1
     # Types should be {block, target, robot}
     assert len(env.types) == 3
     # Action space should be 1-dimensional.
     assert env.action_space == Box(0, 1, (1, ))
+    # Tests for Clear.
+    task = env.get_train_tasks()[0]
+    Clear = [p for p in env.predicates if p.name == "Clear"][0]
+    init_atoms = utils.abstract(task.init, {Clear})
+    assert len(init_atoms) == 2
+    # Clear should not be true after a place.
+    state = task.init.copy()
+    block0, _, _, target0, _ = sorted(state)
+    state.set(block0, "pose", state.get(target0, "pose"))
+    assert not Clear([target0]).holds(state)
 
 
 def test_cover_multistep_options():


### PR DESCRIPTION
closes #417 

I found two separate issues:
1. we were unwittingly checking collisions between a held block and itself when placing on table. that means that the sampler had to find a free space that was far enough away from the held block's original location, which was sometimes hard, leading to sampler-related failures in planning. I fixed the collision check, and also made the oracle placeontable sampler trivial so it just drops off the object whereever it starts out. (this always works by construction.)
2. in some of the harder problems requiring a plan of length 5 (place, pick, place, pick, place), the skeleton search was getting distracted by skeletons like: place the first object onto the second object's target, then place the second object onto that same target. in these cases, skeleton search never considered placeontable within the allotted max skeletons budget. this only happened rarely -- it required the problem being hard, and the ground_nsrts being sorted in a way that disfavored placeontable first. I addressed this by adding the clear predicate which we know gets invented anyway.

I tested by running oracle on 100 seeds and checking that they all got 50/50.