### PR TITLE
Minor fixes to cluttered place

### DIFF
--- a/src/envs/cluttered_table.py
+++ b/src/envs/cluttered_table.py
@@ -292,7 +292,7 @@ class ClutteredTablePlaceEnv(ClutteredTableEnv):
     This version places grasped cans instead of dumping them, and has
     several additional constraints. There are two cans, a goal can and
     an obstructing can in front of it. The action space is restricted so
-    that actions can only begin from the point (0.2,0) and end in the
+    that actions can only begin from the point (0.2,1) and end in the
     [0,0.4] by [0,1.0] region. The goal behavior is to learn to pick up
     the colliding can and place it out of the way of the goal can.
     """
@@ -302,14 +302,14 @@ class ClutteredTablePlaceEnv(ClutteredTableEnv):
         self._Place = ParameterizedOption("Place", [self._can_type],
                                           params_space=Box(
                                               np.array([0, 0, 0, 0]),
-                                              np.array([0.2, 0.2, 1, 1])),
+                                              np.array([1, 1, 1, 1])),
                                           _policy=self._Place_policy,
                                           _initiable=utils.always_initiable,
                                           _terminal=utils.onestep_terminal)
         self._Grasp = ParameterizedOption("Grasp", [self._can_type],
                                           params_space=Box(
                                               np.array([0, 0, 0, 0]),
-                                              np.array([0.2, 0.2, 1, 1])),
+                                              np.array([1, 1, 1, 1])),
                                           _policy=self._Grasp_policy,
                                           _initiable=utils.always_initiable,
                                           _terminal=utils.onestep_terminal)
@@ -324,7 +324,7 @@ class ClutteredTablePlaceEnv(ClutteredTableEnv):
 
     @property
     def action_space(self) -> Box:
-        # The action's starting x,y coordinates are always (0.2,0), and the
+        # The action's starting x,y coordinates are always (0.2,1), and the
         # ending coordinates are in a more narrow region than in the original
         # task. Constraints make this version of the task more challenging.
         return Box(np.array([0, 0, 0, 0]), np.array([1, 1, 1, 1]))
@@ -381,6 +381,6 @@ class ClutteredTablePlaceEnv(ClutteredTableEnv):
         # on the left or right. The obstructing can is in the middle of the
         # action space.
         goal_x = 0.3 if self._train_rng.uniform() < 0.5 else 0.1
-        data[self._cans[0]] = np.array([goal_x, 0.7, radius, 0.0, 0.0])
-        data[self._cans[1]] = np.array([0.2, 0.5, radius, 0.0, 0.0])
+        data[self._cans[0]] = np.array([goal_x, 0.8, radius, 0.0, 0.0])
+        data[self._cans[1]] = np.array([0.2, 0.6, radius, 0.0, 0.0])
         return State(data)

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -427,7 +427,7 @@ def _get_cluttered_table_gt_nsrts(with_place: bool = False) -> Set[NSRT]:
                 # Place up w.r.t the goal, and to some distance left
                 # or right such that we're not going out of x bounds
                 # 0 to 0.4.
-                end_y = goal_y * 1.2
+                end_y = goal_y * 1.1
                 end_x = goal_x + 0.2
                 if end_x > 0.4:
                     end_x = goal_x - 0.2

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -367,7 +367,7 @@ def _get_cluttered_table_gt_nsrts(with_place: bool = False) -> Set[NSRT]:
         end_x = max(0.0, state.get(can, "pose_x"))
         end_y = max(0.0, state.get(can, "pose_y"))
         if with_place:
-            start_x, start_y = 0.2, 0
+            start_x, start_y = 0.2, 0.1
         else:
             start_x, start_y = rng.uniform(0.0, 1.0,
                                            size=2)  # start from anywhere
@@ -414,7 +414,7 @@ def _get_cluttered_table_gt_nsrts(with_place: bool = False) -> Set[NSRT]:
         def place_sampler(state: State, goal: Set[GroundAtom],
                           rng: np.random.Generator,
                           objs: Sequence[Object]) -> Array:
-            start_x, start_y = 0.2, 0.0
+            start_x, start_y = 0.2, 0.1
             # Goal-conditioned sampling
             if CFG.cluttered_table_place_goal_conditioned_sampling:
                 # Get the pose of the goal object

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -388,7 +388,7 @@ def test_cluttered_table_get_gt_nsrts(place_version=False):
         if i == 0 and place_version:
             # This case checks for exception when placing collides.
             grasp_action = Action(
-                np.array([0.2, 0, 0.2, 0.5], dtype=np.float32))
+                np.array([0.2, 0.1, 0.2, 0.6], dtype=np.float32))
         else:
             grasp_option = grasp0_nsrt.sample_option(state, task.goal, rng)
             grasp_action = grasp_option.policy(state)
@@ -412,7 +412,7 @@ def test_cluttered_table_get_gt_nsrts(place_version=False):
             if i == 0:
                 # This case checks for exception when placing collides.
                 place_action = Action(
-                    np.array([0.2, 0, 0.1, 0.75], dtype=np.float32))
+                    np.array([0.2, 0.1, 0.1, 0.75], dtype=np.float32))
                 assert env.action_space.contains(place_action.arr)
             else:
                 place_option = place1_nsrt.sample_option(state, task.goal, rng)

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -412,7 +412,7 @@ def test_cluttered_table_get_gt_nsrts(place_version=False):
             if i == 0:
                 # This case checks for exception when placing collides.
                 place_action = Action(
-                    np.array([0.2, 0.1, 0.1, 0.75], dtype=np.float32))
+                    np.array([0.2, 0.1, 0.1, 0.85], dtype=np.float32))
                 assert env.action_space.contains(place_action.arr)
             else:
                 place_option = place1_nsrt.sample_option(state, task.goal, rng)


### PR DESCRIPTION
Small changes to the cluttered-table-place env to avoid numerical instability on the edge of the environment. 

python src/main.py --env cluttered_table_place --approach nsrt_learning --sesame_max_skeletons_optimized 2 --sesame_max_samples_per_step 1 --num_test_tasks 50 --cluttered_table_num_cans_test 2 --cluttered_table_place_goal_conditioned_sampling True --seed 0 --sampler_learning_use_goals True --sampler_disable_classifier True

solves 50/50 tasks, 

python src/main.py --env cluttered_table_place --approach nsrt_learning --sesame_max_skeletons_optimized 2 --sesame_max_samples_per_step 1 --num_test_tasks 50 --cluttered_table_num_cans_test 2 --cluttered_table_place_goal_conditioned_sampling True --seed 0 --sampler_learning_use_goals False --sampler_disable_classifier True

solves 34/50.