### PR TITLE
change create_env to get_cached_env_instance in ground truth nsrts

### DIFF
--- a/analysis/grammar_search_analysis.py
+++ b/analysis/grammar_search_analysis.py
@@ -8,7 +8,7 @@ import os
 from typing import Dict, DefaultDict, Set, List, Tuple, Sequence, Any
 import pandas as pd
 from predicators.src.datasets import create_dataset
-from predicators.src.envs import create_env, BaseEnv, CoverEnv
+from predicators.src.envs import create_new_env, BaseEnv, CoverEnv
 from predicators.src.approaches import create_approach
 from predicators.src.approaches.grammar_search_invention_approach import \
     _ForallClassifier, _SingleAttributeCompareClassifier
@@ -173,7 +173,7 @@ def _run_proxy_analysis_for_env(args: Dict[str, Any], env_name: str,
         "env": env_name,
         **args,
     })
-    env = create_env(env_name)
+    env = create_new_env(env_name)
     train_tasks = env.get_train_tasks()
     dataset = create_dataset(env, train_tasks)
     start_time = time.time()

--- a/analysis/skeleton_score_analysis.py
+++ b/analysis/skeleton_score_analysis.py
@@ -14,7 +14,7 @@ import numpy as np
 from numpy.typing import NDArray
 import matplotlib.pyplot as plt
 from predicators.src.datasets import create_dataset
-from predicators.src.envs import create_env
+from predicators.src.envs import create_new_env
 from predicators.src.approaches import ApproachFailure, ApproachTimeout
 from predicators.src import utils
 from predicators.src.settings import CFG
@@ -51,7 +51,7 @@ def _setup_data_for_env(env_name: str,
         "env": env_name,
         "offline_data_planning_timeout": 10
     })
-    env = create_env(env_name)
+    env = create_new_env(env_name)
     env.seed(seed)
     train_tasks = env.get_train_tasks()
     dataset = create_dataset(env, train_tasks)
@@ -95,7 +95,7 @@ def _order_predicate_sets(
     utils.reset_config({"seed": seed, "env": env_name})
     score_function = _create_score_function(score_name)
     aggregate = _create_aggregation_function(aggregation_name)
-    env = create_env(env_name)
+    env = create_new_env(env_name)
     oracle_predicates = set(env.predicates)
     # Hack: remove these unnecessary predicates for cover.
     if env_name.startswith("cover"):

--- a/src/envs/__init__.py
+++ b/src/envs/__init__.py
@@ -80,10 +80,13 @@ def create_new_env(name: str, do_cache: bool = False) -> BaseEnv:
 def get_cached_env(name: str) -> BaseEnv:
     """Get the most recent cached env instance.
 
-    If you use this function,
-    you should NOT be doing anything that relies on the environment's
-    internal state (i.e., you should not call reset() or step()).
+    If you use this function, you should NOT be doing anything that relies on
+    the environment's internal state (i.e., you should not call reset() or
+    step()).
+
     Note: if CFG.allow_env_caching is False, always makes a new env instance.
+    We do this because unit testing relies on this method working, e.g., when
+    a unit test calls get_gt_nsrts(), which in turn calls this method.
     """
     if not CFG.allow_env_caching:
         return create_new_env(name)

--- a/src/envs/__init__.py
+++ b/src/envs/__init__.py
@@ -76,8 +76,9 @@ def create_env(name: str) -> BaseEnv:
     return env
 
 
-def get_cached_env_instance(name: str) -> BaseEnv:
-    """Get the most recent cached env instance (env must have been previously
-    created with create_env() to exist in the cache)."""
-    assert name in _MOST_RECENT_ENV_INSTANCE
+def get_or_create_env(name: str) -> BaseEnv:
+    """Get the most recent cached env instance, or create one with
+    create_env() if it doesn't already exist."""
+    if name not in _MOST_RECENT_ENV_INSTANCE:
+        _MOST_RECENT_ENV_INSTANCE[name] = create_env(name)
     return _MOST_RECENT_ENV_INSTANCE[name]

--- a/src/envs/__init__.py
+++ b/src/envs/__init__.py
@@ -1,5 +1,6 @@
 """Default imports for envs folder."""
 
+import sys
 from predicators.src.envs.base_env import BaseEnv
 from predicators.src.envs.cover import CoverEnv, CoverEnvTypedOptions, \
     CoverEnvHierarchicalTypes, CoverMultistepOptions, \
@@ -12,6 +13,7 @@ from predicators.src.envs.painting import PaintingEnv
 from predicators.src.envs.tools import ToolsEnv
 from predicators.src.envs.playroom import PlayroomEnv
 from predicators.src.envs.repeated_nextto import RepeatedNextToEnv
+from predicators.src.settings import CFG
 
 __all__ = [
     "BaseEnv",
@@ -33,52 +35,57 @@ __all__ = [
 _MOST_RECENT_ENV_INSTANCE = {}
 
 
-def _create_new_env_instance(name: str) -> BaseEnv:
+def create_new_env(name: str, do_cache: bool = False) -> BaseEnv:
     """Create a new instance of an environment from its name.
 
-    Note that this env instance will not be cached.
+    If do_cache is True, then cache this env instance so that it can
+    later be loaded using get_cached_env().
     """
     if name == "cover":
-        return CoverEnv()
-    if name == "cover_typed_options":
-        return CoverEnvTypedOptions()
-    if name == "cover_hierarchical_types":
-        return CoverEnvHierarchicalTypes()
-    if name == "cover_regrasp":
-        return CoverEnvRegrasp()
-    if name == "cover_multistep_options":
-        return CoverMultistepOptions()
-    if name == "cover_multistep_options_fixed_tasks":
-        return CoverMultistepOptionsFixedTasks()
-    if name == "cluttered_table":
-        return ClutteredTableEnv()
-    if name == "cluttered_table_place":
-        return ClutteredTablePlaceEnv()
-    if name == "blocks":
-        return BlocksEnv()
-    if name == "painting":
-        return PaintingEnv()
-    if name == "tools":
-        return ToolsEnv()
-    if name == "playroom":
-        return PlayroomEnv()
-    if name == "behavior":
-        return BehaviorEnv()  # pragma: no cover
-    if name == "repeated_nextto":
-        return RepeatedNextToEnv()
-    raise NotImplementedError(f"Unknown env: {name}")
-
-
-def create_env(name: str) -> BaseEnv:
-    """Create an environment instance given its name and cache it."""
-    env = _create_new_env_instance(name)
-    _MOST_RECENT_ENV_INSTANCE[name] = env
+        env: BaseEnv = CoverEnv()
+    elif name == "cover_typed_options":
+        env = CoverEnvTypedOptions()
+    elif name == "cover_hierarchical_types":
+        env = CoverEnvHierarchicalTypes()
+    elif name == "cover_regrasp":
+        env = CoverEnvRegrasp()
+    elif name == "cover_multistep_options":
+        env = CoverMultistepOptions()
+    elif name == "cover_multistep_options_fixed_tasks":
+        env = CoverMultistepOptionsFixedTasks()
+    elif name == "cluttered_table":
+        env = ClutteredTableEnv()
+    elif name == "cluttered_table_place":
+        env = ClutteredTablePlaceEnv()
+    elif name == "blocks":
+        env = BlocksEnv()
+    elif name == "painting":
+        env = PaintingEnv()
+    elif name == "tools":
+        env = ToolsEnv()
+    elif name == "playroom":
+        env = PlayroomEnv()
+    elif name == "behavior":
+        env = BehaviorEnv()  # pragma: no cover
+    elif name == "repeated_nextto":
+        env = RepeatedNextToEnv()
+    else:
+        raise NotImplementedError(f"Unknown env: {name}")
+    if do_cache:
+        assert CFG.allow_env_caching, "CFG.do_env_caching is off!"
+        _MOST_RECENT_ENV_INSTANCE[name] = env
     return env
 
 
-def get_or_create_env(name: str) -> BaseEnv:
-    """Get the most recent cached env instance, or create one with
-    create_env() if it doesn't already exist."""
-    if name not in _MOST_RECENT_ENV_INSTANCE:
-        _MOST_RECENT_ENV_INSTANCE[name] = create_env(name)
+def get_cached_env(name: str) -> BaseEnv:
+    """Get the most recent cached env instance.
+
+    If you use this function,
+    you should NOT be doing anything that relies on the environment's
+    internal state (i.e., you should not call reset() or step()).
+    Note: if CFG.allow_env_caching is False, always makes a new env instance.
+    """
+    if not CFG.allow_env_caching:
+        return create_new_env(name)
+    assert name in _MOST_RECENT_ENV_INSTANCE, f"env {name} not created"
     return _MOST_RECENT_ENV_INSTANCE[name]

--- a/src/envs/__init__.py
+++ b/src/envs/__init__.py
@@ -72,7 +72,7 @@ def create_new_env(name: str, do_cache: bool = False) -> BaseEnv:
     else:
         raise NotImplementedError(f"Unknown env: {name}")
     if do_cache:
-        assert CFG.allow_env_caching, "CFG.do_env_caching is off!"
+        assert CFG.allow_env_caching, "CFG.allow_env_caching is off!"
         _MOST_RECENT_ENV_INSTANCE[name] = env
     return env
 
@@ -87,5 +87,7 @@ def get_cached_env(name: str) -> BaseEnv:
     """
     if not CFG.allow_env_caching:
         return create_new_env(name)
-    assert name in _MOST_RECENT_ENV_INSTANCE, f"env {name} not created"
+    assert name in _MOST_RECENT_ENV_INSTANCE, \
+        (f"CFG.allow_env_caching is on, but {name} is not in the cache. "
+         "If you're doing unit testing, you should turn this setting off.")
     return _MOST_RECENT_ENV_INSTANCE[name]

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -3,14 +3,13 @@
 from typing import List, Sequence, Set, cast
 import itertools
 import numpy as np
-from predicators.src.envs import create_env, BlocksEnv, PaintingEnv, \
-    PlayroomEnv, BehaviorEnv
+from predicators.src.envs import get_cached_env_instance, BlocksEnv, \
+    PaintingEnv, PlayroomEnv, BehaviorEnv, ToolsEnv
 from predicators.src.structs import NSRT, Predicate, State, GroundAtom, \
     ParameterizedOption, Variable, Type, LiftedAtom, Object, Array
 from predicators.src.settings import CFG
 from predicators.src.envs.behavior_options import navigate_to_param_sampler, \
     grasp_obj_param_sampler, place_ontop_obj_pos_sampler
-from predicators.src.envs import get_cached_env_instance, ToolsEnv
 from predicators.src.utils import null_sampler
 
 
@@ -53,7 +52,7 @@ def get_gt_nsrts(predicates: Set[Predicate],
 def _get_from_env_by_names(env_name: str, names: Sequence[str],
                            env_attr: str) -> List:
     """Helper for loading types, predicates, and options by name."""
-    env = create_env(env_name)
+    env = get_cached_env_instance(env_name)
     name_to_env_obj = {}
     for o in getattr(env, env_attr):
         name_to_env_obj[o.name] = o

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -3,7 +3,7 @@
 from typing import List, Sequence, Set, cast
 import itertools
 import numpy as np
-from predicators.src.envs import get_or_create_env, BlocksEnv, \
+from predicators.src.envs import get_cached_env, BlocksEnv, \
     PaintingEnv, PlayroomEnv, BehaviorEnv, ToolsEnv
 from predicators.src.structs import NSRT, Predicate, State, GroundAtom, \
     ParameterizedOption, Variable, Type, LiftedAtom, Object, Array
@@ -52,7 +52,7 @@ def get_gt_nsrts(predicates: Set[Predicate],
 def _get_from_env_by_names(env_name: str, names: Sequence[str],
                            env_attr: str) -> List:
     """Helper for loading types, predicates, and options by name."""
-    env = get_or_create_env(env_name)
+    env = get_cached_env(env_name)
     name_to_env_obj = {}
     for o in getattr(env, env_attr):
         name_to_env_obj[o.name] = o
@@ -1700,7 +1700,7 @@ def _get_repeated_nextto_gt_nsrts() -> Set[NSRT]:
 
 def _get_behavior_gt_nsrts() -> Set[NSRT]:  # pragma: no cover
     """Create ground truth nsrts for BehaviorEnv."""
-    env_base = get_or_create_env("behavior")
+    env_base = get_cached_env("behavior")
     env = cast(BehaviorEnv, env_base)
 
     # NOTE: These two methods below are necessary to help instantiate

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -3,7 +3,7 @@
 from typing import List, Sequence, Set, cast
 import itertools
 import numpy as np
-from predicators.src.envs import get_cached_env_instance, BlocksEnv, \
+from predicators.src.envs import get_or_create_env, BlocksEnv, \
     PaintingEnv, PlayroomEnv, BehaviorEnv, ToolsEnv
 from predicators.src.structs import NSRT, Predicate, State, GroundAtom, \
     ParameterizedOption, Variable, Type, LiftedAtom, Object, Array
@@ -52,7 +52,7 @@ def get_gt_nsrts(predicates: Set[Predicate],
 def _get_from_env_by_names(env_name: str, names: Sequence[str],
                            env_attr: str) -> List:
     """Helper for loading types, predicates, and options by name."""
-    env = get_cached_env_instance(env_name)
+    env = get_or_create_env(env_name)
     name_to_env_obj = {}
     for o in getattr(env, env_attr):
         name_to_env_obj[o.name] = o
@@ -1700,7 +1700,7 @@ def _get_repeated_nextto_gt_nsrts() -> Set[NSRT]:
 
 def _get_behavior_gt_nsrts() -> Set[NSRT]:  # pragma: no cover
     """Create ground truth nsrts for BehaviorEnv."""
-    env_base = get_cached_env_instance("behavior")
+    env_base = get_or_create_env("behavior")
     env = cast(BehaviorEnv, env_base)
 
     # NOTE: These two methods below are necessary to help instantiate

--- a/src/main.py
+++ b/src/main.py
@@ -39,7 +39,7 @@ import subprocess
 import time
 import dill as pkl
 from predicators.src.settings import CFG
-from predicators.src.envs import create_env, BaseEnv
+from predicators.src.envs import create_new_env, BaseEnv
 from predicators.src.approaches import create_approach, ApproachTimeout, \
     ApproachFailure, BaseApproach
 from predicators.src.datasets import create_dataset
@@ -69,7 +69,7 @@ def main() -> None:
                                  "HEAD"]).decode("ascii").strip())
     os.makedirs(CFG.results_dir, exist_ok=True)
     # Create classes. Note that seeding happens inside the env and approach.
-    env = create_env(CFG.env)
+    env = create_new_env(CFG.env, do_cache=True)
     # The action space and options need to be seeded externally, because
     # env.action_space and env.options are often created during env __init__().
     env.action_space.seed(CFG.seed)

--- a/src/nsrt_learning/option_learning.py
+++ b/src/nsrt_learning/option_learning.py
@@ -9,7 +9,7 @@ from predicators.src.structs import STRIPSOperator, OptionSpec, Datastore, \
 from predicators.src.approaches import ApproachFailure
 from predicators.src.settings import CFG
 from predicators.src.torch_models import MLPRegressor
-from predicators.src.envs import create_env, BlocksEnv
+from predicators.src.envs import get_cached_env, BlocksEnv
 
 
 def create_option_learner() -> _OptionLearnerBase:
@@ -105,7 +105,7 @@ class _OracleOptionLearner(_OptionLearnerBase):
 
     def learn_option_specs(self, strips_ops: List[STRIPSOperator],
                            datastores: List[Datastore]) -> List[OptionSpec]:
-        env = create_env(CFG.env)
+        env = get_cached_env(CFG.env)
         option_specs: List[OptionSpec] = []
         if CFG.env == "cover":
             assert len(strips_ops) == 3

--- a/src/nsrt_learning/sampler_learning.py
+++ b/src/nsrt_learning/sampler_learning.py
@@ -10,7 +10,7 @@ from predicators.src import utils
 from predicators.src.torch_models import Classifier, MLPClassifier, \
     NeuralGaussianRegressor
 from predicators.src.settings import CFG
-from predicators.src.envs import create_env
+from predicators.src.envs import get_cached_env
 from predicators.src.ground_truth_nsrts import get_gt_nsrts
 
 
@@ -48,7 +48,7 @@ def _extract_oracle_samplers(
     operators, but some of the given operators can match no ground truth
     operator, in which case such an operator is given a random sampler.
     """
-    env = create_env(CFG.env)
+    env = get_cached_env(CFG.env)
     # We don't need to match ground truth NSRTs with no continuous
     # parameters, so we filter them out.
     gt_nsrts = {

--- a/src/option_model.py
+++ b/src/option_model.py
@@ -6,7 +6,7 @@ from typing import cast
 from predicators.src import utils
 from predicators.src.structs import State, _Option
 from predicators.src.settings import CFG
-from predicators.src.envs import create_env, get_cached_env_instance
+from predicators.src.envs import create_env, get_or_create_env
 from predicators.src.envs.behavior import BehaviorEnv
 
 
@@ -60,7 +60,7 @@ class _BehaviorOptionModel(_OptionModelBase):
 
     def get_next_state(self, state: State,
                        option: _Option) -> State:  # pragma: no cover
-        env_base = get_cached_env_instance("behavior")
+        env_base = get_or_create_env("behavior")
         env = cast(BehaviorEnv, env_base)
         assert option.memory.get("model_controller") is not None
         option.memory["model_controller"](state, env.igibson_behavior_env)

--- a/src/option_model.py
+++ b/src/option_model.py
@@ -6,7 +6,7 @@ from typing import cast
 from predicators.src import utils
 from predicators.src.structs import State, _Option
 from predicators.src.settings import CFG
-from predicators.src.envs import create_env, get_or_create_env
+from predicators.src.envs import get_cached_env
 from predicators.src.envs.behavior import BehaviorEnv
 
 
@@ -40,7 +40,7 @@ class _OracleOptionModel(_OptionModelBase):
 
     def __init__(self, env_name: str) -> None:
         super().__init__()
-        env = create_env(env_name)
+        env = get_cached_env(env_name)
         self._simulator = env.simulate
 
     def get_next_state(self, state: State, option: _Option) -> State:
@@ -60,7 +60,7 @@ class _BehaviorOptionModel(_OptionModelBase):
 
     def get_next_state(self, state: State,
                        option: _Option) -> State:  # pragma: no cover
-        env_base = get_or_create_env("behavior")
+        env_base = get_cached_env("behavior")
         env = cast(BehaviorEnv, env_base)
         assert option.memory.get("model_controller") is not None
         option.memory["model_controller"](state, env.igibson_behavior_env)

--- a/src/settings.py
+++ b/src/settings.py
@@ -30,6 +30,9 @@ class GlobalSettings:
     pretty_print_when_loading = False
     # Used for random seeding in test environment.
     test_env_seed_offset = 10000
+    # This should always be True for the main code path, but unit tests will
+    # often disable this because in tests, we typically don't want caching.
+    allow_env_caching = True
 
     # cover env parameters
     cover_num_blocks = 2

--- a/src/teacher.py
+++ b/src/teacher.py
@@ -9,7 +9,7 @@ from predicators.src.structs import State, Task, Query, Response, \
     DemonstrationResponse, LowLevelTrajectory, InteractionRequest, \
     Action
 from predicators.src.settings import CFG, get_allowed_query_type_names
-from predicators.src.envs import create_env
+from predicators.src.envs import get_cached_env
 from predicators.src.approaches import OracleApproach, ApproachTimeout, \
     ApproachFailure
 from predicators.src import utils
@@ -20,7 +20,7 @@ class Teacher:
 
     def __init__(self, train_tasks: Sequence[Task]) -> None:
         self._train_tasks = train_tasks
-        env = create_env(CFG.env)
+        env = get_cached_env(CFG.env)
         self._pred_name_to_pred = {pred.name: pred for pred in env.predicates}
         self._allowed_query_type_names = get_allowed_query_type_names()
         self._oracle_approach = OracleApproach(

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -1,7 +1,7 @@
 """Test cases for the NSRT learning approach."""
 
 import pytest
-from predicators.src.envs import create_env
+from predicators.src.envs import create_new_env
 from predicators.src.approaches import create_approach
 from predicators.src.datasets import create_dataset
 from predicators.src.settings import CFG
@@ -40,9 +40,10 @@ def _test_approach(env_name,
         "option_learner": option_learner,
         "sampler_learner": sampler_learner,
         "cover_initial_holding_prob": 0.0,
+        "allow_env_caching": False,
         **additional_settings,
     })
-    env = create_env(env_name)
+    env = create_new_env(env_name)
     assert env.goal_predicates.issubset(env.predicates)
     if CFG.excluded_predicates:
         excludeds = set(CFG.excluded_predicates.split(","))

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -30,7 +30,8 @@ def test_cover_get_gt_nsrts():
     utils.reset_config({
         "env": "cover",
         "num_train_tasks": 2,
-        "num_test_tasks": 2
+        "num_test_tasks": 2,
+        "allow_env_caching": False,
     })
     # All predicates and options
     env = CoverEnv()
@@ -110,10 +111,10 @@ def test_check_nsrt_parameters():
         "tools": ToolsEnv(),
         "playroom": PlayroomEnv(),
         "cover_multistep_options": CoverMultistepOptions(),
-        "repeated_nextto": RepeatedNextToEnv()
+        "repeated_nextto": RepeatedNextToEnv(),
     }
     for name, env in envs.items():
-        utils.reset_config({"env": name})
+        utils.reset_config({"env": name, "allow_env_caching": False})
         nsrts = get_gt_nsrts(env.predicates, env.options)
         _check_nsrt_parameters(nsrts)
 
@@ -123,7 +124,8 @@ def test_oracle_approach_cover():
     utils.reset_config({
         "env": "cover",
         "num_train_tasks": 2,
-        "num_test_tasks": 2
+        "num_test_tasks": 2,
+        "allow_env_caching": False,
     })
     env = CoverEnv()
     env.seed(123)
@@ -152,7 +154,8 @@ def test_oracle_approach_cover_typed_options():
     utils.reset_config({
         "env": "cover_typed_options",
         "num_train_tasks": 2,
-        "num_test_tasks": 2
+        "num_test_tasks": 2,
+        "allow_env_caching": False,
     })
     env = CoverEnvTypedOptions()
     env.seed(123)
@@ -181,7 +184,8 @@ def test_oracle_approach_cover_hierarchical_types():
     utils.reset_config({
         "env": "cover_hierarchical_types",
         "num_train_tasks": 2,
-        "num_test_tasks": 2
+        "num_test_tasks": 2,
+        "allow_env_caching": False,
     })
     env = CoverEnvHierarchicalTypes()
     env.seed(123)
@@ -211,6 +215,7 @@ def test_oracle_approach_cover_regrasp():
         "env": "cover_regrasp",
         "num_train_tasks": 2,
         "num_test_tasks": 2,
+        "allow_env_caching": False,
     })
     env = CoverEnvRegrasp()
     env.seed(123)
@@ -244,6 +249,7 @@ def test_oracle_approach_cover_multistep_options():
         "num_test_tasks": 2,
         "cover_multistep_thr_percent": 0.99,
         "cover_multistep_bhr_percent": 0.99,
+        "allow_env_caching": False,
     })
     env = CoverMultistepOptions()
     env.seed(123)
@@ -274,6 +280,7 @@ def test_oracle_approach_cover_multistep_options():
         "num_test_tasks": 2,
         "cover_multistep_thr_percent": 0.99,
         "cover_multistep_bhr_percent": 0.99,
+        "allow_env_caching": False,
     })
     env = CoverMultistepOptions()
     env.seed(123)
@@ -298,6 +305,7 @@ def test_oracle_approach_cover_multistep_options():
         "num_test_tasks": 2,
         "cover_multistep_thr_percent": 0.99,
         "cover_multistep_bhr_percent": 0.99,
+        "allow_env_caching": False,
     })
     env = CoverMultistepOptions()
     env.seed(123)
@@ -330,6 +338,7 @@ def test_oracle_approach_cover_multistep_options_fixed_tasks():
         "num_test_tasks": 2,
         "cover_multistep_thr_percent": 0.99,
         "cover_multistep_bhr_percent": 0.99,
+        "allow_env_caching": False,
     })
     env = CoverMultistepOptionsFixedTasks()
     env.seed(123)
@@ -361,7 +370,8 @@ def test_cluttered_table_get_gt_nsrts(place_version=False):
             # Keep num_train_tasks high enough to ensure hitting the
             # EnvironmentFailure check below at least once
             "num_train_tasks": 5,
-            "num_test_tasks": 2
+            "num_test_tasks": 2,
+            "allow_env_caching": False,
         })
         # All predicates and options
         env = ClutteredTableEnv()
@@ -370,7 +380,8 @@ def test_cluttered_table_get_gt_nsrts(place_version=False):
             "env": "cluttered_table_place",
             # Higher num of train tasks needed for full coverage.
             "num_train_tasks": 5,
-            "num_test_tasks": 2
+            "num_test_tasks": 2,
+            "allow_env_caching": False,
         })
         env = ClutteredTablePlaceEnv()
     nsrts = get_gt_nsrts(env.predicates, env.options)
@@ -458,6 +469,7 @@ def test_oracle_approach_cluttered_table(place_version=False):
             "cluttered_table_num_cans_test": 3,
             "num_train_tasks": 2,
             "num_test_tasks": 2,
+            "allow_env_caching": False,
         })
         env = ClutteredTableEnv()
     else:
@@ -467,6 +479,7 @@ def test_oracle_approach_cluttered_table(place_version=False):
             "cluttered_table_num_cans_test": 3,
             "num_train_tasks": 2,
             "num_test_tasks": 2,
+            "allow_env_caching": False,
         })
         env = ClutteredTablePlaceEnv()
     env.seed(123)
@@ -493,7 +506,8 @@ def test_oracle_approach_blocks():
     utils.reset_config({
         "env": "blocks",
         "num_train_tasks": 2,
-        "num_test_tasks": 2
+        "num_test_tasks": 2,
+        "allow_env_caching": False,
     })
     env = BlocksEnv()
     env.seed(123)
@@ -517,7 +531,8 @@ def test_oracle_approach_painting():
     utils.reset_config({
         "env": "painting",
         "num_train_tasks": 2,
-        "num_test_tasks": 2
+        "num_test_tasks": 2,
+        "allow_env_caching": False,
     })
     env = PaintingEnv()
     env.seed(123)
@@ -541,7 +556,8 @@ def test_oracle_approach_tools():
         "tools_num_items_train": [2],
         "tools_num_items_test": [2],
         "num_train_tasks": 2,
-        "num_test_tasks": 2
+        "num_test_tasks": 2,
+        "allow_env_caching": False,
     })
     env = ToolsEnv()
     env.seed(123)
@@ -563,7 +579,8 @@ def test_oracle_approach_playroom():
     utils.reset_config({
         "env": "playroom",
         "num_train_tasks": 2,
-        "num_test_tasks": 2
+        "num_test_tasks": 2,
+        "allow_env_caching": False,
     })
     env = PlayroomEnv()
     env.seed(123)
@@ -636,7 +653,8 @@ def test_oracle_approach_repeated_nextto():
     utils.reset_config({
         "env": "repeated_nextto",
         "num_train_tasks": 2,
-        "num_test_tasks": 2
+        "num_test_tasks": 2,
+        "allow_env_caching": False,
     })
     env = RepeatedNextToEnv()
     env.seed(123)

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -20,6 +20,7 @@ def test_demo_dataset():
         "offline_data_planning_timeout": 500,
         "option_learner": "arbitrary_dummy",
         "num_train_tasks": 7,
+        "allow_env_caching": False,
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
@@ -39,6 +40,7 @@ def test_demo_dataset():
         "offline_data_planning_timeout": 500,
         "option_learner": "no_learning",
         "num_train_tasks": 7,
+        "allow_env_caching": False,
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
@@ -58,6 +60,7 @@ def test_demo_dataset():
         "offline_data_method": "demo",
         "num_train_tasks": 7,
         "max_initial_demos": 3,
+        "allow_env_caching": False,
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
@@ -91,6 +94,7 @@ def test_demo_replay_dataset():
         "offline_data_num_replays": 3,
         "option_learner": "no_learning",
         "num_train_tasks": 5,
+        "allow_env_caching": False,
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
@@ -114,6 +118,7 @@ def test_demo_replay_dataset():
         "offline_data_num_replays": 3,
         "option_learner": "arbitrary_dummy",
         "num_train_tasks": 5,
+        "allow_env_caching": False,
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
@@ -135,6 +140,7 @@ def test_demo_replay_dataset():
         "offline_data_planning_timeout": 500,
         "offline_data_num_replays": 10,
         "num_train_tasks": 5,
+        "allow_env_caching": False,
     })
     env = ClutteredTableEnv()
     train_tasks = env.get_train_tasks()
@@ -153,6 +159,7 @@ def test_dataset_with_annotations():
         "offline_data_num_replays": 3,
         "option_learner": "no_learning",
         "num_train_tasks": 5,
+        "allow_env_caching": False,
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
@@ -180,6 +187,7 @@ def test_ground_atom_dataset():
         "offline_data_method": "demo+ground_atoms",
         "teacher_dataset_num_examples": 1,
         "excluded_predicates": "Holding,Covers",
+        "allow_env_caching": False,
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
@@ -229,6 +237,7 @@ def test_ground_atom_dataset():
         "offline_data_method": "demo+ground_atoms",
         "teacher_dataset_num_examples": 100,
         "excluded_predicates": "Holding,Covers",
+        "allow_env_caching": False,
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
@@ -241,6 +250,7 @@ def test_empty_dataset():
     utils.reset_config({
         "env": "cover",
         "offline_data_method": "empty",
+        "allow_env_caching": False,
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()

--- a/tests/envs/test_base_env.py
+++ b/tests/envs/test_base_env.py
@@ -1,12 +1,12 @@
 """Test cases for the base environment class."""
 
 import pytest
-from predicators.src.envs import BaseEnv, create_env, get_cached_env_instance
+from predicators.src.envs import BaseEnv, create_env, get_or_create_env
 from predicators.src import utils
 
 
 def test_create_env():
-    """Tests for create_env() and get_cached_env_instance()."""
+    """Tests for create_env() and get_or_create_env()."""
     utils.reset_config()
     for name in [
             "cover",
@@ -24,7 +24,7 @@ def test_create_env():
     ]:
         env = create_env(name)
         assert isinstance(env, BaseEnv)
-        other_env = get_cached_env_instance(name)
+        other_env = get_or_create_env(name)
         assert env is other_env
         train_tasks = env.get_train_tasks()
         for idx, train_task in enumerate(train_tasks):

--- a/tests/envs/test_base_env.py
+++ b/tests/envs/test_base_env.py
@@ -1,13 +1,21 @@
 """Test cases for the base environment class."""
 
 import pytest
-from predicators.src.envs import BaseEnv, create_env, get_or_create_env
+from predicators.src.envs import BaseEnv, create_new_env, get_cached_env
 from predicators.src import utils
 
 
-def test_create_env():
-    """Tests for create_env() and get_or_create_env()."""
-    utils.reset_config()
+def test_env_creation():
+    """Tests for create_new_env() and get_cached_env()."""
+    utils.reset_config({"allow_env_caching": False})
+    env = create_new_env("cover")
+    with pytest.raises(AssertionError):
+        create_new_env("cover", do_cache=True)
+    assert isinstance(env, BaseEnv)
+    other_env = get_cached_env("cover")
+    assert isinstance(other_env, BaseEnv)
+    assert env is not other_env
+    utils.reset_config({"allow_env_caching": True})
     for name in [
             "cover",
             "cover_typed_options",
@@ -22,9 +30,9 @@ def test_create_env():
             "cover_multistep_options",
             "cover_multistep_options_fixed_tasks",
     ]:
-        env = create_env(name)
+        env = create_new_env(name, do_cache=True)
         assert isinstance(env, BaseEnv)
-        other_env = get_or_create_env(name)
+        other_env = get_cached_env(name)
         assert env is other_env
         train_tasks = env.get_train_tasks()
         for idx, train_task in enumerate(train_tasks):
@@ -39,4 +47,4 @@ def test_create_env():
         with pytest.raises(ValueError):
             env.get_task("not a real task category", 0)
     with pytest.raises(NotImplementedError):
-        create_env("Not a real env")
+        create_new_env("Not a real env")

--- a/tests/nsrt_learning/test_option_learning.py
+++ b/tests/nsrt_learning/test_option_learning.py
@@ -3,7 +3,7 @@
 import pytest
 import numpy as np
 from predicators.src.approaches import ApproachFailure
-from predicators.src.envs import create_env
+from predicators.src.envs import create_new_env
 from predicators.src.ground_truth_nsrts import get_gt_nsrts
 from predicators.src.datasets.demo_replay import create_demo_replay_data
 from predicators.src.nsrt_learning.strips_learning import segment_trajectory, \
@@ -21,9 +21,10 @@ def test_known_options_option_learner():
         "env": "cover",
         "approach": "nsrt_learning",
         "num_train_tasks": 3,
-        "option_learner": "no_learning"
+        "option_learner": "no_learning",
+        "allow_env_caching": False,
     })
-    env = create_env("cover")
+    env = create_new_env("cover")
     train_tasks = env.get_train_tasks()
     dataset = create_demo_replay_data(env, train_tasks)
     ground_atom_dataset = utils.create_ground_atom_dataset(
@@ -60,9 +61,10 @@ def test_oracle_option_learner_cover():
         "env": "cover",
         "approach": "nsrt_learning",
         "num_train_tasks": 3,
-        "option_learner": "oracle"
+        "option_learner": "oracle",
+        "allow_env_caching": False,
     })
-    env = create_env("cover")
+    env = create_new_env("cover")
     train_tasks = env.get_train_tasks()
     dataset = create_demo_replay_data(env, train_tasks)
     ground_atom_dataset = utils.create_ground_atom_dataset(
@@ -102,9 +104,10 @@ def test_oracle_option_learner_blocks():
         "approach": "nsrt_learning",
         "seed": 123,
         "num_train_tasks": 3,
-        "option_learner": "oracle"
+        "option_learner": "oracle",
+        "allow_env_caching": False,
     })
-    env = create_env("blocks")
+    env = create_new_env("blocks")
     train_tasks = env.get_train_tasks()
     dataset = create_demo_replay_data(env, train_tasks)
     ground_atom_dataset = utils.create_ground_atom_dataset(
@@ -152,8 +155,9 @@ def test_learned_neural_parameterized_option():
         "mlp_regressor_max_itr": 10,
         "cover_multistep_thr_percent": 0.99,
         "cover_multistep_bhr_percent": 0.99,
+        "allow_env_caching": False,
     })
-    env = create_env("cover_multistep_options")
+    env = create_new_env("cover_multistep_options")
     nsrts = get_gt_nsrts(env.predicates, env.options)
     assert len(nsrts) == 2
     pick_nsrt = min(nsrts, key=lambda o: o.name)

--- a/tests/test_online_learning.py
+++ b/tests/test_online_learning.py
@@ -6,7 +6,7 @@ from predicators.src.datasets import create_dataset
 from predicators.src.structs import Action, InteractionRequest, \
     InteractionResult, Predicate, GroundAtom, GroundAtomsHoldQuery
 from predicators.src.main import _run_pipeline
-from predicators.src.envs import create_env
+from predicators.src.envs import create_new_env
 from predicators.src import utils
 from predicators.src.settings import CFG
 
@@ -82,7 +82,7 @@ def test_interaction():
         "num_test_tasks": 1,
         "num_online_learning_cycles": 1
     })
-    env = create_env("cover")
+    env = create_new_env("cover")
     train_tasks = env.get_train_tasks()
     approach = _MockApproach(env.predicates, env.options, env.types,
                              env.action_space, train_tasks)

--- a/tests/test_predicate_search_score_functions.py
+++ b/tests/test_predicate_search_score_functions.py
@@ -99,7 +99,11 @@ def test_predicate_search_heuristic_base_classes():
         set(), [], {}, [])
     with pytest.raises(NotImplementedError):
         op_learning_score_function.evaluate(set())
-    utils.reset_config({"env": "cover", "cover_initial_holding_prob": 0.0})
+    utils.reset_config({
+        "env": "cover",
+        "cover_initial_holding_prob": 0.0,
+        "allow_env_caching": False
+    })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
     state = train_tasks[0].init
@@ -139,6 +143,7 @@ def test_prediction_error_score_function():
         "offline_data_method": "demo+replay",
         "num_train_tasks": 5,
         "cover_initial_holding_prob": 0.0,
+        "allow_env_caching": False,
     })
     env = CoverEnv()
     ablated = {"HandEmpty", "Holding"}
@@ -170,6 +175,7 @@ def test_prediction_error_score_function():
         "env": "blocks",
         "offline_data_method": "demo+replay",
         "num_train_tasks": 5,
+        "allow_env_caching": False,
     })
     env = BlocksEnv()
     ablated = {"Holding", "Clear", "GripperOpen"}
@@ -207,6 +213,7 @@ def test_hadd_match_score_function():
         "offline_data_method": "demo+replay",
         "num_train_tasks": 5,
         "cover_initial_holding_prob": 0.0,
+        "allow_env_caching": False,
     })
     env = CoverEnv()
     ablated = {"HandEmpty"}
@@ -237,6 +244,7 @@ def test_relaxation_energy_score_function():
         "offline_data_method": "demo+replay",
         "num_train_tasks": 5,
         "cover_initial_holding_prob": 0.0,
+        "allow_env_caching": False,
     })
     env = CoverEnv()
     ablated = {"HandEmpty", "Holding"}
@@ -295,6 +303,7 @@ def test_relaxation_energy_score_function():
         "env": "blocks",
         "offline_data_method": "demo+replay",
         "num_train_tasks": 5,
+        "allow_env_caching": False,
     })
     env = BlocksEnv()
     ablated = {"Holding", "Clear", "GripperOpen"}
@@ -342,34 +351,6 @@ def test_relaxation_energy_score_function():
     gripperopen_excluded_s = score_function.evaluate(
         {name_to_pred["Holding"], name_to_pred["Clear"]})
     assert all_included_s < none_included_s  # good!
-
-    # Tests for PaintingEnv.
-    # Comment out this test because it's flaky.
-    # utils.flush_cache()
-    # utils.reset_config({
-    #     "env": "painting",
-    #     "offline_data_method": "demo+replay",
-    #     "painting_train_families": ["box_and_shelf"],
-    # })
-    # env = PaintingEnv()
-    # ablated = {"IsWet", "IsDry"}
-    # initial_predicates = set()
-    # name_to_pred = {}
-    # for p in env.predicates:
-    #     if p.name in ablated:
-    #         name_to_pred[p.name] = p
-    #     else:
-    #         initial_predicates.add(p)
-    # candidates = {p: 1.0 for p in name_to_pred.values()}
-    # train_tasks = env.get_train_tasks()
-    # dataset = create_dataset(env, train_tasks)
-    # atom_dataset = utils.create_ground_atom_dataset(dataset.trajectories,
-    #                                                 env.predicates)
-    # score_function = _RelaxationHeuristicEnergyBasedScoreFunction(
-    #     initial_predicates, atom_dataset, candidates, train_tasks, ["hadd"])
-    # all_included_s = score_function.evaluate(set(candidates))
-    # none_included_s = score_function.evaluate(set())
-    # assert all_included_s < none_included_s  # hooray!
 
     # Cover edge case where there are no successors.
     # The below is kind of a lot to get one line of coverage (the line is
@@ -423,6 +404,7 @@ def test_exact_energy_score_function():
         "env": "blocks",
         "offline_data_method": "demo+replay",
         "num_train_tasks": 2,
+        "allow_env_caching": False,
     })
     env = BlocksEnv()
     ablated = {"Holding", "Clear", "GripperOpen"}
@@ -486,6 +468,7 @@ def test_count_score_functions():
         "grammar_search_max_demos": 4,
         "grammar_search_max_nondemos": 40,
         "cover_initial_holding_prob": 0.0,
+        "allow_env_caching": False,
     })
     env = CoverEnv()
     ablated = {"Holding", "HandEmpty"}
@@ -529,6 +512,7 @@ def test_branching_factor_score_function():
         "offline_data_num_replays": 500,
         "min_data_for_nsrt": 3,
         "cover_initial_holding_prob": 0.0,
+        "allow_env_caching": False,
     })
     env = CoverEnv()
 
@@ -572,6 +556,7 @@ def test_task_planning_score_function():
         "offline_data_method": "demo+replay",
         "num_train_tasks": 5,
         "cover_initial_holding_prob": 0.0,
+        "allow_env_caching": False,
     })
     env = CoverEnv()
 
@@ -617,6 +602,8 @@ def test_expected_nodes_score_function():
         0.0,
         "grammar_search_expected_nodes_include_suspicious_score":
         True,
+        "allow_env_caching":
+        False,
     })
     for num_train_tasks in [2, 15]:
         utils.update_config({

--- a/tests/test_teacher.py
+++ b/tests/test_teacher.py
@@ -1,6 +1,6 @@
 """Test cases for teacher."""
 
-from predicators.src.envs import create_env
+from predicators.src.envs import create_new_env
 from predicators.src.ground_truth_nsrts import _get_predicates_by_names
 from predicators.src import utils
 from predicators.src.teacher import Teacher, TeacherInteractionMonitor
@@ -12,7 +12,7 @@ from predicators.src.structs import Task, GroundAtom, DemonstrationQuery, \
 def test_GroundAtomsHold():
     """Tests for answering queries of type GroundAtomsHoldQuery."""
     utils.reset_config({"env": "cover", "approach": "unittest"})
-    env = create_env("cover")
+    env = create_new_env("cover")
     train_tasks = env.get_train_tasks()
     teacher = Teacher(train_tasks)
     state = env.get_train_tasks()[0].init
@@ -55,7 +55,7 @@ def test_GroundAtomsHold():
 def test_DemonstrationQuery():
     """Tests for answering queries of type DemonstrationQuery."""
     utils.reset_config({"env": "cover", "approach": "unittest"})
-    env = create_env("cover")
+    env = create_new_env("cover")
     train_tasks = env.get_train_tasks()
     teacher = Teacher(train_tasks)
     train_task_idx = 0
@@ -106,7 +106,7 @@ def test_TeacherInteractionMonitor():
         "num_test_tasks": 1,
         "num_online_learning_cycles": 1
     })
-    env = create_env("cover")
+    env = create_new_env("cover")
     HandEmpty = [p for p in env.predicates if p.name == "HandEmpty"][0]
     hand_empty_atom = GroundAtom(HandEmpty, [])
     query_policy = lambda s: GroundAtomsHoldQuery({hand_empty_atom})


### PR DESCRIPTION
now there are two methods: `create_new_env` and `get_cached_env`

in the main code path, main.py will be the only thing that calls
`create_new_env` (with `do_cache = True`), and everything else just uses
that same single env instance.

one complication is that for unit testing, we don't want to do caching
at all, so that's why we have a new setting "allow_env_caching"