### PR TITLE
Flexible initial state

### DIFF
--- a/src/envs/cover.py
+++ b/src/envs/cover.py
@@ -794,10 +794,10 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         """Creates initial state by (1) placing targets and blocks in random
         locations such that each target has enough space on either side to
         ensure no covering placement will cause a collision (note that this is
-        not necessary to make the task solveable; but we can do this and instead
+        not necessary to make the task solvable; but we can do this and instead
         sufficiently tune the difficulty through hand region specification), and
         (2) choosing hand region intervals on the targets and blocks such that
-        the problem is solveable.
+        the problem is solvable.
         """
         data: Dict[Object, Array] = {}
 
@@ -807,7 +807,7 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
             overlap = False
             counter += 1
             if counter > CFG.cover_multistep_max_placements:
-                raise MaxPlacementsFailure("Reached maximum number of " \
+                raise RuntimeError("Reached maximum number of " \
                 "placements of targets and blocks.")
             block_placements = []
             for block, bw in zip(self._blocks, CFG.cover_block_widths):
@@ -851,7 +851,7 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         data[self._robot] = np.array([0.0, self.initial_robot_y, -1.0, -1.0])
 
         # Make the hand regions
-        # sample a hand region interval in each target
+        # Sample a hand region interval in each target
         target_hand_regions = []
         for i, target in enumerate(self._targets):
             target_hr = self._target_hand_regions[i]
@@ -863,7 +863,7 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
             data[target_hr] = np.array(region)
             target_hand_regions.append(region)
 
-        # sample a hand region interval in each block
+        # Sample a hand region interval in each block
         for i, block in enumerate(self._blocks):
             block_hr = self._block_hand_regions[i]
             thr_left, thr_right = target_hand_regions[i]
@@ -885,7 +885,7 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
             # one placement of the block which covers the target, and in
             # which the block's hand region and the target's hand region
             # have nonzero overlap.
-            # A proxy for this operation is to check:
+            # A proxy for this operation, which we do below, is to check:
             # (1) That in the block's rightmost covering placement, its
             # interval IS NOT completely to the left of the target's
             # hand region, and
@@ -896,16 +896,16 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
             while True:
                 counter += 1
                 if counter > CFG.cover_multistep_max_placements:
-                    raise MaxPlacementsFailure("Reached maximum number of " \
+                    raise RuntimeError("Reached maximum number of " \
                     "placements of hand regions.")
-                # sample hand region
+                # Sample hand region
                 left_pt = rng.uniform(bx - bw/2, bx + bw/2 - region_length)
                 region = [left_pt, left_pt + region_length]
-                # need to make hand region relative to center of block for
+                # Need to make hand region relative to center of block for
                 # the hand region to move with the block for use by
                 # _get_hand_regions()
                 relative_region = [region[0]-bx, region[1]-bx]
-                # perform the valid interval check
+                # Perform the valid interval check
                 relative_r = region[1] - (bx - bw/2)  # for (1)
                 relative_l = bx + bw/2 - region[0]  # for (2)
                 if relative_l >= (tx + tw/2 - thr_right) and \
@@ -1206,6 +1206,3 @@ class CoverMultistepOptionsFixedTasks(CoverMultistepOptions):
         del rng
         zero_rng = np.random.default_rng(0)
         return super()._create_initial_state(zero_rng)
-
-class MaxPlacementsFailure(Exception):
-    """Raised when the maximum number of placement attempts has been reached."""

--- a/src/envs/cover.py
+++ b/src/envs/cover.py
@@ -806,8 +806,6 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
             overlap = False
             counter += 1
             if counter > CFG.cover_multistep_max_tb_placements:
-                print("Reached maximum number of " \
-                "placements of targets and blocks.")
                 raise RuntimeError("Reached maximum number of " \
                 "placements of targets and blocks.")
             block_placements = []
@@ -897,8 +895,6 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
             while True:
                 counter += 1
                 if counter > CFG.cover_multistep_max_hr_placements:
-                    print("Reached maximum number of " \
-                    "placements of hand regions.")
                     raise RuntimeError("Reached maximum number of " \
                     "placements of hand regions.")
                 # Sample hand region

--- a/src/envs/cover.py
+++ b/src/envs/cover.py
@@ -712,7 +712,9 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         # Draw main line
         plt.plot([-0.2, 1.2], [-0.001, -0.001], color="black", linewidth=0.4)
         # Draw hand regions
-        hand_regions = self._get_hand_regions(state)
+        block_hand_regions = self._get_hand_regions_block(state)
+        target_hand_regions = self._get_hand_regions_target(state)
+        hand_regions = block_hand_regions + target_hand_regions
         for i, (hand_lb, hand_rb) in enumerate(hand_regions):
             if i == 0:
                 label = "Allowed hand region"

--- a/src/envs/cover.py
+++ b/src/envs/cover.py
@@ -512,12 +512,12 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         self._target_hand_regions = []
         for i in range(CFG.cover_num_blocks):
             self._blocks.append(Object(f"block{i}", self._block_type))
-            self._block_hand_regions.append(Object(f"block_{i}_hand_region", \
+            self._block_hand_regions.append(Object(f"block{i}_hand_region", \
             self._hand_region_type))
         for i in range(CFG.cover_num_targets):
             target = Object(f"target{i}", self._target_type)
             self._targets.append(target)
-            self._target_hand_regions.append(Object(f"target_{i}_hand_region", \
+            self._target_hand_regions.append(Object(f"target{i}_hand_region", \
             self._hand_region_type))
         self._robot = Object("robby", self._robot_type)
         # Override the original options to make them multi-step.

--- a/src/envs/cover.py
+++ b/src/envs/cover.py
@@ -723,7 +723,7 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
             plt.plot([hand_lb, hand_rb], [-0.08, -0.08],
                      color="red",
                      alpha=0.5,
-                     lw=8.,
+                     lw=4.,
                      label=label)
         # Draw hand
         plt.scatter(state.get(self._robot, "x"),
@@ -911,7 +911,6 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
                 if relative_l >= (tx + tw/2 - thr_right) and \
                     relative_r >= (thr_left-(tx - tw/2)):
                     break
-
             data[block_hr] = np.array(relative_region)
 
         return State(data)

--- a/src/envs/cover.py
+++ b/src/envs/cover.py
@@ -795,10 +795,9 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         locations such that each target has enough space on either side to
         ensure no covering placement will cause a collision (note that this is
         not necessary to make the task solvable; but we can do this and instead
-        sufficiently tune the difficulty through hand region specification), and
-        (2) choosing hand region intervals on the targets and blocks such that
-        the problem is solvable.
-        """
+        sufficiently tune the difficulty through hand region specification),
+        and (2) choosing hand region intervals on the targets and blocks such
+        that the problem is solvable."""
         data: Dict[Object, Array] = {}
 
         # Place targets and blocks
@@ -806,28 +805,30 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         while True:
             overlap = False
             counter += 1
-            if counter > CFG.cover_multistep_max_placements:
+            if counter > CFG.cover_multistep_max_tb_placements:
+                print("Reached maximum number of " \
+                "placements of targets and blocks.")
                 raise RuntimeError("Reached maximum number of " \
                 "placements of targets and blocks.")
             block_placements = []
             for block, bw in zip(self._blocks, CFG.cover_block_widths):
-                xb = rng.uniform(bw/2, 1-bw/2)
-                left_pt = xb - bw/2
-                right_pt = xb + bw/2
+                xb = rng.uniform(bw / 2, 1 - bw / 2)
+                left_pt = xb - bw / 2
+                right_pt = xb + bw / 2
                 block_placements.append((left_pt, xb, right_pt))
             target_placements = []
             for target, tw, bw in zip(self._targets, CFG.cover_target_widths, \
                 CFG.cover_block_widths):
-                xt = rng.uniform(bw-tw/2, 1-bw+tw/2)
-                left_pt = xt + tw/2 - bw
-                right_pt = xt - tw/2 + bw
+                xt = rng.uniform(bw - tw / 2, 1 - bw + tw / 2)
+                left_pt = xt + tw / 2 - bw
+                right_pt = xt - tw / 2 + bw
                 target_placements.append((left_pt, xt, right_pt))
             # check for overlap
             all_placements = target_placements + block_placements
             all_placements.sort(key=lambda x: x[0])
             for i in range(1, len(all_placements)):
                 curr = all_placements[i]
-                prev = all_placements[i-1]
+                prev = all_placements[i - 1]
                 if curr[0] < prev[2]:
                     overlap = True
             if not overlap:
@@ -858,7 +859,7 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
             tw = CFG.cover_target_widths[i]
             _, x, _ = target_placements[i]
             region_length = tw * CFG.cover_multistep_thr_percent
-            left_pt = rng.uniform(x - tw/2, x + tw/2 - region_length)
+            left_pt = rng.uniform(x - tw / 2, x + tw / 2 - region_length)
             region = [left_pt, left_pt + region_length]
             data[target_hr] = np.array(region)
             target_hand_regions.append(region)
@@ -895,19 +896,21 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
             counter = 0
             while True:
                 counter += 1
-                if counter > CFG.cover_multistep_max_placements:
+                if counter > CFG.cover_multistep_max_hr_placements:
+                    print("Reached maximum number of " \
+                    "placements of hand regions.")
                     raise RuntimeError("Reached maximum number of " \
                     "placements of hand regions.")
                 # Sample hand region
-                left_pt = rng.uniform(bx - bw/2, bx + bw/2 - region_length)
+                left_pt = rng.uniform(bx - bw / 2, bx + bw / 2 - region_length)
                 region = [left_pt, left_pt + region_length]
                 # Need to make hand region relative to center of block for
                 # the hand region to move with the block for use by
                 # _get_hand_regions()
-                relative_region = [region[0]-bx, region[1]-bx]
+                relative_region = [region[0] - bx, region[1] - bx]
                 # Perform the valid interval check
-                relative_r = region[1] - (bx - bw/2)  # for (1)
-                relative_l = bx + bw/2 - region[0]  # for (2)
+                relative_r = region[1] - (bx - bw / 2)  # for (1)
+                relative_l = bx + bw / 2 - region[0]  # for (2)
                 if relative_l >= (tx + tw/2 - thr_right) and \
                     relative_r >= (thr_left-(tx - tw/2)):
                     break
@@ -928,9 +931,8 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         -> List[Tuple[float, float]]:
         hand_regions = []
         for target_hr in self._target_hand_regions:
-            hand_regions.append(
-                (state.get(target_hr, "lb"),
-                 state.get(target_hr, "ub")))
+            hand_regions.append((state.get(target_hr,
+                                           "lb"), state.get(target_hr, "ub")))
         return hand_regions
 
     def _Pick_initiable(self, s: State, m: Dict, o: Sequence[Object],

--- a/src/settings.py
+++ b/src/settings.py
@@ -40,8 +40,8 @@ class GlobalSettings:
     cover_multistep_action_limits = [-np.inf, np.inf]
     cover_multistep_use_learned_equivalents = True
     cover_multistep_degenerate_oracle_samplers = False
-    cover_multistep_max_tb_placements = 100 # max placements of targets/blocks
-    cover_multistep_max_hr_placements = 100 # max placements of hand regions
+    cover_multistep_max_tb_placements = 100  # max placements of targets/blocks
+    cover_multistep_max_hr_placements = 100  # max placements of hand regions
     cover_multistep_thr_percent = 0.5  # target hand region percent of width
     cover_multistep_bhr_percent = 0.5  # block hand region percent of width
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -40,9 +40,10 @@ class GlobalSettings:
     cover_multistep_action_limits = [-np.inf, np.inf]
     cover_multistep_use_learned_equivalents = True
     cover_multistep_degenerate_oracle_samplers = False
-    cover_multistep_max_placements = 100
-    cover_multistep_thr_percent = 0.5 # target hand region percent of width
-    cover_multistep_bhr_percent = 0.5 # block hand region percent of width
+    cover_multistep_max_tb_placements = 100 # max placements of targets/blocks
+    cover_multistep_max_hr_placements = 100 # max placements of hand regions
+    cover_multistep_thr_percent = 0.5  # target hand region percent of width
+    cover_multistep_bhr_percent = 0.5  # block hand region percent of width
 
     # cluttered table env parameters
     cluttered_table_num_cans_train = 5

--- a/src/settings.py
+++ b/src/settings.py
@@ -40,6 +40,9 @@ class GlobalSettings:
     cover_multistep_action_limits = [-np.inf, np.inf]
     cover_multistep_use_learned_equivalents = True
     cover_multistep_degenerate_oracle_samplers = False
+    cover_multistep_max_placements = 100
+    cover_multistep_thr_percent = 0.5 # target hand region percent of width
+    cover_multistep_bhr_percent = 0.5 # block hand region percent of width
 
     # cluttered table env parameters
     cluttered_table_num_cans_train = 5

--- a/tests/envs/test_cover.py
+++ b/tests/envs/test_cover.py
@@ -1,5 +1,6 @@
 """Test cases for the cover environment."""
 
+import pytest
 import numpy as np
 from gym.spaces import Box
 from predicators.src.envs import CoverEnv, CoverEnvTypedOptions, \
@@ -7,7 +8,7 @@ from predicators.src.envs import CoverEnv, CoverEnvTypedOptions, \
     CoverEnvRegrasp
 from predicators.src.structs import State, Action, Task
 from predicators.src import utils
-
+from predicators.src.envs.cover import MaxPlacementsFailure
 
 def test_cover():
     """Tests for CoverEnv class."""
@@ -238,7 +239,6 @@ def test_cover_multistep_options():
     # Run through a specific plan of low-level actions.
     task = env.get_test_tasks()[0]
     state = task.init
-    goal = task.goal
     block0 = [b for b in state if b.name == "block0"][0]
     block1 = [b for b in state if b.name == "block1"][0]
     target0 = [b for b in state if b.name == "target0"][0]
@@ -253,9 +253,9 @@ def test_cover_multistep_options():
     state.data[target1] = np.array([0., 1., 0.03, 0.63629464])
     state.data[block0_hr] = np.array([-0.1/2, 0.1/2])
     state.data[block1_hr] = np.array([-0.07/2, 0.07/2])
-    state.data[target0_hr] = np.array([0.17778981 - 0.05/2, 0.17778981 + 0.05/2])
-    state.data[target1_hr] = np.array([0.63629464 - 0.03/2, 0.63629464 + 0.03/2])
-    task = Task(state, goal)
+    state.data[target0_hr] = np.array([0.17778981-0.05/2, 0.17778981+0.05/2])
+    state.data[target1_hr] = np.array([0.63629464-0.03/2, 0.63629464+0.03/2])
+    task = Task(state, task.goal)
     action_arrs = [
         # Move to above block0
         np.array([0.05, 0., 0.], dtype=np.float32),
@@ -527,6 +527,32 @@ def test_cover_multistep_options():
     robot = [r for r in traj.states[0] if r.name == "robby"][0]
     assert np.array_equal(traj.states[-1][robot], traj.states[-2][robot])
 
+    # Check max placement failure for target and block placement
+    utils.reset_config({
+        "env": "cover_multistep_options",
+        "num_train_tasks": 10,
+        "num_test_tasks": 10,
+        "cover_block_widths": [0.25, 0.25],
+        "cover_target_widths": [0.25, 0.25]
+    })
+    env = CoverMultistepOptions()
+    env.seed(123)
+    with pytest.raises(MaxPlacementsFailure):
+        env.get_test_tasks()
+
+    # Check max placement failure for hand region placement
+    utils.reset_config({
+        "env": "cover_multistep_options",
+        "num_train_tasks": 10,
+        "num_test_tasks": 10,
+        "cover_multistep_max_placements": 2,
+        "cover_multistep_thr_percent": 0.001,
+        "cover_multistep_bhr_percent": 0.001
+    })
+    env = CoverMultistepOptions()
+    env.seed(123)
+    with pytest.raises(MaxPlacementsFailure):
+        env.get_test_tasks()
 
 def test_cover_multistep_options_fixed_tasks():
     """Tests for CoverMultistepOptionsFixedTasks."""

--- a/tests/envs/test_cover.py
+++ b/tests/envs/test_cover.py
@@ -8,7 +8,6 @@ from predicators.src.envs import CoverEnv, CoverEnvTypedOptions, \
     CoverEnvRegrasp
 from predicators.src.structs import State, Action, Task
 from predicators.src import utils
-from predicators.src.envs.cover import MaxPlacementsFailure
 
 def test_cover():
     """Tests for CoverEnv class."""
@@ -537,7 +536,7 @@ def test_cover_multistep_options():
     })
     env = CoverMultistepOptions()
     env.seed(123)
-    with pytest.raises(MaxPlacementsFailure):
+    with pytest.raises(RuntimeError):
         env.get_test_tasks()
 
     # Check max placement failure for hand region placement
@@ -551,7 +550,7 @@ def test_cover_multistep_options():
     })
     env = CoverMultistepOptions()
     env.seed(123)
-    with pytest.raises(MaxPlacementsFailure):
+    with pytest.raises(RuntimeError):
         env.get_test_tasks()
 
     # Test that new _create_initial_state is working
@@ -565,8 +564,7 @@ def test_cover_multistep_options():
     env = CoverMultistepOptions()
     env.seed(123)
     task = env.get_test_tasks()[0]
-    print(task.init.pretty_str())
-    make_video = True  # Can toggle to true for debugging
+    make_video = False  # Can toggle to true for debugging
 
     action_arrs = [
         np.array([0.88, 0., 0.], dtype=np.float32),
@@ -603,7 +601,6 @@ def test_cover_multistep_options():
     Covers = [p for p in env.predicates if p.name == "Covers"][0]
     init_atoms = utils.abstract(state, env.predicates)
     final_atoms = utils.abstract(traj.states[-1], env.predicates)
-    print("final state: ", traj.states[-1].pretty_str())
     assert Covers([block0, target0]) not in init_atoms
     assert Covers([block0, target0]) in final_atoms
 

--- a/tests/envs/test_cover.py
+++ b/tests/envs/test_cover.py
@@ -5,7 +5,7 @@ from gym.spaces import Box
 from predicators.src.envs import CoverEnv, CoverEnvTypedOptions, \
     CoverMultistepOptions, CoverMultistepOptionsFixedTasks, \
     CoverEnvRegrasp
-from predicators.src.structs import State, Action
+from predicators.src.structs import State, Action, Task
 from predicators.src import utils
 
 
@@ -237,6 +237,27 @@ def test_cover_multistep_options():
     assert len(env.action_space.low) == 3
     # Run through a specific plan of low-level actions.
     task = env.get_test_tasks()[0]
+    state = task.init
+    goal = task.goal
+    block0 = [b for b in state if b.name == "block0"][0]
+    block1 = [b for b in state if b.name == "block1"][0]
+    target0 = [b for b in state if b.name == "target0"][0]
+    target1 = [b for b in state if b.name == "target1"][0]
+    block0_hr = [b for b in state if b.name == "block0_hand_region"][0]
+    block1_hr = [b for b in state if b.name == "block1_hand_region"][0]
+    target0_hr = [b for b in state if b.name == "target0_hand_region"][0]
+    target1_hr = [b for b in state if b.name == "target1_hand_region"][0]
+    state.data[block0] = np.array([1., 0., 0.1, 0.43592563, -1., 0.1, 0.1])
+    state.data[block1] = np.array([1., 0., 0.07, 0.8334956, -1., 0.1, 0.1])
+    state.data[target0] = np.array([0., 1., 0.05, 0.17778981])
+    state.data[target1] = np.array([0., 1., 0.03, 0.63629464])
+    state.data[block0_hr] = np.array([0.43592563 - 0.1/2, 0.43592563 + 0.1/2])
+    state.data[block1_hr] = np.array([0.8334956 - 0.07/2, 0.8334956 + 0.07/2])
+    state.data[target0_hr] = np.array([0.17778981 - 0.05/2, 0.17778981 + 0.05/2])
+    state.data[target1_hr] = np.array([0.63629464 - 0.03/2, 0.63629464 + 0.03/2])
+    task = Task(state, goal)
+    env.render(state, task)
+    break
     action_arrs = [
         # Move to above block0
         np.array([0.05, 0., 0.], dtype=np.float32),
@@ -284,7 +305,7 @@ def test_cover_multistep_options():
         # Ungrasp
         np.array([0., 0., -0.1], dtype=np.float32),
     ]
-    make_video = False  # Can toggle to true for debugging
+    make_video = True  # Can toggle to true for debugging
 
     def policy(s: State) -> Action:
         del s  # unused
@@ -300,12 +321,6 @@ def test_cover_multistep_options():
     env.render(state, task)
     # Render a state where we're grasping
     env.render(traj.states[20], task)
-    block0 = [b for b in state if b.name == "block0"][0]
-    block1 = [b for b in state if b.name == "block1"][0]
-    target0 = [b for b in state if b.name == "target0"][0]
-    target1 = [b for b in state if b.name == "target1"][0]
-    block0 = [b for b in state if b.name == "block0"][0]
-    target0 = [b for b in state if b.name == "target0"][0]
     Covers = [p for p in env.predicates if p.name == "Covers"][0]
     init_atoms = utils.abstract(state, env.predicates)
     final_atoms = utils.abstract(traj.states[-1], env.predicates)

--- a/tests/envs/test_cover.py
+++ b/tests/envs/test_cover.py
@@ -9,6 +9,7 @@ from predicators.src.envs import CoverEnv, CoverEnvTypedOptions, \
 from predicators.src.structs import State, Action, Task
 from predicators.src import utils
 
+
 def test_cover():
     """Tests for CoverEnv class."""
     utils.reset_config({"env": "cover", "cover_initial_holding_prob": 0.0})
@@ -250,10 +251,12 @@ def test_cover_multistep_options():
     state.data[block1] = np.array([1., 0., 0.07, 0.8334956, -1., 0.1, 0.1])
     state.data[target0] = np.array([0., 1., 0.05, 0.17778981])
     state.data[target1] = np.array([0., 1., 0.03, 0.63629464])
-    state.data[block0_hr] = np.array([-0.1/2, 0.1/2])
-    state.data[block1_hr] = np.array([-0.07/2, 0.07/2])
-    state.data[target0_hr] = np.array([0.17778981-0.05/2, 0.17778981+0.05/2])
-    state.data[target1_hr] = np.array([0.63629464-0.03/2, 0.63629464+0.03/2])
+    state.data[block0_hr] = np.array([-0.1 / 2, 0.1 / 2])
+    state.data[block1_hr] = np.array([-0.07 / 2, 0.07 / 2])
+    state.data[target0_hr] = np.array(
+        [0.17778981 - 0.05 / 2, 0.17778981 + 0.05 / 2])
+    state.data[target1_hr] = np.array(
+        [0.63629464 - 0.03 / 2, 0.63629464 + 0.03 / 2])
     task = Task(state, task.goal)
     action_arrs = [
         # Move to above block0
@@ -537,21 +540,22 @@ def test_cover_multistep_options():
     env = CoverMultistepOptions()
     env.seed(123)
     with pytest.raises(RuntimeError):
-        env.get_test_tasks()
+        tasks = env.get_test_tasks()
 
     # Check max placement failure for hand region placement
     utils.reset_config({
         "env": "cover_multistep_options",
         "num_train_tasks": 10,
         "num_test_tasks": 10,
-        "cover_multistep_max_placements": 2,
+        "cover_multistep_max_tb_placements": 100,
+        "cover_multistep_max_hr_placements": 2,
         "cover_multistep_thr_percent": 0.001,
         "cover_multistep_bhr_percent": 0.001
     })
     env = CoverMultistepOptions()
     env.seed(123)
     with pytest.raises(RuntimeError):
-        env.get_test_tasks()
+        tasks = env.get_test_tasks()
 
     # Test that new _create_initial_state is working
     utils.reset_config({
@@ -564,8 +568,6 @@ def test_cover_multistep_options():
     env = CoverMultistepOptions()
     env.seed(123)
     task = env.get_test_tasks()[0]
-    make_video = False  # Can toggle to true for debugging
-
     action_arrs = [
         np.array([0.88, 0., 0.], dtype=np.float32),
         np.array([0., -0.05, 0], dtype=np.float32),
@@ -587,11 +589,7 @@ def test_cover_multistep_options():
         np.array([0., -0.1, 0.1], dtype=np.float32),
         np.array([0., -0.01, -0.1], dtype=np.float32),
     ]
-
-    def policy(s: State) -> Action:
-        del s  # unused
-        return Action(action_arrs.pop(0))
-
+    make_video = False  # Can toggle to true for debugging
     traj, video, _ = utils.run_policy_on_task(
         policy, task, env.simulate, len(action_arrs),
         env.render if make_video else None)
@@ -603,6 +601,7 @@ def test_cover_multistep_options():
     final_atoms = utils.abstract(traj.states[-1], env.predicates)
     assert Covers([block0, target0]) not in init_atoms
     assert Covers([block0, target0]) in final_atoms
+
 
 def test_cover_multistep_options_fixed_tasks():
     """Tests for CoverMultistepOptionsFixedTasks."""

--- a/tests/envs/test_cover.py
+++ b/tests/envs/test_cover.py
@@ -540,7 +540,7 @@ def test_cover_multistep_options():
     env = CoverMultistepOptions()
     env.seed(123)
     with pytest.raises(RuntimeError):
-        tasks = env.get_test_tasks()
+        env.get_test_tasks()
 
     # Check max placement failure for hand region placement
     utils.reset_config({
@@ -555,7 +555,7 @@ def test_cover_multistep_options():
     env = CoverMultistepOptions()
     env.seed(123)
     with pytest.raises(RuntimeError):
-        tasks = env.get_test_tasks()
+        env.get_test_tasks()
 
     # Test that new _create_initial_state is working
     utils.reset_config({

--- a/tests/envs/test_cover.py
+++ b/tests/envs/test_cover.py
@@ -251,13 +251,11 @@ def test_cover_multistep_options():
     state.data[block1] = np.array([1., 0., 0.07, 0.8334956, -1., 0.1, 0.1])
     state.data[target0] = np.array([0., 1., 0.05, 0.17778981])
     state.data[target1] = np.array([0., 1., 0.03, 0.63629464])
-    state.data[block0_hr] = np.array([0.43592563 - 0.1/2, 0.43592563 + 0.1/2])
-    state.data[block1_hr] = np.array([0.8334956 - 0.07/2, 0.8334956 + 0.07/2])
+    state.data[block0_hr] = np.array([-0.1/2, 0.1/2])
+    state.data[block1_hr] = np.array([-0.07/2, 0.07/2])
     state.data[target0_hr] = np.array([0.17778981 - 0.05/2, 0.17778981 + 0.05/2])
     state.data[target1_hr] = np.array([0.63629464 - 0.03/2, 0.63629464 + 0.03/2])
     task = Task(state, goal)
-    env.render(state, task)
-    break
     action_arrs = [
         # Move to above block0
         np.array([0.05, 0., 0.], dtype=np.float32),
@@ -305,7 +303,7 @@ def test_cover_multistep_options():
         # Ungrasp
         np.array([0., 0., -0.1], dtype=np.float32),
     ]
-    make_video = True  # Can toggle to true for debugging
+    make_video = False  # Can toggle to true for debugging
 
     def policy(s: State) -> Action:
         del s  # unused

--- a/tests/envs/test_cover.py
+++ b/tests/envs/test_cover.py
@@ -564,7 +564,8 @@ def test_cover_multistep_options():
         "num_train_tasks": 10,
         "num_test_tasks": 10,
         "cover_multistep_thr_percent": 0.2,
-        "cover_multistep_bhr_percent": 0.2
+        "cover_multistep_bhr_percent": 0.2,
+        "test_env_seed_offset": 0
     })
     env = CoverMultistepOptions()
     env.seed(123)

--- a/tests/nsrt_learning/test_option_learning.py
+++ b/tests/nsrt_learning/test_option_learning.py
@@ -181,7 +181,8 @@ def test_learned_neural_parameterized_option():
     env.seed(123)
     task = env.get_test_tasks()[0]
     state = task.init.copy()
-    block0, block1, robot, _, _ = sorted(state)
+    print("SORTED STATE: ", sorted(state))
+    block0, block1, _, _, robot, _, _, _, _ = sorted(state)
     assert block0.name == "block0"
     assert robot.name == "robby"
     option = param_option.ground([block0, robot],

--- a/tests/nsrt_learning/test_option_learning.py
+++ b/tests/nsrt_learning/test_option_learning.py
@@ -182,7 +182,6 @@ def test_learned_neural_parameterized_option():
     task = env.get_test_tasks()[0]
 
     state = task.init.copy()
-    print("SORTED STATE: ", sorted(state))
     block0, _, block1, _, robot, _, _, _, _ = sorted(state)
     assert block0.name == "block0"
     assert robot.name == "robby"

--- a/tests/nsrt_learning/test_option_learning.py
+++ b/tests/nsrt_learning/test_option_learning.py
@@ -180,9 +180,10 @@ def test_learned_neural_parameterized_option():
     # Get an initial state where picking should be possible.
     env.seed(123)
     task = env.get_test_tasks()[0]
+
     state = task.init.copy()
     print("SORTED STATE: ", sorted(state))
-    block0, block1, _, _, robot, _, _, _, _ = sorted(state)
+    block0, _, block1, _, robot, _, _, _, _ = sorted(state)
     assert block0.name == "block0"
     assert robot.name == "robby"
     option = param_option.ground([block0, robot],


### PR DESCRIPTION
Creates initial state by (1) placing targets and blocks in random locations such that each target has enough space on either side to ensure no covering placement will cause a collision (note that this is not necessary to make the task solveable; but we can do this and instead sufficiently tune the difficulty through hand region specification), and (2) choosing hand region intervals on the targets and blocks such that the problem is solveable.

Note that the hand regions could be made attributes of the target and block objects. This was not done just because it would require editing more code all over the codebase, and creating new "hand region objects" didn't seem like an issue. But, can make this change if preferred.  

There are two kinds of difficulties we want to be able to tune: 
1. Measure of backtracking difficulty (need to resample the pick()): what percent of samples in the pick() option will lead to a place() that is impossible to cover the target with, assuming you try placing somewhere along the target's hand_region?
2. Measure of resampling difficulty (need to resample the place()): what percent of samples in the place() option will lead to a place() that is infeasible due to not hitting the target's hand_region?
Will follow up with some code that simulates to figure out what parameters to choose for CFG.cover_multistep_bhr_percent and CFG.cover_multistep_thr_percent to get the kind of difficulty we want (explicitly measuring the difficulty) while keeping the problem solveable in reasonable time. 

Linter is failing on code I didn't touch, and the tests are saying missing coverage for lines I didn't touch (still looking into this). Also, I will add a test that hard-codes solving one task with the new create_initial_state function. 