### PR TITLE
change objtovar dicts to maps in datastores 

### DIFF
--- a/src/nsrt_learning/option_learning.py
+++ b/src/nsrt_learning/option_learning.py
@@ -67,7 +67,7 @@ class _KnownOptionsOptionLearner(_OptionLearnerBase):
         option_specs = []
         for datastore in datastores:
             param_option = None
-            option_vars = None
+            option_vars: List[Variable] = []
             for i, (segment, obj_var_map) in enumerate(datastore):
                 option = segment.actions[0].get_option()
                 var_obj_sub = {v: o for o, v in obj_var_map}

--- a/src/nsrt_learning/sampler_learning.py
+++ b/src/nsrt_learning/sampler_learning.py
@@ -174,7 +174,7 @@ def _create_sampler_data(
     positive_data = []
     negative_data = []
     for idx, datastore in enumerate(datastores):
-        for (segment, obj_to_var) in datastore:
+        for (segment, obj_var_map) in datastore:
             assert segment.has_option()
             option = segment.get_option()
             state = segment.states[0]
@@ -189,7 +189,7 @@ def _create_sampler_data(
                 # sampler for, and this datapoint matches the actual grounding,
                 # add it to the positive data and continue.
                 if idx == datastore_idx:
-                    var_to_obj = {v: k for k, v in obj_to_var.items()}
+                    var_to_obj = {v: k for k, v in obj_var_map}
                     actual_grounding = [var_to_obj[var] for var in variables]
                     if grounding == actual_grounding:
                         assert all(

--- a/src/structs.py
+++ b/src/structs.py
@@ -1046,7 +1046,7 @@ class PartialNSRTAndDatastore:
     op: STRIPSOperator
     # The datastore, a list of segments that are covered by the
     # STRIPSOperator self.op. For each such segment, the datastore also
-    # maintains a substitution dictionary of type ObjToVarSub,
+    # maintains a relation between objects and variables of type ObjVarMap,
     # under which the ParameterizedOption and effects for all
     # segments in the datastore are equivalent.
     datastore: Datastore
@@ -1055,23 +1055,36 @@ class PartialNSRTAndDatastore:
     # The sampler for this NSRT.
     sampler: Optional[NSRTSampler] = field(init=False, default=None)
 
-    def add_to_datastore(self, member: Tuple[Segment, ObjToVarSub]) -> None:
+    def add_to_datastore(self,
+                         member: Tuple[Segment, ObjVarMap],
+                         check_effect_equality: bool = True) -> None:
         """Add a new member to self.datastore."""
-        seg, sub = member
-        # Check for consistency.
+        seg, obj_var_map = member
         if len(self.datastore) > 0:
+            obj_var_sub = dict(obj_var_map)
+            var_obj_sub = {v: o for (o, v) in obj_var_map}
+            # All variables should have a corresponding object.
+            assert set(var_obj_sub) == set(self.op.parameters)
             # The effects should match.
-            lifted_add_effects = {a.lift(sub) for a in seg.add_effects}
-            lifted_delete_effects = {a.lift(sub) for a in seg.delete_effects}
-            assert lifted_add_effects == self.op.add_effects
-            assert lifted_delete_effects == self.op.delete_effects
+            if check_effect_equality:
+                lifted_add_effects = {
+                    a.lift(obj_var_sub)
+                    for a in seg.add_effects
+                }
+                lifted_del_effects = {
+                    a.lift(obj_var_sub)
+                    for a in seg.delete_effects
+                }
+                assert lifted_add_effects == self.op.add_effects
+                assert lifted_del_effects == self.op.delete_effects
             if seg.has_option():
+                # The option should match.
                 option = seg.get_option()
                 part_param_option, part_option_args = self.option_spec
                 assert option.parent == part_param_option
-                option_args = [sub[o] for o in option.objects]
-                assert option_args == part_option_args
-        # Add to members.
+                option_args = [var_obj_sub[v] for v in part_option_args]
+                assert option.objects == option_args
+        # Add to datastore.
         self.datastore.append(member)
 
     def make_nsrt(self) -> NSRT:
@@ -1167,12 +1180,13 @@ GroundAtomTrajectory = Tuple[LowLevelTrajectory, List[Set[GroundAtom]]]
 Image = NDArray[np.uint8]
 Video = List[Image]
 Array = NDArray[np.float32]
+ObjVarMap = Set[Tuple[Object, Variable]]
 ObjToVarSub = Dict[Object, Variable]
 ObjToObjSub = Dict[Object, Object]
 VarToObjSub = Dict[Variable, Object]
 VarToVarSub = Dict[Variable, Variable]
 EntToEntSub = Dict[_TypedEntity, _TypedEntity]
-Datastore = List[Tuple[Segment, ObjToVarSub]]
+Datastore = List[Tuple[Segment, ObjVarMap]]
 NSRTSampler = Callable[
     [State, Set[GroundAtom], np.random.Generator, Sequence[Object]], Array]
 Metrics = DefaultDict[str, float]

--- a/tests/nsrt_learning/test_sampler_learning.py
+++ b/tests/nsrt_learning/test_sampler_learning.py
@@ -37,7 +37,7 @@ def test_create_sampler_data():
     next_atoms = utils.abstract(next_state, predicates)
     segment1 = Segment(LowLevelTrajectory([state, next_state], [action]),
                        atoms, next_atoms, option)
-    obj_to_var1 = {cup0: var_cup0}
+    obj_to_var1 = {(cup0, var_cup0)}
 
     # Transition 2: does nothing
     state = State({cup0: [0.4]})
@@ -48,7 +48,7 @@ def test_create_sampler_data():
     next_atoms = utils.abstract(next_state, predicates)
     segment2 = Segment(LowLevelTrajectory([state, next_state], [action]),
                        atoms, next_atoms, option)
-    obj_to_var2 = {cup0: var_cup0}
+    obj_to_var2 = {(cup0, var_cup0)}
 
     datastores = [[(segment1, obj_to_var1)], [(segment2, obj_to_var2)]]
     variables = [var_cup0]

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -774,7 +774,7 @@ def test_pnad():
     params = [0.5]
     option = parameterized_option.ground([], params)
     segment1 = Segment(traj, init_atoms, final_atoms, option)
-    objtovar = {cup: cup_var, plate: plate_var}
+    objtovar = {(cup, cup_var), (plate, plate_var)}
     segment2 = Segment(traj, init_atoms, final_atoms, option)
     segment3 = Segment(traj, init_atoms, set(), option)
     datastore = [(segment1, objtovar)]


### PR DESCRIPTION
this is (maybe) needed to avoid a crash in #453 . we should look at this with fresh eyes tomorrow before learning. one thing I'm especially not sure about is whether the logic in `_KnownOptionsOptionLearner` for setting up `option_vars` is correct.

I'm also not 100% sure that there isn't a simpler workaround to the issue in #453.