### PR TITLE
mark demo responses as demos with train task idxs

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -121,7 +121,7 @@ def _run_pipeline(env: BaseEnv,
         results["num_transitions"] = total_num_transitions
         results["learning_time"] = time.time() - learning_start
         _save_test_results(results, online_learning_cycle=None)
-        teacher = Teacher()
+        teacher = Teacher(train_tasks)
         # The online learning loop.
         for i in range(CFG.num_online_learning_cycles):
             print(f"\n\nONLINE LEARNING CYCLE {i}\n\n")

--- a/src/structs.py
+++ b/src/structs.py
@@ -1124,8 +1124,7 @@ class GroundAtomsHoldResponse(Response):
 
 @dataclass(frozen=True, eq=False, repr=False)
 class DemonstrationQuery(Query):
-    """A query requesting a demonstration to get from the state to a goal."""
-    goal: Set[GroundAtom]
+    """A query requesting a demonstration to finish a train task."""
     train_task_idx: int
 
 

--- a/src/structs.py
+++ b/src/structs.py
@@ -1126,6 +1126,7 @@ class GroundAtomsHoldResponse(Response):
 class DemonstrationQuery(Query):
     """A query requesting a demonstration to get from the state to a goal."""
     goal: Set[GroundAtom]
+    train_task_idx: int
 
 
 @dataclass(frozen=True, eq=False, repr=False)

--- a/src/teacher.py
+++ b/src/teacher.py
@@ -4,7 +4,7 @@ information to assist an agent during online learning."""
 from __future__ import annotations
 from predicators.src.structs import State, Task, Query, Response, \
     GroundAtomsHoldQuery, GroundAtomsHoldResponse, DemonstrationQuery, \
-    DemonstrationResponse
+    DemonstrationResponse, LowLevelTrajectory
 from predicators.src.settings import CFG, get_allowed_query_type_names
 from predicators.src.envs import create_env
 from predicators.src.approaches import ApproachTimeout, ApproachFailure
@@ -51,7 +51,11 @@ class Teacher:
         except (ApproachTimeout, ApproachFailure):
             return DemonstrationResponse(query, teacher_traj=None)
 
-        teacher_traj, _, goal_reached = utils.run_policy_on_task(
+        traj, _, goal_reached = utils.run_policy_on_task(
             policy, task, self._simulator, CFG.max_num_steps_option_rollout)
         assert goal_reached
+        teacher_traj = LowLevelTrajectory(traj.states,
+                                          traj.actions,
+                                          _is_demo=True,
+                                          _train_task_idx=query.train_task_idx)
         return DemonstrationResponse(query, teacher_traj)

--- a/tests/approaches/test_interactive_approach.py
+++ b/tests/approaches/test_interactive_approach.py
@@ -37,7 +37,7 @@ def test_interactive_learning_approach():
     approach = InteractiveLearningApproach(initial_predicates, env.options,
                                            env.types, env.action_space,
                                            train_tasks)
-    teacher = Teacher()
+    teacher = Teacher(train_tasks)
     dataset = create_dataset(env, train_tasks)
     assert approach.is_learning_based
     # Learning with an empty dataset should not crash.

--- a/tests/test_teacher.py
+++ b/tests/test_teacher.py
@@ -56,17 +56,20 @@ def test_DemonstrationQuery():
     utils.reset_config({"env": "cover", "approach": "unittest"})
     teacher = Teacher()
     env = create_env("cover")
-    task = env.get_train_tasks()[0]
+    train_task_idx = 0
+    task = env.get_train_tasks()[train_task_idx]
     state = task.init
     goal = task.goal
     # Test normal usage
-    query = DemonstrationQuery(goal)
+    query = DemonstrationQuery(goal, train_task_idx)
     response = teacher.answer_query(state, query)
     assert isinstance(response, DemonstrationResponse)
     assert response.query is query
     assert isinstance(response.teacher_traj, LowLevelTrajectory)
     assert len(response.teacher_traj.actions) == 2
     assert all(atom.holds(response.teacher_traj.states[-1]) for atom in goal)
+    assert response.teacher_traj.is_demo
+    assert response.teacher_traj.train_task_idx == train_task_idx
     # Test usage when goal is already achieved
     response = teacher.answer_query(response.teacher_traj.states[-1], query)
     assert isinstance(response, DemonstrationResponse)
@@ -80,7 +83,7 @@ def test_DemonstrationQuery():
     IsBlock = utils.strip_predicate(IsBlock)
     NotIsBlock = IsBlock.get_negation()
     not_is_block_block = GroundAtom(NotIsBlock, [block])
-    query = DemonstrationQuery({not_is_block_block})
+    query = DemonstrationQuery({not_is_block_block}, train_task_idx)
     response = teacher.answer_query(state, query)
     assert isinstance(response, DemonstrationResponse)
     assert response.query is query

--- a/tests/test_teacher.py
+++ b/tests/test_teacher.py
@@ -4,16 +4,17 @@ from predicators.src.envs import create_env
 from predicators.src.ground_truth_nsrts import _get_predicates_by_names
 from predicators.src import utils
 from predicators.src.teacher import Teacher
-from predicators.src.structs import DemonstrationQuery, DemonstrationResponse,\
-    GroundAtomsHoldQuery, GroundAtomsHoldResponse, GroundAtom,\
-        LowLevelTrajectory
+from predicators.src.structs import Task, GroundAtom, DemonstrationQuery, \
+    DemonstrationResponse, GroundAtomsHoldQuery, GroundAtomsHoldResponse, \
+    LowLevelTrajectory
 
 
 def test_GroundAtomsHold():
     """Tests for answering queries of type GroundAtomsHoldQuery."""
     utils.reset_config({"env": "cover", "approach": "unittest"})
-    teacher = Teacher()
     env = create_env("cover")
+    train_tasks = env.get_train_tasks()
+    teacher = Teacher(train_tasks)
     state = env.get_train_tasks()[0].init
     block_type = [t for t in env.types if t.name == "block"][0]
     target_type = [t for t in env.types if t.name == "target"][0]
@@ -54,14 +55,15 @@ def test_GroundAtomsHold():
 def test_DemonstrationQuery():
     """Tests for answering queries of type DemonstrationQuery."""
     utils.reset_config({"env": "cover", "approach": "unittest"})
-    teacher = Teacher()
     env = create_env("cover")
+    train_tasks = env.get_train_tasks()
+    teacher = Teacher(train_tasks)
     train_task_idx = 0
-    task = env.get_train_tasks()[train_task_idx]
+    task = train_tasks[train_task_idx]
     state = task.init
     goal = task.goal
     # Test normal usage
-    query = DemonstrationQuery(goal, train_task_idx)
+    query = DemonstrationQuery(train_task_idx)
     response = teacher.answer_query(state, query)
     assert isinstance(response, DemonstrationResponse)
     assert response.query is query
@@ -77,13 +79,16 @@ def test_DemonstrationQuery():
     assert isinstance(response.teacher_traj, LowLevelTrajectory)
     assert len(response.teacher_traj.actions) == 0
     # Test usage when achieving goal is impossible
-    block_type = [t for t in env.types if t.name == "block"][0]
-    block = block_type("block0")
+    state = train_tasks[0].init
+    block = [b for b in state if b.name == "block1"][0]
     IsBlock = _get_predicates_by_names("cover", ["IsBlock"])[0]
     IsBlock = utils.strip_predicate(IsBlock)
     NotIsBlock = IsBlock.get_negation()
     not_is_block_block = GroundAtom(NotIsBlock, [block])
-    query = DemonstrationQuery({not_is_block_block}, train_task_idx)
+    impossible_task = Task(state, {not_is_block_block})
+    train_tasks = [impossible_task]
+    teacher = Teacher(train_tasks)
+    query = DemonstrationQuery(train_task_idx=0)
     response = teacher.answer_query(state, query)
     assert isinstance(response, DemonstrationResponse)
     assert response.query is query

--- a/tests/test_teacher.py
+++ b/tests/test_teacher.py
@@ -80,7 +80,7 @@ def test_DemonstrationQuery():
     assert len(response.teacher_traj.actions) == 0
     # Test usage when achieving goal is impossible
     state = train_tasks[0].init
-    block = [b for b in state if b.name == "block1"][0]
+    block = [b for b in state if b.name == "block0"][0]
     IsBlock = _get_predicates_by_names("cover", ["IsBlock"])[0]
     IsBlock = utils.strip_predicate(IsBlock)
     NotIsBlock = IsBlock.get_negation()


### PR DESCRIPTION
demonstration responses should be marked as demos. we also will need to know at least the goal that the trajectories are for. one thing to be aware of in general is: now, if a LowLevelTrajectory has train_task_idx 5, it does _not_ mean that the trajectory is a full demonstration of the entire train_task_idx 5; it just means that the trajectory ends up in the goal for that train task, starting at a potentially arbitrary state. if this is too confusing, we may need to make `is_demo`, `train_task_idx`, and `goal` three different properties for `LowLevelTrajectory`. @ronuchit lmk what you think -- I am neutral about whether we should do that.