### PR TITLE
switch datastore subs to vartoobj

### DIFF
--- a/src/nsrt_learning/sampler_learning.py
+++ b/src/nsrt_learning/sampler_learning.py
@@ -174,7 +174,7 @@ def _create_sampler_data(
     positive_data = []
     negative_data = []
     for idx, datastore in enumerate(datastores):
-        for (segment, obj_to_var) in datastore:
+        for (segment, var_to_obj) in datastore:
             assert segment.has_option()
             option = segment.get_option()
             state = segment.states[0]
@@ -189,7 +189,6 @@ def _create_sampler_data(
                 # sampler for, and this datapoint matches the actual grounding,
                 # add it to the positive data and continue.
                 if idx == datastore_idx:
-                    var_to_obj = {v: k for k, v in obj_to_var.items()}
                     actual_grounding = [var_to_obj[var] for var in variables]
                     if grounding == actual_grounding:
                         assert all(

--- a/src/structs.py
+++ b/src/structs.py
@@ -348,7 +348,7 @@ class GroundAtom(_Atom):
         return (str(self.predicate) + "(" + ", ".join(map(str, self.objects)) +
                 ")")
 
-    def lift(self, sub: dict[Object, Variable]) -> LiftedAtom:
+    def lift(self, sub: ObjToVarSub) -> LiftedAtom:
         """Create a LiftedAtom with a given substitution."""
         assert set(self.objects).issubset(set(sub.keys()))
         return LiftedAtom(self.predicate, [sub[o] for o in self.objects])
@@ -1046,7 +1046,7 @@ class PartialNSRTAndDatastore:
     op: STRIPSOperator
     # The datastore, a list of segments that are covered by the
     # STRIPSOperator self.op. For each such segment, the datastore also
-    # maintains a substitution dictionary of type ObjToVarSub,
+    # maintains a substitution dictionary of type VarToObjSub,
     # under which the ParameterizedOption and effects for all
     # segments in the datastore are equivalent.
     datastore: Datastore
@@ -1055,23 +1055,35 @@ class PartialNSRTAndDatastore:
     # The sampler for this NSRT.
     sampler: Optional[NSRTSampler] = field(init=False, default=None)
 
-    def add_to_datastore(self, member: Tuple[Segment, ObjToVarSub]) -> None:
+    def add_to_datastore(self,
+                         member: Tuple[Segment, VarToObjSub],
+                         check_effect_equality: bool = True) -> None:
         """Add a new member to self.datastore."""
-        seg, sub = member
-        # Check for consistency.
+        seg, var_obj_sub = member
         if len(self.datastore) > 0:
+            obj_var_sub = {o: v for (v, o) in var_obj_sub.items()}
+            # All variables should have a corresponding object.
+            assert set(var_obj_sub) == set(self.op.parameters)
             # The effects should match.
-            lifted_add_effects = {a.lift(sub) for a in seg.add_effects}
-            lifted_delete_effects = {a.lift(sub) for a in seg.delete_effects}
-            assert lifted_add_effects == self.op.add_effects
-            assert lifted_delete_effects == self.op.delete_effects
+            if check_effect_equality:
+                lifted_add_effects = {
+                    a.lift(obj_var_sub)
+                    for a in seg.add_effects
+                }
+                lifted_del_effects = {
+                    a.lift(obj_var_sub)
+                    for a in seg.delete_effects
+                }
+                assert lifted_add_effects == self.op.add_effects
+                assert lifted_del_effects == self.op.delete_effects
             if seg.has_option():
+                # The option should match.
                 option = seg.get_option()
                 part_param_option, part_option_args = self.option_spec
                 assert option.parent == part_param_option
-                option_args = [sub[o] for o in option.objects]
-                assert option_args == part_option_args
-        # Add to members.
+                option_args = [var_obj_sub[v] for v in part_option_args]
+                assert option.objects == option_args
+        # Add to datastore.
         self.datastore.append(member)
 
     def make_nsrt(self) -> NSRT:
@@ -1172,7 +1184,7 @@ ObjToObjSub = Dict[Object, Object]
 VarToObjSub = Dict[Variable, Object]
 VarToVarSub = Dict[Variable, Variable]
 EntToEntSub = Dict[_TypedEntity, _TypedEntity]
-Datastore = List[Tuple[Segment, ObjToVarSub]]
+Datastore = List[Tuple[Segment, VarToObjSub]]
 NSRTSampler = Callable[
     [State, Set[GroundAtom], np.random.Generator, Sequence[Object]], Array]
 Metrics = DefaultDict[str, float]


### PR DESCRIPTION
this is an alternative to #456 , which should also resolve the crash in #453 , and is probably preferable.

a third option is to do neither of these things, assume that duplicate arguments in ground operators are disallowed, and just remove the TODO comment.