### PR TITLE
Longrun

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -16,3 +16,7 @@ exclude_lines =
 
     # Don't complain about TYPE_CHECKING imports.
     if TYPE_CHECKING:
+
+    # Don't complain about longrun tests.
+    @longrun
+    pragma: no cover

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -359,7 +359,6 @@ def test_longrun_oracle_approach_cover_multistep_options():
         "env": "cover_multistep_options",
         "cover_multistep_use_learned_equivalents": True,
     })
-    timeout = CFG.offline_data_planning_timeout
     env = CoverMultistepOptions()
     env.seed(123)
     train_tasks = env.get_train_tasks()
@@ -368,10 +367,10 @@ def test_longrun_oracle_approach_cover_multistep_options():
     assert not approach.is_learning_based
     approach.seed(123)
     for task in train_tasks:
-        policy = approach.solve(task, timeout=timeout)
+        policy = approach.solve(task, timeout=500)
         assert policy_solves_task(policy, task, env.simulate)
     for task in env.get_test_tasks():
-        policy = approach.solve(task, timeout=timeout)
+        policy = approach.solve(task, timeout=500)
         assert policy_solves_task(policy, task, env.simulate)
 
 

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -12,6 +12,7 @@ from predicators.src.envs import CoverEnv, CoverEnvTypedOptions, \
 from predicators.src.structs import Action, NSRT, Variable
 from predicators.src.settings import CFG
 from predicators.src import utils
+from predicators.tests.conftest import longrun
 
 
 def policy_solves_task(policy, task, simulator):
@@ -344,6 +345,33 @@ def test_oracle_approach_cover_multistep_options():
         assert policy_solves_task(policy, task, env.simulate)
     for task in env.get_test_tasks():
         policy = approach.solve(task, timeout=500)
+        assert policy_solves_task(policy, task, env.simulate)
+
+
+@longrun
+def test_longrun_oracle_approach_cover_multistep_options():
+    """Tests for OracleApproach class with CoverMultistepOptions.
+
+    This is a longrun test because planning with default parameters is
+    hard in this environment.
+    """
+    utils.reset_config({
+        "env": "cover_multistep_options",
+        "cover_multistep_use_learned_equivalents": True,
+    })
+    timeout = CFG.offline_data_planning_timeout
+    env = CoverMultistepOptions()
+    env.seed(123)
+    train_tasks = env.get_train_tasks()
+    approach = OracleApproach(env.predicates, env.options, env.types,
+                              env.action_space, train_tasks)
+    assert not approach.is_learning_based
+    approach.seed(123)
+    for task in train_tasks:
+        policy = approach.solve(task, timeout=timeout)
+        assert policy_solves_task(policy, task, env.simulate)
+    for task in env.get_test_tasks():
+        policy = approach.solve(task, timeout=timeout)
         assert policy_solves_task(policy, task, env.simulate)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Shared configurations for pytest.
+
+See https://docs.pytest.org/en/6.2.x/fixture.html.
+"""
+import pytest
+
+longrun = pytest.mark.skipif("not config.getoption('longrun')")
+
+
+def pytest_addoption(parser):
+    """Enable a commandline flag for running tests marked as longrun."""
+    parser.addoption('--longrun',
+                     action='store_true',
+                     dest="longrun",
+                     default=False,
+                     help="enable longrundecorated tests")


### PR DESCRIPTION
reference: https://stackoverflow.com/questions/33084190/default-skip-test-unless-command-line-parameter-present-in-py-test

example:

`pytest -s tests/approaches/test_oracle_approach.py` finishes in ~7 seconds

`pytest -s tests/approaches/test_oracle_approach.py --longrun` finishes in ~160 seconds.