### PR TITLE
fixes to cover multistep and tests

### DIFF
--- a/src/envs/cover.py
+++ b/src/envs/cover.py
@@ -692,15 +692,20 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
         # Note: unlike parent env, we also need to check the grip.
         if held_block is not None and above_block is None and \
             grip < self.grasp_thresh and (hy-hh) < self.placing_height:
-            if any(state.get(targ, "x")-state.get(targ, "width")/2 <= x <=
-                state.get(targ, "x")+state.get(targ, "width")/2 for targ in \
-                self._targets) and not any(hand_lb <= x <= hand_rb for \
-                hand_lb, hand_rb in self._get_hand_regions_target(state)):
-                return state.copy()
+            # Tentatively set the next state and check whether the placement
+            # would cover some target.
             next_state.set(held_block, "y", self.initial_block_y)
             next_state.set(held_block, "grasp", -1)
             next_state.set(self._robot, "holding", -1)
-
+            place_would_cover = any(
+                self._Covers_holds(next_state, [held_block, targ])
+                for targ in self._targets)
+            # If the place would cover, but we were outside of an allowed
+            # hand region, then disallow the place. Otherwise, keep the new
+            # next state (place succeeded).
+            if place_would_cover and not any(hand_lb <= x <= hand_rb for \
+                hand_lb, hand_rb in self._get_hand_regions_target(state)):
+                return state.copy()
         return next_state
 
     def render(self,

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -95,7 +95,11 @@ def test_neural_option_learning():
                    try_solving=False,
                    sampler_learner="random",
                    option_learner="neural",
-                   check_solution=False)
+                   check_solution=False,
+                   additional_settings={
+                       "cover_multistep_thr_percent": 0.99,
+                       "cover_multistep_bhr_percent": 0.99,
+                   })
 
 
 def test_oracle_samplers():

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -230,6 +230,8 @@ def test_oracle_approach_cover_multistep_options():
         "cover_multistep_degenerate_oracle_samplers": False,
         "num_train_tasks": 2,
         "num_test_tasks": 2,
+        "cover_multistep_thr_percent": 0.99,
+        "cover_multistep_bhr_percent": 0.99,
     })
     env = CoverMultistepOptions()
     env.seed(123)
@@ -258,6 +260,8 @@ def test_oracle_approach_cover_multistep_options():
         "sampler_learner": "neural",
         "num_train_tasks": 2,
         "num_test_tasks": 2,
+        "cover_multistep_thr_percent": 0.99,
+        "cover_multistep_bhr_percent": 0.99,
     })
     env = CoverMultistepOptions()
     env.seed(123)
@@ -280,6 +284,8 @@ def test_oracle_approach_cover_multistep_options():
         "cover_multistep_degenerate_oracle_samplers": True,
         "num_train_tasks": 2,
         "num_test_tasks": 2,
+        "cover_multistep_thr_percent": 0.99,
+        "cover_multistep_bhr_percent": 0.99,
     })
     env = CoverMultistepOptions()
     env.seed(123)
@@ -309,7 +315,9 @@ def test_oracle_approach_cover_multistep_options_fixed_tasks():
         "env": "cover_multistep_options_fixed_tasks",
         "cover_multistep_use_learned_equivalents": True,
         "num_train_tasks": 2,
-        "num_test_tasks": 2
+        "num_test_tasks": 2,
+        "cover_multistep_thr_percent": 0.99,
+        "cover_multistep_bhr_percent": 0.99,
     })
     env = CoverMultistepOptionsFixedTasks()
     env.seed(123)

--- a/tests/envs/test_cover.py
+++ b/tests/envs/test_cover.py
@@ -530,8 +530,7 @@ def test_cover_multistep_options():
     robot = [r for r in traj.states[0] if r.name == "robby"][0]
     assert np.array_equal(traj.states[-1][robot], traj.states[-2][robot])
 
-    # Cover the case where a place is attempted outside of a hand region
-    # Check collision of held block with the floor.
+    # Cover the case where a place is attempted outside of a hand region.
     action_arrs = [
         np.array([0.05, 0., 0.], dtype=np.float32),
         np.array([0.05, 0., 0.], dtype=np.float32),

--- a/tests/envs/test_cover.py
+++ b/tests/envs/test_cover.py
@@ -530,6 +530,49 @@ def test_cover_multistep_options():
     robot = [r for r in traj.states[0] if r.name == "robby"][0]
     assert np.array_equal(traj.states[-1][robot], traj.states[-2][robot])
 
+    # Cover the case where a place is attempted outside of a hand region
+    # Check collision of held block with the floor.
+    action_arrs = [
+        np.array([0.05, 0., 0.], dtype=np.float32),
+        np.array([0.05, 0., 0.], dtype=np.float32),
+        np.array([0.05, 0., 0.], dtype=np.float32),
+        np.array([0.05, 0., 0.], dtype=np.float32),
+        np.array([0.05, 0., 0.], dtype=np.float32),
+        np.array([0.05, 0., 0.], dtype=np.float32),
+        np.array([0.05, 0., 0.], dtype=np.float32),
+        np.array([0.05, 0., 0.], dtype=np.float32),
+        np.array([0., -0.05, 0], dtype=np.float32),
+        np.array([0., -0.05, 0.], dtype=np.float32),
+        np.array([0., -0.05, 0.], dtype=np.float32),
+        np.array([0., -0.05, 0.], dtype=np.float32),
+        np.array([0., -0.05, 0.], dtype=np.float32),
+        np.array([0., -0.045, 0.1], dtype=np.float32),
+        np.array([0., 0.05, 0.1], dtype=np.float32),
+        np.array([0., 0.05, 0.1], dtype=np.float32),
+        np.array([0., 0.05, 0.1], dtype=np.float32),
+        np.array([0., 0.05, 0.1], dtype=np.float32),
+        np.array([0., 0.05, 0.1], dtype=np.float32),
+        np.array([0., 0.05, 0.1], dtype=np.float32),
+        np.array([0.05, 0., 0.1], dtype=np.float32),
+        np.array([0.05, 0., 0.1], dtype=np.float32),
+        np.array([0.05, 0., 0.1], dtype=np.float32),
+        np.array([0.05, 0., 0.1], dtype=np.float32),
+        np.array([0., -0.1, 0.1], dtype=np.float32),
+        np.array([0., -0.1, 0.1], dtype=np.float32),
+        np.array([0., -0.1, 0.1], dtype=np.float32),
+        np.array([0., 0., -0.1], dtype=np.float32),
+        np.array([0., 0.1, 0.], dtype=np.float32),
+    ]
+    make_video = False  # Can toggle to true for debugging
+    traj, video, _ = utils.run_policy_on_task(
+        policy, task, env.simulate, len(action_arrs),
+        env.render if make_video else None)
+    if make_video:
+        outfile = "place_fail_multistep_cover.mp4"  # pragma: no cover
+        utils.save_video(outfile, video)  # pragma: no cover
+    robot = [r for r in traj.states[0] if r.name == "robby"][0]
+    assert traj.states[-1].get(robot, "holding") > -1
+
     # Check max placement failure for target and block placement
     utils.reset_config({
         "env": "cover_multistep_options",

--- a/tests/envs/test_cover.py
+++ b/tests/envs/test_cover.py
@@ -315,9 +315,9 @@ def test_cover_multistep_options():
     traj, video, _ = utils.run_policy_on_task(
         policy, task, env.simulate, len(action_arrs),
         env.render if make_video else None)
-    if make_video:
-        outfile = "hardcoded_actions_com.mp4"  # pragma: no cover
-        utils.save_video(outfile, video)  # pragma: no cover
+    if make_video:  # pragma: no cover
+        outfile = "hardcoded_actions_com.mp4"
+        utils.save_video(outfile, video)
     state = traj.states[0]
     env.render(state, task)
     # Render a state where we're grasping
@@ -342,9 +342,9 @@ def test_cover_multistep_options():
     traj, video, _ = utils.run_policy_on_task(
         utils.option_plan_to_policy(plan), task, env.simulate, 100,
         env.render if make_video else None)
-    if make_video:
-        outfile = "hardcoded_options_com.mp4"  # pragma: no cover
-        utils.save_video(outfile, video)  # pragma: no cover
+    if make_video:  # pragma: no cover
+        outfile = "hardcoded_options_com.mp4"
+        utils.save_video(outfile, video)
     final_atoms = utils.abstract(traj.states[-1], env.predicates)
     assert Covers([block0, target0]) in final_atoms
     assert Covers([block1, target1]) in final_atoms
@@ -376,9 +376,9 @@ def test_cover_multistep_options():
     traj, video, _ = utils.run_policy_on_task(
         policy, task, env.simulate, len(action_arrs),
         env.render if make_video else None)
-    if make_video:
-        outfile = "hardcoded_actions_robot_collision1.mp4"  # pragma: no cover
-        utils.save_video(outfile, video)  # pragma: no cover
+    if make_video:  # pragma: no cover
+        outfile = "hardcoded_actions_robot_collision1.mp4"
+        utils.save_video(outfile, video)
     robot = [r for r in traj.states[0] if r.name == "robby"][0]
     assert np.array_equal(traj.states[-1][robot], traj.states[-2][robot])
 
@@ -400,9 +400,9 @@ def test_cover_multistep_options():
     traj, video, _ = utils.run_policy_on_task(
         policy, task, env.simulate, len(action_arrs),
         env.render if make_video else None)
-    if make_video:
-        outfile = "hardcoded_actions_robot_collision2.mp4"  # pragma: no cover
-        utils.save_video(outfile, video)  # pragma: no cover
+    if make_video:  # pragma: no cover
+        outfile = "hardcoded_actions_robot_collision2.mp4"
+        utils.save_video(outfile, video)
     robot = [r for r in traj.states[0] if r.name == "robby"][0]
     assert np.array_equal(traj.states[-1][robot], traj.states[-2][robot])
 
@@ -442,9 +442,9 @@ def test_cover_multistep_options():
     traj, video, _ = utils.run_policy_on_task(
         policy, task, env.simulate, len(action_arrs),
         env.render if make_video else None)
-    if make_video:
-        outfile = "hardcoded_actions_block_collision1.mp4"  # pragma: no cover
-        utils.save_video(outfile, video)  # pragma: no cover
+    if make_video:  # pragma: no cover
+        outfile = "hardcoded_actions_block_collision1.mp4"
+        utils.save_video(outfile, video)
     robot = [r for r in traj.states[0] if r.name == "robby"][0]
     assert np.array_equal(traj.states[-1][robot], traj.states[-2][robot])
 
@@ -483,9 +483,9 @@ def test_cover_multistep_options():
     traj, video, _ = utils.run_policy_on_task(
         policy, task, env.simulate, len(action_arrs),
         env.render if make_video else None)
-    if make_video:
-        outfile = "hardcoded_actions_block_collision2.mp4"  # pragma: no cover
-        utils.save_video(outfile, video)  # pragma: no cover
+    if make_video:  # pragma: no cover
+        outfile = "hardcoded_actions_block_collision2.mp4"
+        utils.save_video(outfile, video)
     robot = [r for r in traj.states[0] if r.name == "robby"][0]
     assert np.array_equal(traj.states[-1][robot], traj.states[-2][robot])
 
@@ -524,9 +524,9 @@ def test_cover_multistep_options():
     traj, video, _ = utils.run_policy_on_task(
         policy, task, env.simulate, len(action_arrs),
         env.render if make_video else None)
-    if make_video:
-        outfile = "hardcoded_actions_block_collision3.mp4"  # pragma: no cover
-        utils.save_video(outfile, video)  # pragma: no cover
+    if make_video:  # pragma: no cover
+        outfile = "hardcoded_actions_block_collision3.mp4"
+        utils.save_video(outfile, video)
     robot = [r for r in traj.states[0] if r.name == "robby"][0]
     assert np.array_equal(traj.states[-1][robot], traj.states[-2][robot])
 
@@ -566,9 +566,9 @@ def test_cover_multistep_options():
     traj, video, _ = utils.run_policy_on_task(
         policy, task, env.simulate, len(action_arrs),
         env.render if make_video else None)
-    if make_video:
-        outfile = "place_fail_multistep_cover.mp4"  # pragma: no cover
-        utils.save_video(outfile, video)  # pragma: no cover
+    if make_video:  # pragma: no cover
+        outfile = "place_fail_multistep_cover.mp4"
+        utils.save_video(outfile, video)
     robot = [r for r in traj.states[0] if r.name == "robby"][0]
     assert traj.states[-1].get(robot, "holding") > -1
 
@@ -637,9 +637,9 @@ def test_cover_multistep_options():
     traj, video, _ = utils.run_policy_on_task(
         policy, task, env.simulate, len(action_arrs),
         env.render if make_video else None)
-    if make_video:
-        outfile = "hardcoded_actions_com_2.mp4"  # pragma: no cover
-        utils.save_video(outfile, video)  # pragma: no cover
+    if make_video:  # pragma: no cover
+        outfile = "hardcoded_actions_com_2.mp4"
+        utils.save_video(outfile, video)
     Covers = [p for p in env.predicates if p.name == "Covers"][0]
     init_atoms = utils.abstract(state, env.predicates)
     final_atoms = utils.abstract(traj.states[-1], env.predicates)

--- a/tests/nsrt_learning/test_option_learning.py
+++ b/tests/nsrt_learning/test_option_learning.py
@@ -150,6 +150,8 @@ def test_learned_neural_parameterized_option():
         "env": "cover_multistep_options",
         "option_learner": "neural",
         "mlp_regressor_max_itr": 10,
+        "cover_multistep_thr_percent": 0.99,
+        "cover_multistep_bhr_percent": 0.99,
     })
     env = create_env("cover_multistep_options")
     nsrts = get_gt_nsrts(env.predicates, env.options)


### PR DESCRIPTION
closes #493 and should resolve the unit test failures in #479 

the issue in #493 was an edge case where the hand is placing outside of both the allowed hand region _and_ outside of the target region. before this PR, the code would think that this placement was a "place on table", which is allowed. but that's not always the case, like in this video:

https://user-images.githubusercontent.com/2816502/156375704-ed0135e9-1f9e-467a-9080-e93cc85f74df.mp4

the unit test failures in #479 were related to default hyperparameter settings being challenging for oracle planning. we want to leave the defaults alone because we want the environment to be challenging, but I made them easier in the relevant unit tests.
