### PR TITLE
allow lists and tuples on the commandline

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1417,6 +1417,14 @@ def string_to_python_object(value: str) -> Any:
         return float(value)
     except ValueError:
         pass
+    if value.startswith("["):
+        assert value.endswith("]")
+        inner_strs = value[1:-1].split(",")
+        return [string_to_python_object(s) for s in inner_strs]
+    if value.startswith("("):
+        assert value.endswith(")")
+        inner_strs = value[1:-1].split(",")
+        return tuple(string_to_python_object(s) for s in inner_strs)
     return value
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1840,6 +1840,11 @@ def test_string_to_python_object():
     assert utils.string_to_python_object("True") is True
     assert utils.string_to_python_object("False") is False
     assert utils.string_to_python_object("None") is None
+    assert utils.string_to_python_object("[3.2]") == [3.2]
+    assert utils.string_to_python_object("[3.2,4.3]") == [3.2, 4.3]
+    assert utils.string_to_python_object("[3.2, 4.3]") == [3.2, 4.3]
+    assert utils.string_to_python_object("(3.2,4.3)") == (3.2, 4.3)
+    assert utils.string_to_python_object("(3.2, 4.3)") == (3.2, 4.3)
 
 
 def test_create_video_from_partial_refinements():


### PR DESCRIPTION
examples:
* `python src/main.py --env cover --approach oracle --seed 0 --cover_target_widths "[0.03, 0.05]"`
* `python src/main.py --env cover --approach oracle --seed 0 --cover_target_widths [0.03,0.05]`