### PR TITLE
include num_train_tasks in dataset filename

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -152,7 +152,8 @@ def _generate_or_load_offline_dataset(env: BaseEnv,
                                       train_tasks: List[Task]) -> Dataset:
     """Create offline dataset from training tasks."""
     dataset_filename = (
-        f"{CFG.env}__{CFG.offline_data_method}__{CFG.seed}.data")
+        f"{CFG.env}__{CFG.offline_data_method}__{CFG.num_train_tasks}"
+        f"__{CFG.seed}.data")
     dataset_filepath = os.path.join(CFG.data_dir, dataset_filename)
     if CFG.load_data:
         assert os.path.exists(dataset_filepath)


### PR DESCRIPTION
we know this isn't everything we would technically need in the dataset
filename. see #451 for a complete list. but that would make the filename
really long, so we only add in num_train_tasks which is the most
important one

closes #451