### PR TITLE
improve NSRTs printout

### DIFF
--- a/src/nsrt_learning.py
+++ b/src/nsrt_learning.py
@@ -58,7 +58,7 @@ def learn_nsrts_from_data(trajectories: Sequence[LowLevelTrajectory],
     # STEP 7: Print and return the NSRTs.
     nsrts = [pnad.make_nsrt() for pnad in pnads]
     print("\nLearned NSRTs:")
-    for nsrt in sorted(nsrts):
+    for nsrt in nsrts:
         print(nsrt)
     print()
     return set(nsrts)


### PR DESCRIPTION
when we print in sorted order, we ruin the order of the printed NSRTs.
this makes them different from the STRIPS operator printouts, which are
in the proper order since we don't sort those. note nsrts is a list, not
a set.