### PR TITLE
updates to supercloud run script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ build
 dist
 pylint_recursive.py
 .coverage
-supercloud_logs
+logs
 results
 videos
 logs

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ build
 dist
 pylint_recursive.py
 .coverage
-logs
 results
 videos
 logs

--- a/launch_slack_bot.py
+++ b/launch_slack_bot.py
@@ -255,7 +255,7 @@ class SupercloudLaunchResponse(SupercloudResponse):
 
     def _get_commands(self) -> List[str]:
         return [("git stash && git checkout master && git pull && "
-                 "rm -f results/* supercloud_logs/* saved_approaches/* "
+                 "rm -f results/* logs/* saved_approaches/* "
                  f"saved_datasets/* && {LAUNCH_CMD}")]
 
     def _supercloud_get_message_chunks(self) -> List[str]:

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -3,31 +3,31 @@
 import sys
 import subprocess
 import os
-import numpy as np
-
-RUN_INDEX = np.random.randint(int(1e15))
+from predicators.src import utils
+from predicators.src.settings import CFG
 
 
 def _run() -> None:
-    log_dir = "supercloud_logs"
-    os.makedirs(log_dir, exist_ok=True)
+    args = utils.parse_args()
+    utils.update_config(args)
+    job_name = f"{CFG.experiment_id}_{CFG.seed}"
     argsstr = " ".join(sys.argv[1:])
     mystr = f"#!/bin/bash\npython src/main.py {argsstr}"
-    with open(f"run_{RUN_INDEX}.sh", "w", encoding="utf-8") as f:
+    temp_run_file = "temp_run_file.sh"
+    assert not os.path.exists(temp_run_file)
+    with open(temp_run_file, "w", encoding="utf-8") as f:
         f.write(mystr)
     cmd = ("sbatch -p normal --time=99:00:00 --partition=xeon-p8 "
-           "--nodes=1 --exclusive --job-name=run.sh "
-           f"-o {log_dir}/%j_log.out run_{RUN_INDEX}.sh")
+           f"--nodes=1 --exclusive --job-name={job_name} "
+           f"-o /tmp/%j_log.out {temp_run_file}")
     print(f"Running command: {cmd}")
     output = subprocess.getoutput(cmd)
     if "command not found" in output:
-        os.remove(f"run_{RUN_INDEX}.sh")
+        os.remove(temp_run_file)
         raise Exception("Are you logged into supercloud?")
-    job_id = output.split()[-1]
-    print("Started job, see log with:\ntail -n 10000 "
-          f"-F {log_dir}/{job_id}_log.out")
-    os.remove(f"run_{RUN_INDEX}.sh")
-
+    os.remove(temp_run_file)
+    logfile = os.path.join(CFG.log_dir, f"{utils.get_config_path_str()}.log")
+    print(f"Started job, see log with:\ntail -n 10000 -F {logfile}")
 
 if __name__ == "__main__":
     _run()

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -29,5 +29,6 @@ def _run() -> None:
     logfile = os.path.join(CFG.log_dir, f"{utils.get_config_path_str()}.log")
     print(f"Started job, see log with:\ntail -n 10000 -F {logfile}")
 
+
 if __name__ == "__main__":
     _run()

--- a/supercloud.md
+++ b/supercloud.md
@@ -31,6 +31,8 @@ export TMPDIR=/state/partition1/user/$USER
 pip install -r requirements.txt
 # Add a shortcut for activating the conda env and switching to this repository.
 echo -e "predicate() {\n    cd ~/predicators\n    conda activate predicators\n}" >> ~/.bashrc
+# Add a shortcut for displaying running jobs.
+echo "alias sl='squeue --format=\"%.18i %.9P %.42j %.8u %.8T %.10M %.6D %R\"'" >> ~/.bashrc
 source ~/.bashrc
 ```
 To test if it worked:
@@ -52,7 +54,7 @@ To get started, activate the conda environment and switch to the repository. If 
 
 Before running any experiments, it is good practice to make sure that you have a clean workspace:
 * Make sure that you have already backed up any old results that you want to keep.
-* Remove all previous results: `rm -f results/* supercloud_logs/* saved_approaches/* saved_datasets/*`.
+* Remove all previous results: `rm -f results/* logs/* saved_approaches/* saved_datasets/*`.
 * Make sure you are on the right branch (`git branch`) with a clean diff (`git diff`).
 
 To run our default suite of experiments (will take many hours to complete, we recommend letting it run overnight):
@@ -62,17 +64,17 @@ To run our default suite of experiments (will take many hours to complete, we re
 
 Upon running that script, you should see many printouts, such as:
 ```
-Running command: sbatch -p normal --time=99:00:00 --partition=xeon-p8 --nodes=1 --exclusive --job-name=run.sh -o supercloud_logs/%j_log.out run_534559589715824.sh
+Running command: sbatch -p normal --time=99:00:00 --partition=xeon-p8 --nodes=1 --exclusive --job-name=pybullet_blocks_nsrt_learning_456.sh -o /tmp/%j_log.out temp_run_file.sh
 Started job, see log with:
-tail -n 10000 -F supercloud_logs/14438294_log.out
+tail -n 10000 -F logs/pybullet_blocks_nsrt_learning_456.log
 ```
 
 After experiments are running:
-* To monitor experiments that are running, use `squeue`.
-* As indicated by the printouts, to see individual logs, you can use, for example, `tail -n 10000 -F supercloud_logs/14438294_log.out`.
+* To monitor experiments that are running, use `sl`.
+* As indicated by the printouts, to see individual logs, you can use, for example, `logs/pybullet_blocks_nsrt_learning_456.log`.
 * To cancel all jobs, use `scancel -u $USER`.
 * To see a summary of results so far, do `python scripts/analyze_results_directory.py`.
-* To download results onto your local machine, use `scp -r`. The most important directory to back up is `results/`, but we also recommend backing up `supercloud_logs/`, `saved_datasets/`, and `saved_approaches/`.
+* To download results onto your local machine, use `scp -r`. The most important directory to back up is `results/`, but we also recommend backing up `logs/`, `saved_datasets/`, and `saved_approaches/`.
 
 ## Contributing
 


### PR DESCRIPTION
closes #568

* `supercloud_logs` is no more, there is only `logs`
* log names are readable now
* supercloud job names are now readable
* `squeue` is no longer recommended, a custom command `sl` is recommended instead (see updated `supercloud.md`)