### PR TITLE
disable sampler classifiers

### DIFF
--- a/analysis/run_supercloud_experiments.sh
+++ b/analysis/run_supercloud_experiments.sh
@@ -22,30 +22,30 @@ for SEED in $(seq $START_SEED $((NUM_SEEDS+START_SEED-1))); do
 
         # cover
         python $FILE --experiment_id cover_noinvent_noexclude_$NUM_TRAIN_TASKS --env cover --approach nsrt_learning $COMMON_ARGS
-        python $FILE --experiment_id cover_noinvent_allexclude_$NUM_TRAIN_TASKS --env cover --approach nsrt_learning --excluded_predicates all $COMMON_ARGS
-        python $FILE --experiment_id cover_invent_noexclude_$NUM_TRAIN_TASKS --env cover --approach grammar_search_invention $COMMON_ARGS
+        # python $FILE --experiment_id cover_noinvent_allexclude_$NUM_TRAIN_TASKS --env cover --approach nsrt_learning --excluded_predicates all $COMMON_ARGS
+        # python $FILE --experiment_id cover_invent_noexclude_$NUM_TRAIN_TASKS --env cover --approach grammar_search_invention $COMMON_ARGS
         python $FILE --experiment_id cover_invent_allexclude_$NUM_TRAIN_TASKS --env cover --approach grammar_search_invention --excluded_predicates all $COMMON_ARGS
 
         # blocks
         python $FILE --experiment_id blocks_noinvent_noexclude_$NUM_TRAIN_TASKS --env blocks --approach nsrt_learning $COMMON_ARGS
-        python $FILE --experiment_id blocks_noinvent_allexclude_$NUM_TRAIN_TASKS --env blocks --approach nsrt_learning --excluded_predicates all $COMMON_ARGS
-        python $FILE --experiment_id blocks_invent_noexclude_$NUM_TRAIN_TASKS --env blocks --approach grammar_search_invention $COMMON_ARGS
+        # python $FILE --experiment_id blocks_noinvent_allexclude_$NUM_TRAIN_TASKS --env blocks --approach nsrt_learning --excluded_predicates all $COMMON_ARGS
+        # python $FILE --experiment_id blocks_invent_noexclude_$NUM_TRAIN_TASKS --env blocks --approach grammar_search_invention $COMMON_ARGS
         python $FILE --experiment_id blocks_invent_allexclude_$NUM_TRAIN_TASKS --env blocks --approach grammar_search_invention --excluded_predicates all $COMMON_ARGS
 
         # painting
         python $FILE --experiment_id painting_noinvent_noexclude_$NUM_TRAIN_TASKS --env painting --approach nsrt_learning $COMMON_ARGS
-        python $FILE --experiment_id painting_noinvent_allexclude_$NUM_TRAIN_TASKS --env painting --approach nsrt_learning --excluded_predicates all $COMMON_ARGS
-        python $FILE --experiment_id painting_invent_noexclude_$NUM_TRAIN_TASKS --env painting --approach grammar_search_invention $COMMON_ARGS
+        # python $FILE --experiment_id painting_noinvent_allexclude_$NUM_TRAIN_TASKS --env painting --approach nsrt_learning --excluded_predicates all $COMMON_ARGS
+        # python $FILE --experiment_id painting_invent_noexclude_$NUM_TRAIN_TASKS --env painting --approach grammar_search_invention $COMMON_ARGS
         python $FILE --experiment_id painting_invent_allexclude_$NUM_TRAIN_TASKS --env painting --approach grammar_search_invention --excluded_predicates all $COMMON_ARGS
 
         # tools
         python $FILE --experiment_id tools_noinvent_noexclude_$NUM_TRAIN_TASKS --env tools --approach nsrt_learning $COMMON_ARGS
-        python $FILE --experiment_id tools_noinvent_allexclude_$NUM_TRAIN_TASKS --env tools --approach nsrt_learning --excluded_predicates all $COMMON_ARGS
-        python $FILE --experiment_id tools_invent_noexclude_$NUM_TRAIN_TASKS --env tools --approach grammar_search_invention $COMMON_ARGS
+        # python $FILE --experiment_id tools_noinvent_allexclude_$NUM_TRAIN_TASKS --env tools --approach nsrt_learning --excluded_predicates all $COMMON_ARGS
+        # python $FILE --experiment_id tools_invent_noexclude_$NUM_TRAIN_TASKS --env tools --approach grammar_search_invention $COMMON_ARGS
         python $FILE --experiment_id tools_invent_allexclude_$NUM_TRAIN_TASKS --env tools --approach grammar_search_invention --excluded_predicates all $COMMON_ARGS
 
         # repeated_nextto
         python $FILE --experiment_id repeated_nextto_noinvent_noexclude_$NUM_TRAIN_TASKS --env repeated_nextto --approach nsrt_learning --learn_side_predicates True $COMMON_ARGS
-        python $FILE --experiment_id repeated_nextto_noinvent_allexclude_$NUM_TRAIN_TASKS --env repeated_nextto --approach nsrt_learning --learn_side_predicates True --excluded_predicates all $COMMON_ARGS
+        # python $FILE --experiment_id repeated_nextto_noinvent_allexclude_$NUM_TRAIN_TASKS --env repeated_nextto --approach nsrt_learning --learn_side_predicates True --excluded_predicates all $COMMON_ARGS
     done
 done

--- a/analysis/run_supercloud_experiments.sh
+++ b/analysis/run_supercloud_experiments.sh
@@ -22,30 +22,30 @@ for SEED in $(seq $START_SEED $((NUM_SEEDS+START_SEED-1))); do
 
         # cover
         python $FILE --experiment_id cover_noinvent_noexclude_$NUM_TRAIN_TASKS --env cover --approach nsrt_learning $COMMON_ARGS
-        # python $FILE --experiment_id cover_noinvent_allexclude_$NUM_TRAIN_TASKS --env cover --approach nsrt_learning --excluded_predicates all $COMMON_ARGS
-        # python $FILE --experiment_id cover_invent_noexclude_$NUM_TRAIN_TASKS --env cover --approach grammar_search_invention $COMMON_ARGS
+        python $FILE --experiment_id cover_noinvent_allexclude_$NUM_TRAIN_TASKS --env cover --approach nsrt_learning --excluded_predicates all $COMMON_ARGS
+        python $FILE --experiment_id cover_invent_noexclude_$NUM_TRAIN_TASKS --env cover --approach grammar_search_invention $COMMON_ARGS
         python $FILE --experiment_id cover_invent_allexclude_$NUM_TRAIN_TASKS --env cover --approach grammar_search_invention --excluded_predicates all $COMMON_ARGS
 
         # blocks
         python $FILE --experiment_id blocks_noinvent_noexclude_$NUM_TRAIN_TASKS --env blocks --approach nsrt_learning $COMMON_ARGS
-        # python $FILE --experiment_id blocks_noinvent_allexclude_$NUM_TRAIN_TASKS --env blocks --approach nsrt_learning --excluded_predicates all $COMMON_ARGS
-        # python $FILE --experiment_id blocks_invent_noexclude_$NUM_TRAIN_TASKS --env blocks --approach grammar_search_invention $COMMON_ARGS
+        python $FILE --experiment_id blocks_noinvent_allexclude_$NUM_TRAIN_TASKS --env blocks --approach nsrt_learning --excluded_predicates all $COMMON_ARGS
+        python $FILE --experiment_id blocks_invent_noexclude_$NUM_TRAIN_TASKS --env blocks --approach grammar_search_invention $COMMON_ARGS
         python $FILE --experiment_id blocks_invent_allexclude_$NUM_TRAIN_TASKS --env blocks --approach grammar_search_invention --excluded_predicates all $COMMON_ARGS
 
         # painting
         python $FILE --experiment_id painting_noinvent_noexclude_$NUM_TRAIN_TASKS --env painting --approach nsrt_learning $COMMON_ARGS
-        # python $FILE --experiment_id painting_noinvent_allexclude_$NUM_TRAIN_TASKS --env painting --approach nsrt_learning --excluded_predicates all $COMMON_ARGS
-        # python $FILE --experiment_id painting_invent_noexclude_$NUM_TRAIN_TASKS --env painting --approach grammar_search_invention $COMMON_ARGS
+        python $FILE --experiment_id painting_noinvent_allexclude_$NUM_TRAIN_TASKS --env painting --approach nsrt_learning --excluded_predicates all $COMMON_ARGS
+        python $FILE --experiment_id painting_invent_noexclude_$NUM_TRAIN_TASKS --env painting --approach grammar_search_invention $COMMON_ARGS
         python $FILE --experiment_id painting_invent_allexclude_$NUM_TRAIN_TASKS --env painting --approach grammar_search_invention --excluded_predicates all $COMMON_ARGS
 
         # tools
         python $FILE --experiment_id tools_noinvent_noexclude_$NUM_TRAIN_TASKS --env tools --approach nsrt_learning $COMMON_ARGS
-        # python $FILE --experiment_id tools_noinvent_allexclude_$NUM_TRAIN_TASKS --env tools --approach nsrt_learning --excluded_predicates all $COMMON_ARGS
-        # python $FILE --experiment_id tools_invent_noexclude_$NUM_TRAIN_TASKS --env tools --approach grammar_search_invention $COMMON_ARGS
+        python $FILE --experiment_id tools_noinvent_allexclude_$NUM_TRAIN_TASKS --env tools --approach nsrt_learning --excluded_predicates all $COMMON_ARGS
+        python $FILE --experiment_id tools_invent_noexclude_$NUM_TRAIN_TASKS --env tools --approach grammar_search_invention $COMMON_ARGS
         python $FILE --experiment_id tools_invent_allexclude_$NUM_TRAIN_TASKS --env tools --approach grammar_search_invention --excluded_predicates all $COMMON_ARGS
 
         # repeated_nextto
         python $FILE --experiment_id repeated_nextto_noinvent_noexclude_$NUM_TRAIN_TASKS --env repeated_nextto --approach nsrt_learning --learn_side_predicates True $COMMON_ARGS
-        # python $FILE --experiment_id repeated_nextto_noinvent_allexclude_$NUM_TRAIN_TASKS --env repeated_nextto --approach nsrt_learning --learn_side_predicates True --excluded_predicates all $COMMON_ARGS
+        python $FILE --experiment_id repeated_nextto_noinvent_allexclude_$NUM_TRAIN_TASKS --env repeated_nextto --approach nsrt_learning --learn_side_predicates True --excluded_predicates all $COMMON_ARGS
     done
 done

--- a/src/nsrt_learning/sampler_learning.py
+++ b/src/nsrt_learning/sampler_learning.py
@@ -141,10 +141,7 @@ def _learn_neural_sampler(datastores: List[Datastore], nsrt_name: str,
                                 [0 for _ in negative_data])
     classifier = MLPClassifier(X_arr_classifier.shape[1],
                                CFG.sampler_mlp_classifier_max_itr)
-    if CFG.sampler_disable_classifier:
-        classifier.fit(X_arr_classifier, np.ones_like(y_arr_classifier))
-    else:
-        classifier.fit(X_arr_classifier, y_arr_classifier)
+    classifier.fit(X_arr_classifier, y_arr_classifier)
 
     # Fit regressor to data
     print("Fitting regressor...")
@@ -200,11 +197,11 @@ def _create_sampler_data(
                             for pre in preconditions)
                         positive_data.append((state, var_to_obj, option))
                         continue
-                sub = dict(zip(variables, grounding))
-                ground_preconditions = {p.ground(sub) for p in preconditions}
-                if CFG.sampler_classifier_neg_check_pre and \
-                   not ground_preconditions.issubset(segment.init_atoms):
+                if CFG.sampler_disable_classifier:
+                    # We disable the classifier by not providing it any
+                    # negative examples, so that it always outputs 1.
                     continue
+                sub = dict(zip(variables, grounding))
                 # When building data for a datastore with effects X, if we
                 # encounter a transition with effects Y, and if Y is a superset
                 # of X, then we do not want to include the transition as a

--- a/src/settings.py
+++ b/src/settings.py
@@ -126,6 +126,8 @@ class GlobalSettings:
     sampler_learner = "neural"  # "neural" or "random" or "oracle"
     max_rejection_sampling_tries = 100
     sampler_mlp_classifier_max_itr = 10000
+    sampler_classifier_neg_check_pre = False
+    sampler_disable_classifier = False
 
     # iterative invention parameters
     iterative_invention_accept_score = 1 - 1e-3

--- a/src/settings.py
+++ b/src/settings.py
@@ -128,8 +128,7 @@ class GlobalSettings:
     sampler_learner = "neural"  # "neural" or "random" or "oracle"
     max_rejection_sampling_tries = 100
     sampler_mlp_classifier_max_itr = 10000
-    sampler_classifier_neg_check_pre = False
-    sampler_disable_classifier = False
+    sampler_disable_classifier = True
 
     # iterative invention parameters
     iterative_invention_accept_score = 1 - 1e-3

--- a/tests/nsrt_learning/test_sampler_learning.py
+++ b/tests/nsrt_learning/test_sampler_learning.py
@@ -16,6 +16,7 @@ def test_create_sampler_data():
         "env": "cover",
         "min_data_for_nsrt": 0,
         "num_train_tasks": 15,
+        "sampler_disable_classifier": False,
     })
     # Create two datastores
     cup_type = Type("cup_type", ["feat1"])


### PR DESCRIPTION
Edit: opening this PR to turn off sampler classifiers, because they seem unnecessary based on experimentation. Can revert if it's causing problems later down the line.

some of the commits in this PR also close #474 (in particular, the experiment with `--sampler_classifier_neg_check_pre True`)

2/16/22 overnight experiments:

140 jobs per supercloud
ronuchit: control
tslvr: filter out neg data that doesn't match preconditions (`--sampler_classifier_neg_check_pre True`)
njk: no sampler classifier at all (`--sampler_disable_classifier True`)

cc @tomsilver @NishanthJKumar 