### PR TITLE
max initial demos

### DIFF
--- a/src/datasets/demo_only.py
+++ b/src/datasets/demo_only.py
@@ -16,6 +16,8 @@ def create_demo_data(env: BaseEnv, train_tasks: List[Task]) -> Dataset:
                                       env.types, env.action_space, train_tasks)
     trajectories = []
     for idx, task in enumerate(train_tasks):
+        if idx >= CFG.max_initial_demos:
+            break
         try:
             policy = oracle_approach.solve(
                 task, timeout=CFG.offline_data_planning_timeout)

--- a/src/settings.py
+++ b/src/settings.py
@@ -17,6 +17,9 @@ class GlobalSettings:
     num_train_tasks = 50
     num_test_tasks = 50
     num_online_learning_cycles = 10
+    # Maximum number of training tasks to give a demonstration for, if the
+    # offline_data_method is demo-based.
+    max_initial_demos = float("inf")
     # Maximum number of steps to run a policy when checking if it solves a task.
     max_num_steps_check_policy = 100
     # Maximum number of steps to run an InteractionRequest policy.

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -52,6 +52,18 @@ def test_demo_dataset():
             assert action.has_option()
     with pytest.raises(AssertionError):
         _ = dataset.annotations
+    # Test max_initial_demos.
+    utils.reset_config({
+        "env": "cover",
+        "offline_data_method": "demo",
+        "num_train_tasks": 7,
+        "max_initial_demos": 3,
+    })
+    env = CoverEnv()
+    train_tasks = env.get_train_tasks()
+    assert len(train_tasks) == 7
+    dataset = create_dataset(env, train_tasks)
+    assert len(dataset.trajectories) == 3
     utils.update_config({
         "offline_data_method": "not a real method",
     })


### PR DESCRIPTION
for online learning methods, it makes sense to have the number of initial demos and the number of train tasks be two different things, because the method can collect its own data in train tasks that it didn't receive a demo for.