### PR TITLE
improve API for side predicate learning

### DIFF
--- a/src/approaches/nsrt_learning_approach.py
+++ b/src/approaches/nsrt_learning_approach.py
@@ -42,6 +42,7 @@ class NSRTLearningApproach(TAMPApproach):
                      online_learning_cycle: Optional[int]) -> None:
         self._nsrts = learn_nsrts_from_data(
             trajectories,
+            self._train_tasks,
             self._get_current_predicates(),
             sampler_learner=CFG.sampler_learner)
         save_path = utils.get_approach_save_path_str()

--- a/tests/test_nsrt_learning.py
+++ b/tests/test_nsrt_learning.py
@@ -125,7 +125,7 @@ def test_nsrt_learning_specific_nsrts():
     action1.set_option(option1)
     next_state1 = State({cup0: [0.8], cup1: [0.3], cup2: [1.0]})
     dataset = [LowLevelTrajectory([state1, next_state1], [action1])]
-    nsrts = learn_nsrts_from_data(dataset, preds, sampler_learner="neural")
+    nsrts = learn_nsrts_from_data(dataset, [], preds, sampler_learner="neural")
     assert len(nsrts) == 1
     nsrt = nsrts.pop()
     assert str(nsrt) == """NSRT-Op0:
@@ -158,7 +158,7 @@ def test_nsrt_learning_specific_nsrts():
         LowLevelTrajectory([state1, next_state1], [action1]),
         LowLevelTrajectory([state2, next_state2], [action2])
     ]
-    nsrts = learn_nsrts_from_data(dataset, preds, sampler_learner="random")
+    nsrts = learn_nsrts_from_data(dataset, [], preds, sampler_learner="random")
     assert len(nsrts) == 1
     nsrt = nsrts.pop()
     assert str(nsrt) == """NSRT-Op0:
@@ -196,7 +196,7 @@ def test_nsrt_learning_specific_nsrts():
         LowLevelTrajectory([state1, next_state1], [action1]),
         LowLevelTrajectory([state2, next_state2], [action2])
     ]
-    nsrts = learn_nsrts_from_data(dataset, preds, sampler_learner="random")
+    nsrts = learn_nsrts_from_data(dataset, [], preds, sampler_learner="random")
     assert len(nsrts) == 2
     expected = {
         "Op0":
@@ -234,7 +234,7 @@ def test_nsrt_learning_specific_nsrts():
         LowLevelTrajectory([state1, next_state1], [action1]),
         LowLevelTrajectory([state2, next_state2], [action2])
     ]
-    nsrts = learn_nsrts_from_data(dataset, preds, sampler_learner="random")
+    nsrts = learn_nsrts_from_data(dataset, [], preds, sampler_learner="random")
     assert len(nsrts) == 2
     expected = {
         "Op0":
@@ -258,7 +258,7 @@ def test_nsrt_learning_specific_nsrts():
         assert str(nsrt) == expected[nsrt.name]
     # Test minimum number of examples parameter
     utils.update_config({"min_data_for_nsrt": 3})
-    nsrts = learn_nsrts_from_data(dataset, preds, sampler_learner="random")
+    nsrts = learn_nsrts_from_data(dataset, [], preds, sampler_learner="random")
     assert len(nsrts) == 0
     # Test max_rejection_sampling_tries = 0
     utils.update_config({
@@ -267,7 +267,7 @@ def test_nsrt_learning_specific_nsrts():
         "sampler_mlp_classifier_max_itr": 1,
         "neural_gaus_regressor_max_itr": 1
     })
-    nsrts = learn_nsrts_from_data(dataset, preds, sampler_learner="neural")
+    nsrts = learn_nsrts_from_data(dataset, [], preds, sampler_learner="neural")
     assert len(nsrts) == 2
     for nsrt in nsrts:
         for _ in range(10):

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -449,7 +449,7 @@ def test_option_memory_correct():
     assert opt2.terminal(state)
 
 
-def test_nsrts():
+def test_operators_and_nsrts():
     """Tests for STRIPSOperator, _GroundSTRIPSOperator, NSRT and
     _GroundNSRT."""
     cup_type = Type("cup_type", ["feat1"])
@@ -494,6 +494,34 @@ def test_nsrts():
                                       delete_effects, side_predicates)
     assert strips_operator < strips_operator3
     assert strips_operator3 > strips_operator
+    with pytest.raises(AssertionError):
+        strips_operator.effect_to_side_predicate(next(
+            iter(add_effects)), [], "dummy")  # invalid last argument
+    with pytest.raises(AssertionError):
+        strips_operator.effect_to_side_predicate(next(
+            iter(add_effects)), [], "delete")  # not a delete effect!
+    with pytest.raises(AssertionError):
+        strips_operator.effect_to_side_predicate(next(iter(delete_effects)),
+                                                 [],
+                                                 "add")  # not an add effect!
+    sidelined_add = strips_operator.effect_to_side_predicate(
+        next(iter(add_effects)), [], "add")
+    assert str(sidelined_add) == repr(sidelined_add) == \
+        """STRIPS-Pick:
+    Parameters: [?cup:cup_type, ?plate:plate_type]
+    Preconditions: [NotOn(?cup:cup_type, ?plate:plate_type)]
+    Add Effects: []
+    Delete Effects: [NotOn(?cup:cup_type, ?plate:plate_type)]
+    Side Predicates: [On]"""
+    sidelined_delete = strips_operator.effect_to_side_predicate(
+        next(iter(delete_effects)), [], "delete")
+    assert str(sidelined_delete) == repr(sidelined_delete) == \
+        """STRIPS-Pick:
+    Parameters: [?cup:cup_type, ?plate:plate_type]
+    Preconditions: [NotOn(?cup:cup_type, ?plate:plate_type)]
+    Add Effects: [On(?cup:cup_type, ?plate:plate_type)]
+    Delete Effects: []
+    Side Predicates: [NotOn, On]"""
     # _GroundSTRIPSOperator
     cup = cup_type("cup")
     plate = plate_type("plate")


### PR DESCRIPTION
theoretically, a person in the future may want to work on side predicate
stuff. if such a person were to exist, they may appreciate the API
providing the things they would need. this is an attempt to remedy that.

* learn_pnad_side_predicates now takes in PNADs, ground atom data,
train_tasks, predicates, and segments
* added a helper function `op.effect_to_side_predicate()` with tests