### PR TITLE
Metric for counting num queries made

### DIFF
--- a/analysis/analyze_results_directory.py
+++ b/analysis/analyze_results_directory.py
@@ -39,6 +39,7 @@ COLUMN_NAMES_AND_KEYS = [
     # ("AVG_PLAN_LEN", "avg_plan_length"),
     # ("AVG_EXECUTION_FAILURES", "avg_execution_failures"),
     # ("NUM_TRANSITIONS", "num_transitions"),
+    # ("CUM_QUERY_COST", "cumulative_query_cost"),
 ]
 
 

--- a/analysis/run_active_learning_baseline.sh
+++ b/analysis/run_active_learning_baseline.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+START_SEED=456
+NUM_SEEDS=10
+CYCLES=100
+FILE="analysis/submit.py"
+
+for SEED in $(seq $START_SEED $((NUM_SEEDS+START_SEED-1))); do
+    python $FILE --env cover --approach interactive_learning --seed $SEED --excluded_predicates Covers --interactive_query_policy nonstrict_best_seen --interactive_score_function trivial --num_online_learning_cycles $CYCLES --max_initial_demos 1
+done

--- a/src/approaches/interactive_learning_approach.py
+++ b/src/approaches/interactive_learning_approach.py
@@ -191,6 +191,7 @@ class InteractiveLearningApproach(NSRTLearningApproach):
         ground_atom_universe = utils.all_possible_ground_atoms(init, preds)
         # If there are no possible goals, fall back to random immediately.
         if not ground_atom_universe:
+            print("No possible goals, falling back to random")
             return self._create_random_interaction_strategy(train_task_idx)
         possible_goals = utils.sample_subsets(
             ground_atom_universe,
@@ -213,6 +214,7 @@ class InteractiveLearningApproach(NSRTLearningApproach):
         except ApproachFailure:
             # Fall back to a random exploration strategy if no solvable task
             # can be found.
+            print("No solvable task found, falling back to random")
             return self._create_random_interaction_strategy(train_task_idx)
         assert task.init is init
 

--- a/src/main.py
+++ b/src/main.py
@@ -111,7 +111,7 @@ def _run_pipeline(env: BaseEnv,
         assert offline_dataset is not None, "Missing offline dataset"
         total_num_transitions = sum(
             len(traj.actions) for traj in offline_dataset.trajectories)
-        total_num_queries = 0
+        total_query_cost = 0.0
         learning_start = time.time()
         if CFG.load_approach:
             approach.load(online_learning_cycle=None)
@@ -120,7 +120,7 @@ def _run_pipeline(env: BaseEnv,
         # Run evaluation once before online learning starts.
         results = _run_testing(env, approach)
         results["num_transitions"] = total_num_transitions
-        results["num_queries"] = total_num_queries
+        results["cumulative_query_cost"] = total_query_cost
         results["learning_time"] = time.time() - learning_start
         _save_test_results(results, online_learning_cycle=None)
         teacher = Teacher(train_tasks)
@@ -131,12 +131,12 @@ def _run_pipeline(env: BaseEnv,
             interaction_requests = approach.get_interaction_requests()
             if not interaction_requests:
                 break  # agent doesn't want to learn anything more; terminate
-            interaction_results, num_queries = _generate_interaction_results(
+            interaction_results, query_cost = _generate_interaction_results(
                 env.simulate, teacher, train_tasks, interaction_requests)
             total_num_transitions += sum(
                 len(result.actions) for result in interaction_results)
-            total_num_queries += num_queries
-            print(f"Number of queries made this cycle: {num_queries}")
+            total_query_cost += query_cost
+            print(f"Query cost incurred this cycle: {query_cost}")
             if CFG.load_approach:
                 approach.load(online_learning_cycle=i)
             else:
@@ -144,7 +144,7 @@ def _run_pipeline(env: BaseEnv,
             # Evaluate approach after every online learning cycle.
             results = _run_testing(env, approach)
             results["num_transitions"] = total_num_transitions
-            results["num_queries"] = total_num_queries
+            results["cumulative_query_cost"] = total_query_cost
             results["learning_time"] = time.time() - learning_start
             _save_test_results(results, online_learning_cycle=i)
     else:
@@ -178,12 +178,12 @@ def _generate_or_load_offline_dataset(env: BaseEnv,
 def _generate_interaction_results(
     simulator: Callable[[State, Action], State], teacher: Teacher,
     train_tasks: List[Task], requests: Sequence[InteractionRequest]
-) -> Tuple[List[InteractionResult], int]:
+) -> Tuple[List[InteractionResult], float]:
     """Given a sequence of InteractionRequest objects, handle the requests and
     return a list of InteractionResult objects."""
     print("Generating interaction results...")
     results = []
-    num_queries = 0
+    query_cost = 0.0
     for request in requests:
         # First, roll out the acting policy.
         task = train_tasks[request.train_task_idx]
@@ -205,11 +205,11 @@ def _generate_interaction_results(
                 responses.append(None)
             else:
                 responses.append(teacher.answer_query(state, query))
-                num_queries += len(query)
+                query_cost += query.cost
         # Finally, assemble the InteractionResult object.
         result = InteractionResult(traj.states, traj.actions, responses)
         results.append(result)
-    return results, num_queries
+    return results, query_cost
 
 
 def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:

--- a/src/main.py
+++ b/src/main.py
@@ -176,9 +176,9 @@ def _generate_or_load_offline_dataset(env: BaseEnv,
 
 
 def _generate_interaction_results(
-        simulator: Callable[[State, Action],
-                            State], teacher: Teacher, train_tasks: List[Task],
-        requests: Sequence[InteractionRequest]) -> Tuple[List[InteractionResult], int]:
+    simulator: Callable[[State, Action], State], teacher: Teacher,
+    train_tasks: List[Task], requests: Sequence[InteractionRequest]
+) -> Tuple[List[InteractionResult], int]:
     """Given a sequence of InteractionRequest objects, handle the requests and
     return a list of InteractionResult objects."""
     print("Generating interaction results...")

--- a/src/structs.py
+++ b/src/structs.py
@@ -1135,12 +1135,10 @@ class InteractionResult:
 class Query(abc.ABC):
     """Base class for a Query."""
 
-    def __len__(self) -> int:
-        """The number of queries in this Query.
-
-        Defaults to 1.
-        """
-        return 1
+    @property
+    def cost(self) -> float:
+        """The cost of making this Query."""
+        raise NotImplementedError("Override me")
 
 
 @dataclass(frozen=True, eq=False, repr=False)
@@ -1157,7 +1155,8 @@ class GroundAtomsHoldQuery(Query):
     """A query for whether ground atoms hold in the state."""
     ground_atoms: Collection[GroundAtom]
 
-    def __len__(self) -> int:
+    @property
+    def cost(self) -> float:
         return len(self.ground_atoms)
 
 
@@ -1171,6 +1170,10 @@ class GroundAtomsHoldResponse(Response):
 class DemonstrationQuery(Query):
     """A query requesting a demonstration to finish a train task."""
     train_task_idx: int
+
+    @property
+    def cost(self) -> float:
+        return 1
 
 
 @dataclass(frozen=True, eq=False, repr=False)

--- a/src/structs.py
+++ b/src/structs.py
@@ -1134,9 +1134,11 @@ class InteractionResult:
 @dataclass(frozen=True, eq=False, repr=False)
 class Query(abc.ABC):
     """Base class for a Query.
-
-    Has no API.
     """
+    def __len__(self) -> int:
+        """The number of queries in this Query. Defaults to 1.
+        """
+        return 1
 
 
 @dataclass(frozen=True, eq=False, repr=False)
@@ -1152,6 +1154,9 @@ class Response(abc.ABC):
 class GroundAtomsHoldQuery(Query):
     """A query for whether ground atoms hold in the state."""
     ground_atoms: Collection[GroundAtom]
+
+    def __len__(self) -> int:
+        return len(self.ground_atoms)
 
 
 @dataclass(frozen=True, eq=False, repr=False)

--- a/src/structs.py
+++ b/src/structs.py
@@ -1133,10 +1133,12 @@ class InteractionResult:
 
 @dataclass(frozen=True, eq=False, repr=False)
 class Query(abc.ABC):
-    """Base class for a Query.
-    """
+    """Base class for a Query."""
+
     def __len__(self) -> int:
-        """The number of queries in this Query. Defaults to 1.
+        """The number of queries in this Query.
+
+        Defaults to 1.
         """
         return 1
 

--- a/tests/approaches/test_interactive_approach.py
+++ b/tests/approaches/test_interactive_approach.py
@@ -1,5 +1,6 @@
 """Test cases for the interactive learning approach."""
 
+import numpy as np
 import pytest
 from predicators.src.approaches import InteractiveLearningApproach, \
     ApproachTimeout, ApproachFailure
@@ -46,7 +47,7 @@ def test_interactive_learning_approach():
     approach.learn_from_offline_dataset(dataset)
     approach.load(online_learning_cycle=None)
     interaction_requests = approach.get_interaction_requests()
-    interaction_results = _generate_interaction_results(
+    interaction_results, _ = _generate_interaction_results(
         env.simulate, teacher, train_tasks, interaction_requests)
     approach.learn_from_interaction_results(interaction_results)
     approach.load(online_learning_cycle=0)
@@ -63,6 +64,7 @@ def test_interactive_learning_approach():
     utils.update_config({
         "interactive_action_strategy": "random",
     })
+    approach._best_score = -np.inf  # reset
     interaction_requests = approach.get_interaction_requests()
     _generate_interaction_results(env.simulate, teacher, train_tasks,
                                   interaction_requests)
@@ -71,6 +73,7 @@ def test_interactive_learning_approach():
         "interactive_action_strategy": "glib",
         "timeout": 0.0,
     })
+    approach._best_score = -np.inf  # reset
     interaction_requests = approach.get_interaction_requests()
     _generate_interaction_results(env.simulate, teacher, train_tasks,
                                   interaction_requests)
@@ -85,9 +88,19 @@ def test_interactive_learning_approach():
         "interactive_query_policy": "nonstrict_best_seen",
         "interactive_score_function": "trivial",
     })
+    approach._best_score = -np.inf  # reset
     interaction_requests = approach.get_interaction_requests()
-    _generate_interaction_results(env.simulate, teacher, train_tasks,
-                                  interaction_requests)
+    interaction_results, num_queries = _generate_interaction_results(
+        env.simulate, teacher, train_tasks,
+        interaction_requests)
+    assert len(interaction_results) == 1
+    interaction_result = interaction_results[0]
+    expected_num_queries = 0
+    for s in interaction_result.states:
+        ground_atoms = utils.all_possible_ground_atoms(
+                s, approach._predicates_to_learn)
+        expected_num_queries += len(ground_atoms)
+    assert num_queries == expected_num_queries
     # Cover unrecognized interactive_action_strategy.
     utils.update_config({
         "interactive_action_strategy": "not a real action strategy",

--- a/tests/approaches/test_interactive_approach.py
+++ b/tests/approaches/test_interactive_approach.py
@@ -64,7 +64,6 @@ def test_interactive_learning_approach():
     utils.update_config({
         "interactive_action_strategy": "random",
     })
-    approach._best_score = -np.inf  # reset
     interaction_requests = approach.get_interaction_requests()
     _generate_interaction_results(env.simulate, teacher, train_tasks,
                                   interaction_requests)
@@ -73,7 +72,6 @@ def test_interactive_learning_approach():
         "interactive_action_strategy": "glib",
         "timeout": 0.0,
     })
-    approach._best_score = -np.inf  # reset
     interaction_requests = approach.get_interaction_requests()
     _generate_interaction_results(env.simulate, teacher, train_tasks,
                                   interaction_requests)
@@ -88,17 +86,19 @@ def test_interactive_learning_approach():
         "interactive_query_policy": "nonstrict_best_seen",
         "interactive_score_function": "trivial",
     })
-    approach._best_score = -np.inf  # reset
+    approach._best_score = -np.inf  # pylint:disable=protected-access
     interaction_requests = approach.get_interaction_requests()
     interaction_results, num_queries = _generate_interaction_results(
-        env.simulate, teacher, train_tasks,
-        interaction_requests)
+        env.simulate, teacher, train_tasks, interaction_requests)
     assert len(interaction_results) == 1
     interaction_result = interaction_results[0]
+    predicates_to_learn = {
+        p
+        for p in env.predicates if p.name in ["Covers", "Holding"]
+    }
     expected_num_queries = 0
     for s in interaction_result.states:
-        ground_atoms = utils.all_possible_ground_atoms(
-                s, approach._predicates_to_learn)
+        ground_atoms = utils.all_possible_ground_atoms(s, predicates_to_learn)
         expected_num_queries += len(ground_atoms)
     assert num_queries == expected_num_queries
     # Cover unrecognized interactive_action_strategy.

--- a/tests/approaches/test_interactive_approach.py
+++ b/tests/approaches/test_interactive_approach.py
@@ -88,7 +88,7 @@ def test_interactive_learning_approach():
     })
     approach._best_score = -np.inf  # pylint:disable=protected-access
     interaction_requests = approach.get_interaction_requests()
-    interaction_results, num_queries = _generate_interaction_results(
+    interaction_results, query_cost = _generate_interaction_results(
         env.simulate, teacher, train_tasks, interaction_requests)
     assert len(interaction_results) == 1
     interaction_result = interaction_results[0]
@@ -96,11 +96,11 @@ def test_interactive_learning_approach():
         p
         for p in env.predicates if p.name in ["Covers", "Holding"]
     }
-    expected_num_queries = 0
+    expected_query_cost = 0
     for s in interaction_result.states:
         ground_atoms = utils.all_possible_ground_atoms(s, predicates_to_learn)
-        expected_num_queries += len(ground_atoms)
-    assert num_queries == expected_num_queries
+        expected_query_cost += len(ground_atoms)
+    assert query_cost == expected_query_cost
     # Cover unrecognized interactive_action_strategy.
     utils.update_config({
         "interactive_action_strategy": "not a real action strategy",

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -828,7 +828,7 @@ def test_query():
     """Test for Query classes."""
     query = Query()
     with pytest.raises(NotImplementedError):
-        query.cost
+        _ = query.cost
     demo_query = DemonstrationQuery(0)
     assert demo_query.cost == 1
     

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -7,7 +7,7 @@ from predicators.src.structs import Type, Object, Variable, State, Predicate, \
     _Atom, LiftedAtom, GroundAtom, Task, ParameterizedOption, _Option, \
     STRIPSOperator, NSRT, _GroundNSRT, Action, Segment, LowLevelTrajectory, \
     PartialNSRTAndDatastore, _GroundSTRIPSOperator, InteractionRequest, \
-    InteractionResult, DefaultState
+    InteractionResult, DefaultState, Query
 from predicators.src import utils
 
 
@@ -822,3 +822,8 @@ def test_interaction_request_and_result():
         InteractionResult([None, None], [None], [None])
     InteractionResult([None, None], [None], [None, None])
     InteractionResult([None], [], [None])
+
+
+def test_query():
+    """Test for Query class."""
+    assert len(Query()) == 1  # test for coverage

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -831,4 +831,3 @@ def test_query():
         _ = query.cost
     demo_query = DemonstrationQuery(0)
     assert demo_query.cost == 1
-    

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -7,7 +7,7 @@ from predicators.src.structs import Type, Object, Variable, State, Predicate, \
     _Atom, LiftedAtom, GroundAtom, Task, ParameterizedOption, _Option, \
     STRIPSOperator, NSRT, _GroundNSRT, Action, Segment, LowLevelTrajectory, \
     PartialNSRTAndDatastore, _GroundSTRIPSOperator, InteractionRequest, \
-    InteractionResult, DefaultState, Query
+    InteractionResult, DefaultState, Query, DemonstrationQuery
 from predicators.src import utils
 
 
@@ -825,5 +825,10 @@ def test_interaction_request_and_result():
 
 
 def test_query():
-    """Test for Query class."""
-    assert len(Query()) == 1  # test for coverage
+    """Test for Query classes."""
+    query = Query()
+    with pytest.raises(NotImplementedError):
+        query.cost
+    demo_query = DemonstrationQuery(0)
+    assert demo_query.cost == 1
+    


### PR DESCRIPTION
it's a little weird because we decided to allow the robot to ask about multiple ground atoms in one state, so in the case of `GroundAtomsHoldQuery` I'm taking "number of queries" to mean "number of ground atoms asked about."

also added some printouts for during the exploration part of online learning