### PR TITLE
Constrained cluttered place

### DIFF
--- a/src/envs/cluttered_table.py
+++ b/src/envs/cluttered_table.py
@@ -173,11 +173,7 @@ class ClutteredTableEnv(BaseEnv):
         tasks = []
         goal = {GroundAtom(self._Holding, [self._cans[0]])}
         for _ in range(num):
-            if CFG.cluttered_table_place_custom_setting:
-                tasks.append(Task(self._create_custom_initial_state(), goal))
-            else:
-                tasks.append(
-                    Task(self._create_initial_state(train_or_test), goal))
+            tasks.append(Task(self._create_initial_state(train_or_test), goal))
         return tasks
 
     def _create_initial_state(self, train_or_test: str) -> State:
@@ -200,21 +196,6 @@ class ClutteredTableEnv(BaseEnv):
                     break
             # [pose_x, pose_y, radius, is_grasped, is_trashed]
             data[can] = np.array([pose[0], pose[1], radius, 0.0, 0.0])
-        return State(data)
-
-    def _create_custom_initial_state(self) -> State:
-        # Two cans
-        self._cans = []
-        for i in range(2):
-            self._cans.append(Object(f"can{i}", self._can_type))
-        data: Dict[Object, Array] = {}
-        radius = CFG.cluttered_table_can_radius
-        # The goal can is placed behind an obstructing can and randomly either
-        # on the left or right. The obstructing can is in the middle of the
-        # action space.
-        goal_x = 0.3 if self._train_rng.uniform() < 0.5 else 0.1
-        data[self._cans[0]] = np.array([goal_x, 0.7, radius, 0.0, 0.0])
-        data[self._cans[1]] = np.array([0.2, 0.5, radius, 0.0, 0.0])
         return State(data)
 
     @staticmethod
@@ -308,11 +289,12 @@ class ClutteredTableEnv(BaseEnv):
 class ClutteredTablePlaceEnv(ClutteredTableEnv):
     """Toy cluttered table domain (place version).
 
-    This version places grasped cans instead of dumping them. As an
-    additional challenge, the action space is restricted so that actions
-    can only begin from within a 0.2 x 0.2 corner. The goal behavior is
-    to learn to pick up colliding cans and place them out of the way of
-    the desired can.
+    This version places grasped cans instead of dumping them, and has
+    several additional constraints. There are two cans, a goal can and
+    an obstructing can in front of it. The action space is restricted so
+    that actions can only begin from the point (0.2,0) and end in the
+    [0,0.4] by [0,1.0] region. The goal behavior is to learn to pick up
+    the colliding can and place it out of the way of the goal can.
     """
 
     def __init__(self) -> None:
@@ -331,6 +313,10 @@ class ClutteredTablePlaceEnv(ClutteredTableEnv):
                                           _policy=self._Grasp_policy,
                                           _initiable=utils.always_initiable,
                                           _terminal=utils.onestep_terminal)
+        # Place env will always use two cans.
+        self._cans = []
+        for i in range(2):
+            self._cans.append(Object(f"can{i}", self._can_type))
 
     @property
     def options(self) -> Set[ParameterizedOption]:
@@ -387,3 +373,14 @@ class ClutteredTablePlaceEnv(ClutteredTableEnv):
         # No collisions, update state and return.
         next_state.set(desired_can, "is_grasped", 1.0)
         return next_state
+
+    def _create_initial_state(self, train_or_test: str) -> State:
+        data: Dict[Object, Array] = {}
+        radius = CFG.cluttered_table_can_radius
+        # The goal can is placed behind an obstructing can and randomly either
+        # on the left or right. The obstructing can is in the middle of the
+        # action space.
+        goal_x = 0.3 if self._train_rng.uniform() < 0.5 else 0.1
+        data[self._cans[0]] = np.array([goal_x, 0.7, radius, 0.0, 0.0])
+        data[self._cans[1]] = np.array([0.2, 0.5, radius, 0.0, 0.0])
+        return State(data)

--- a/src/envs/cluttered_table.py
+++ b/src/envs/cluttered_table.py
@@ -176,7 +176,8 @@ class ClutteredTableEnv(BaseEnv):
             if CFG.cluttered_table_place_custom_setting:
                 tasks.append(Task(self._create_custom_initial_state(), goal))
             else:
-                tasks.append(Task(self._create_initial_state(train_or_test), goal))  
+                tasks.append(
+                    Task(self._create_initial_state(train_or_test), goal))
         return tasks
 
     def _create_initial_state(self, train_or_test: str) -> State:

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -414,6 +414,7 @@ def _get_cluttered_table_gt_nsrts(with_place: bool = False) -> Set[NSRT]:
         def place_sampler(state: State, goal: Set[GroundAtom],
                           rng: np.random.Generator,
                           objs: Sequence[Object]) -> Array:
+            print("sample in place sampler")
             start_x, start_y = 0.2, 0.0
             # Goal-conditioned sampling
             if CFG.cluttered_table_place_goal_conditioned_sampling:
@@ -438,7 +439,7 @@ def _get_cluttered_table_gt_nsrts(with_place: bool = False) -> Set[NSRT]:
             return np.array(
                 [start_x, start_y,
                  rng.uniform(0, 0.4),
-                 rng.uniform(0, 0.4)],
+                 rng.uniform(0, 1.0)],
                 dtype=np.float32)
 
         place_nsrt = NSRT("Place", parameters, preconditions, add_effects,

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -367,8 +367,7 @@ def _get_cluttered_table_gt_nsrts(with_place: bool = False) -> Set[NSRT]:
         end_x = max(0.0, state.get(can, "pose_x"))
         end_y = max(0.0, state.get(can, "pose_y"))
         if with_place:
-            start_x, start_y = rng.uniform(0.0, 0.2,
-                                           size=2)  # start from 0.2x0.2 corner
+            start_x, start_y = 0.2, 0
         else:
             start_x, start_y = rng.uniform(0.0, 1.0,
                                            size=2)  # start from anywhere

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -414,7 +414,6 @@ def _get_cluttered_table_gt_nsrts(with_place: bool = False) -> Set[NSRT]:
         def place_sampler(state: State, goal: Set[GroundAtom],
                           rng: np.random.Generator,
                           objs: Sequence[Object]) -> Array:
-            print("sample in place sampler")
             start_x, start_y = 0.2, 0.0
             # Goal-conditioned sampling
             if CFG.cluttered_table_place_goal_conditioned_sampling:

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -425,26 +425,21 @@ def _get_cluttered_table_gt_nsrts(with_place: bool = False) -> Set[NSRT]:
                 goal_x = state.get(goal_obj, "pose_x")
                 goal_y = state.get(goal_obj, "pose_y")
                 # Place up w.r.t the goal, and to some distance left
-                # or right such that we're not going out of x bounds 
-                # 0 to 0.4. 
-                end_y = goal_y * 1.2 
-                end_x = goal_x + 0.2 
-                if end_x > 0.4: 
+                # or right such that we're not going out of x bounds
+                # 0 to 0.4.
+                end_y = goal_y * 1.2
+                end_x = goal_x + 0.2
+                if end_x > 0.4:
                     end_x = goal_x - 0.2
-                return np.array([
-                    start_x,
-                    start_y,
-                    end_x, 
-                    end_y
-                ], dtype=np.float32)
+                return np.array([start_x, start_y, end_x, end_y],
+                                dtype=np.float32)
             # Non-goal-conditioned sampling
             del state, goal, objs
-            return np.array([
-                start_x,
-                start_y,
-                rng.uniform(0, 0.4),
-                rng.uniform(0, 0.4)
-            ], dtype=np.float32)
+            return np.array(
+                [start_x, start_y,
+                 rng.uniform(0, 0.4),
+                 rng.uniform(0, 0.4)],
+                dtype=np.float32)
 
         place_nsrt = NSRT("Place", parameters, preconditions, add_effects,
                           delete_effects, set(), option, option_vars,

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -411,12 +411,42 @@ def _get_cluttered_table_gt_nsrts(with_place: bool = False) -> Set[NSRT]:
         }
         add_effects = {LiftedAtom(HandEmpty, [])}
         delete_effects = {LiftedAtom(Holding, [can])}
-        place_sampler = lambda s, g, r, o: np.array([
-            r.uniform(0, 0.2),
-            r.uniform(0, 0.2),
-            r.uniform(0, 1.),
-            r.uniform(0, 1.)
-        ])
+
+        def place_sampler(state: State, goal: Set[GroundAtom],
+                          rng: np.random.Generator,
+                          objs: Sequence[Object]) -> Array:
+            start_x, start_y = 0.2, 0.0
+            # Goal-conditioned sampling
+            if CFG.cluttered_table_place_goal_conditioned_sampling:
+                # Get the pose of the goal object
+                assert len(goal) == 1
+                goal_atom = next(iter(goal))
+                assert goal_atom.predicate == Holding
+                goal_obj = goal_atom.objects[0]
+                goal_x = state.get(goal_obj, "pose_x")
+                goal_y = state.get(goal_obj, "pose_y")
+                # Place up w.r.t the goal, and to some distance left
+                # or right such that we're not going out of x bounds 
+                # 0 to 0.4. 
+                end_y = goal_y * 1.2 
+                end_x = goal_x + 0.2 
+                if end_x > 0.4: 
+                    end_x = goal_x - 0.2
+                return np.array([
+                    start_x,
+                    start_y,
+                    end_x, 
+                    end_y
+                ], dtype=np.float32)
+            # Non-goal-conditioned sampling
+            del state, goal, objs
+            return np.array([
+                start_x,
+                start_y,
+                rng.uniform(0, 0.4),
+                rng.uniform(0, 0.4)
+            ], dtype=np.float32)
+
         place_nsrt = NSRT("Place", parameters, preconditions, add_effects,
                           delete_effects, set(), option, option_vars,
                           place_sampler)

--- a/src/settings.py
+++ b/src/settings.py
@@ -40,6 +40,7 @@ class GlobalSettings:
     cluttered_table_can_radius = 0.01
     cluttered_table_collision_angle_thresh = np.pi / 4
     cluttered_table_place_goal_conditioned_sampling = True
+    cluttered_table_place_custom_setting = False
 
     # repeated nextto env parameters
     repeated_nextto_num_dots = 25

--- a/src/settings.py
+++ b/src/settings.py
@@ -39,6 +39,7 @@ class GlobalSettings:
     cluttered_table_num_cans_test = 10
     cluttered_table_can_radius = 0.01
     cluttered_table_collision_angle_thresh = np.pi / 4
+    cluttered_table_place_goal_conditioned_sampling = True
 
     # repeated nextto env parameters
     repeated_nextto_num_dots = 25

--- a/src/settings.py
+++ b/src/settings.py
@@ -40,7 +40,6 @@ class GlobalSettings:
     cluttered_table_can_radius = 0.01
     cluttered_table_collision_angle_thresh = np.pi / 4
     cluttered_table_place_goal_conditioned_sampling = True
-    cluttered_table_place_custom_setting = False
 
     # repeated nextto env parameters
     repeated_nextto_num_dots = 25

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -364,9 +364,9 @@ def test_cluttered_table_get_gt_nsrts(place_version=False):
         assert grasp_nsrt.name == "Grasp"
         assert place_nsrt.name == "Place"
     env.seed(123)
-    train_tasks = env.get_train_tasks() 
+    train_tasks = env.get_train_tasks()
     for (i, task) in enumerate(train_tasks):
-        if i < len(train_tasks)/2:
+        if i < len(train_tasks) / 2:
             utils.reset_config(
                 {"cluttered_table_place_goal_conditioned_sampling": False})
         else:
@@ -385,10 +385,11 @@ def test_cluttered_table_get_gt_nsrts(place_version=False):
         with pytest.raises(AssertionError):
             grasp_nsrt.ground([])
         rng = np.random.default_rng(123)
-        if i ==0 and place_version: 
+        if i == 0 and place_version:
             # This case checks for exception when placing collides.
-            grasp_action = Action(np.array([0.2, 0, 0.2, 0.5], dtype=np.float32))
-        else: 
+            grasp_action = Action(
+                np.array([0.2, 0, 0.2, 0.5], dtype=np.float32))
+        else:
             grasp_option = grasp0_nsrt.sample_option(state, task.goal, rng)
             grasp_action = grasp_option.policy(state)
         assert env.action_space.contains(grasp_action.arr)
@@ -410,7 +411,8 @@ def test_cluttered_table_get_gt_nsrts(place_version=False):
                 place_nsrt.ground([can0, can1])
             if i == 0:
                 # This case checks for exception when placing collides.
-                place_action = Action(np.array([0.2, 0, 0.1, 0.75], dtype=np.float32))
+                place_action = Action(
+                    np.array([0.2, 0, 0.1, 0.75], dtype=np.float32))
                 assert env.action_space.contains(place_action.arr)
             else:
                 place_option = place1_nsrt.sample_option(state, task.goal, rng)

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -364,12 +364,14 @@ def test_cluttered_table_get_gt_nsrts(place_version=False):
         assert place_nsrt.name == "Place"
     env.seed(123)
     for (i, task) in enumerate(env.get_train_tasks()):
-        if i == 0: 
-            utils.reset_config({"cluttered_table_place_goal_conditioned_sampling": False})
-        else: 
-            utils.reset_config({"cluttered_table_place_goal_conditioned_sampling": True})
+        if i == 0:
+            utils.reset_config(
+                {"cluttered_table_place_goal_conditioned_sampling": False})
+        else:
+            utils.reset_config(
+                {"cluttered_table_place_goal_conditioned_sampling": True})
         state = task.init
-        if not place_version: 
+        if not place_version:
             can0, can1, _, can3, _ = list(state)
             assert can0.name == "can0"
             assert can3.name == "can3"
@@ -409,7 +411,7 @@ def test_cluttered_table_get_gt_nsrts(place_version=False):
             assert env.action_space.contains(place_action.arr)
             try:
                 env.simulate(state, place_action)
-            except utils.EnvironmentFailure as e: # pragma: no cover
+            except utils.EnvironmentFailure as e:  # pragma: no cover
                 assert len(e.info["offending_objects"]) == 1
 
 

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -363,11 +363,20 @@ def test_cluttered_table_get_gt_nsrts(place_version=False):
         assert grasp_nsrt.name == "Grasp"
         assert place_nsrt.name == "Place"
     env.seed(123)
-    for task in env.get_train_tasks():
+    for (i, task) in enumerate(env.get_train_tasks()):
+        if i == 0: 
+            utils.reset_config({"cluttered_table_place_goal_conditioned_sampling": False})
+        else: 
+            utils.reset_config({"cluttered_table_place_goal_conditioned_sampling": True})
         state = task.init
-        can0, can1, _, can3, _ = list(state)
-        assert can0.name == "can0"
-        assert can3.name == "can3"
+        if not place_version: 
+            can0, can1, _, can3, _ = list(state)
+            assert can0.name == "can0"
+            assert can3.name == "can3"
+        else:
+            can0, can1 = list(state)
+            assert can0.name == "can0"
+            assert can1.name == "can1"
         grasp0_nsrt = grasp_nsrt.ground([can0])
         with pytest.raises(AssertionError):
             grasp_nsrt.ground([])
@@ -388,15 +397,19 @@ def test_cluttered_table_get_gt_nsrts(place_version=False):
             assert env.action_space.contains(dump_action.arr)
             env.simulate(state, dump_action)  # never raises EnvironmentFailure
         else:
-            place3_nsrt = place_nsrt.ground([can3])
+            print("hihi again")
+            place1_nsrt = place_nsrt.ground([can1])
             with pytest.raises(AssertionError):
-                place_nsrt.ground([can3, can1])
-            place_option = place3_nsrt.sample_option(state, task.goal, rng)
+                place_nsrt.ground([can0, can1])
+
+            print("hihi again 2!")
+            place_option = place1_nsrt.sample_option(state, task.goal, rng)
+            print("hihi again 3!")
             place_action = place_option.policy(state)
             assert env.action_space.contains(place_action.arr)
             try:
                 env.simulate(state, place_action)
-            except utils.EnvironmentFailure as e:
+            except utils.EnvironmentFailure as e: # pragma: no cover
                 assert len(e.info["offending_objects"]) == 1
 
 

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -399,14 +399,10 @@ def test_cluttered_table_get_gt_nsrts(place_version=False):
             assert env.action_space.contains(dump_action.arr)
             env.simulate(state, dump_action)  # never raises EnvironmentFailure
         else:
-            print("hihi again")
             place1_nsrt = place_nsrt.ground([can1])
             with pytest.raises(AssertionError):
                 place_nsrt.ground([can0, can1])
-
-            print("hihi again 2!")
             place_option = place1_nsrt.sample_option(state, task.goal, rng)
-            print("hihi again 3!")
             place_action = place_option.policy(state)
             assert env.action_space.contains(place_action.arr)
             try:

--- a/tests/envs/test_cluttered_table.py
+++ b/tests/envs/test_cluttered_table.py
@@ -60,8 +60,8 @@ def test_cluttered_table(place_version=False):
         can = list(state)[0]
         print('hihi2')
         act = Action(env.action_space.sample())
-        if i == 0: 
-            env.render(state, task, act)            
+        if i == 0:
+            env.render(state, task, act)
         try:
             env.simulate(state, act)
         except utils.EnvironmentFailure:  # pragma: no cover
@@ -75,7 +75,8 @@ def test_cluttered_table(place_version=False):
             state.set(can, "is_grasped", 1.0)
             pose_x = state.get(can, "pose_x")
             pose_y = state.get(can, "pose_y")
-            act = Action(np.array([0.0, 0.0, pose_x, pose_y], dtype=np.float32))
+            act = Action(np.array([0.0, 0.0, pose_x, pose_y],
+                                  dtype=np.float32))
             next_state = env.simulate(state,
                                       act)  # grasp while already grasping
             assert state.allclose(next_state)

--- a/tests/envs/test_cluttered_table.py
+++ b/tests/envs/test_cluttered_table.py
@@ -34,8 +34,8 @@ def test_cluttered_table(place_version=False):
     if not place_version:
         assert env.action_space == Box(0, 1, (4, ))
     else:
-        assert env.action_space == Box(np.array([0, 0, 0, 0]),
-                                       np.array([0.2, 0.2, 1, 1]))
+        assert env.action_space == Box(np.array([0.2, 0, 0, 0]),
+                                       np.array([0.2, 0, 0.4, 1]))
     HandEmpty = [pred for pred in env.predicates
                  if pred.name == "HandEmpty"][0]
     Untrashed = [pred for pred in env.predicates
@@ -44,6 +44,7 @@ def test_cluttered_table(place_version=False):
     # Test init state and simulate()
     for i, task in enumerate(env.get_test_tasks()):
         state = task.init
+        print("hihi")
         for can1 in state:
             pose_x1 = state.get(can1, "pose_x")
             pose_y1 = state.get(can1, "pose_y")
@@ -57,26 +58,24 @@ def test_cluttered_table(place_version=False):
                 assert np.linalg.norm([pose_y2 - pose_y1, pose_x2 - pose_x1
                                        ]) > rad1 + rad2
         can = list(state)[0]
+        print('hihi2')
         act = Action(env.action_space.sample())
-        if i == 0:
-            env.render(state, task, act)
+        if i == 0: 
+            env.render(state, task, act)            
         try:
             env.simulate(state, act)
         except utils.EnvironmentFailure:  # pragma: no cover
             pass
-        atoms = utils.abstract(state, env.predicates)
-        assert GroundAtom(HandEmpty, []) in atoms
-        for can1 in state:
-            assert Untrashed([can1]) in atoms
-        state.set(can, "is_grasped", 1.0)
-        pose_x = state.get(can, "pose_x")
-        pose_y = state.get(can, "pose_y")
-        act = Action(np.array([0.0, 0.0, pose_x, pose_y], dtype=np.float32))
+        print('hihi3')
         if not place_version:
-            next_state = env.simulate(state,
-                                      act)  # grasp while already grasping
-            assert state.allclose(next_state)
-        if not place_version:
+            atoms = utils.abstract(state, env.predicates)
+            assert GroundAtom(HandEmpty, []) in atoms
+            for can1 in state:
+                assert Untrashed([can1]) in atoms
+            state.set(can, "is_grasped", 1.0)
+            pose_x = state.get(can, "pose_x")
+            pose_y = state.get(can, "pose_y")
+            act = Action(np.array([0.0, 0.0, pose_x, pose_y], dtype=np.float32))
             next_state = env.simulate(state,
                                       act)  # grasp while already grasping
             assert state.allclose(next_state)
@@ -85,6 +84,10 @@ def test_cluttered_table(place_version=False):
             assert Holding([can]) in atoms
             for can1 in state:
                 assert Untrashed([can1]) in atoms
+            # Additionally test when grasp is not on top of can coordinates
+            act = Action(np.array([0.0, 0.0, 0.9, 0.9], dtype=np.float32))
+            next_state = env.simulate(state, act)
+            assert state.allclose(next_state)
         if i == 0:
             env.render(state, task, act)
 

--- a/tests/envs/test_cluttered_table.py
+++ b/tests/envs/test_cluttered_table.py
@@ -44,7 +44,6 @@ def test_cluttered_table(place_version=False):
     # Test init state and simulate()
     for i, task in enumerate(env.get_test_tasks()):
         state = task.init
-        print("hihi")
         for can1 in state:
             pose_x1 = state.get(can1, "pose_x")
             pose_y1 = state.get(can1, "pose_y")
@@ -58,7 +57,6 @@ def test_cluttered_table(place_version=False):
                 assert np.linalg.norm([pose_y2 - pose_y1, pose_x2 - pose_x1
                                        ]) > rad1 + rad2
         can = list(state)[0]
-        print('hihi2')
         act = Action(env.action_space.sample())
         if i == 0:
             env.render(state, task, act)
@@ -66,7 +64,6 @@ def test_cluttered_table(place_version=False):
             env.simulate(state, act)
         except utils.EnvironmentFailure:  # pragma: no cover
             pass
-        print('hihi3')
         if not place_version:
             atoms = utils.abstract(state, env.predicates)
             assert GroundAtom(HandEmpty, []) in atoms


### PR DESCRIPTION
Further constraining cluttered place environment to make task more difficult + goal-conditioned action sampling that works. 

python src/main.py --env cluttered_table_place --approach oracle --max_skeletons_optimized 2 --max_samples_per_step 1 --num_test_tasks 50 --cluttered_table_num_cans_test 2 --cluttered_table_place_goal_conditioned_sampling False  --seed 0
 
solves 9/50  tasks compared to 

 python src/main.py --env cluttered_table_place --approach oracle --max_skeletons_optimized 2 --max_samples_per_step 1 --num_test_tasks 50 --cluttered_table_num_cans_test 2 --cluttered_table_place_goal_conditioned_sampling True  --seed 0 

solves 50/50 tasks