### PR TITLE
goal predicate learning proof of concept

### DIFF
--- a/src/approaches/interactive_learning_approach.py
+++ b/src/approaches/interactive_learning_approach.py
@@ -11,8 +11,7 @@ from predicators.src.structs import State, Predicate, ParameterizedOption, \
     Type, Task, Dataset, GroundAtom, LowLevelTrajectory, InteractionRequest, \
     InteractionResult, Action, GroundAtomsHoldQuery, GroundAtomsHoldResponse, \
     Query
-from predicators.src.torch_models import LearnedPredicateClassifier, \
-    MLPClassifier
+from predicators.src.torch_models import learn_predicate_from_annotated_data
 from predicators.src.settings import CFG
 
 
@@ -68,38 +67,7 @@ class InteractiveLearningApproach(NSRTLearningApproach):
         print("\nRelearning predicates and NSRTs...")
         # Learn predicates
         for pred in self._predicates_to_learn:
-            input_examples = []
-            output_examples = []
-            for (traj, traj_annotations) in zip(self._dataset.trajectories,
-                                                self._dataset.annotations):
-                assert len(traj.states) == len(traj_annotations)
-                for (state, state_annotation) in zip(traj.states,
-                                                     traj_annotations):
-                    assert len(state_annotation) == 2
-                    for target_class, examples in enumerate(state_annotation):
-                        for atom in examples:
-                            if not atom.predicate == pred:
-                                continue
-                            x = state.vec(atom.objects)
-                            input_examples.append(x)
-                            output_examples.append(target_class)
-            num_positives = sum(y == 1 for y in output_examples)
-            num_negatives = sum(y == 0 for y in output_examples)
-            assert num_positives + num_negatives == len(output_examples)
-            print(f"Generated {num_positives} positive and "
-                  f"{num_negatives} negative examples for "
-                  f"predicate {pred}")
-
-            # Train MLP
-            X = np.array(input_examples)
-            Y = np.array(output_examples)
-            model = MLPClassifier(X.shape[1],
-                                  CFG.predicate_mlp_classifier_max_itr)
-            model.fit(X, Y)
-
-            # Construct classifier function, create new Predicate, and save it
-            classifier = LearnedPredicateClassifier(model).classifier
-            new_pred = Predicate(pred.name, pred.types, classifier)
+            new_pred = learn_predicate_from_annotated_data(pred, self._dataset)
             self._predicates_to_learn = \
                 (self._predicates_to_learn - {pred}) | {new_pred}
 

--- a/src/datasets/__init__.py
+++ b/src/datasets/__init__.py
@@ -26,6 +26,11 @@ def create_dataset(env: BaseEnv, train_tasks: List[Task]) -> Dataset:
         n = int(CFG.teacher_dataset_num_examples)
         assert n >= 1, "Must have at least 1 example of each predicate"
         return create_ground_atom_data(env, base_dataset, excluded_preds, n)
+    if CFG.offline_data_method == "demo+goal_atoms":
+        base_dataset = create_demo_data(env, train_tasks)
+        # Annotate all goal predicates.
+        excluded_preds = set(env.goal_predicates)
+        return create_ground_atom_data(env, base_dataset, excluded_preds)
     if CFG.offline_data_method == "empty":
         return Dataset([])
     raise NotImplementedError("Unrecognized dataset method.")

--- a/src/settings.py
+++ b/src/settings.py
@@ -171,6 +171,7 @@ class GlobalSettings:
     grammar_search_expected_nodes_include_suspicious_score = False
     grammar_search_expected_nodes_allow_noops = True
     grammar_search_classifier_pretty_str_names = ["?x", "?y", "?z"]
+    grammar_search_learn_goal_predicates = False
 
     @staticmethod
     def get_arg_specific_settings(args: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
I expect this to break for goal predicates that would require quantification. But in the meantime, here's an encouraging initial result:

`python src/main.py --env cover --approach grammar_search_invention --seed 0 --excluded_predicates all --grammar_search_learn_goal_predicates True --offline_data_method demo+goal_atoms`

```
CREATED DATASET
Generated 137 positive and 555 negative examples for predicate Covers
Reduced dataset size from 692 to 274
Training MLPClassifier on 274 datapoints
Loss: 0.00727, iter: 1000/1000
Loaded best model with loss: 0.00727
Generating candidate predicates...
```
...
```
Tasks solved: 50 / 50
Average time for successes: 0.00949 seconds
Test results: defaultdict(<class 'float'>, {'num_solved': 50, 'num_total': 50, 'avg_suc_time': 0.009485149383544922, 'min_skeletons_optimized': 1.0, 'max_skeletons_optimized': 1.0, 'avg_execution_failures': 0.0, 'avg_num_skeletons_optimized': 1.0, 'avg_num_nodes_expanded': 2.64, 'avg_num_nodes_created': 5.02, 'avg_num_nsrts': 2.0, 'avg_num_preds': 6.0, 'avg_plan_length': 2.46, 'avg_num_failures_discovered': 0.0, 'num_transitions': 123, 'cumulative_query_cost': 0.0, 'learning_time': 183.4433159828186})
Main script terminated in 186.09634 seconds
```