### PR TITLE
one potential solution to envs/approaches __init__

### DIFF
--- a/scripts/grammar_search_analysis.py
+++ b/scripts/grammar_search_analysis.py
@@ -8,7 +8,8 @@ import os
 from typing import Dict, DefaultDict, Set, List, Tuple, Sequence, Any
 import pandas as pd
 from predicators.src.datasets import create_dataset
-from predicators.src.envs import create_new_env, BaseEnv, CoverEnv
+from predicators.src.envs import create_new_env, BaseEnv
+from predicators.src.envs.cover import CoverEnv
 from predicators.src.approaches import create_approach
 from predicators.src.approaches.grammar_search_invention_approach import \
     _ForallClassifier, _SingleAttributeCompareClassifier

--- a/src/approaches/__init__.py
+++ b/src/approaches/__init__.py
@@ -11,7 +11,6 @@ from predicators.src import utils
 
 __all__ = ["BaseApproach", "ApproachTimeout", "ApproachFailure"]
 
-
 if not TYPE_CHECKING:
     # Load all modules so that utils.get_all_subclasses() works.
     for loader, module_name, _ in pkgutil.walk_packages(__path__):
@@ -26,8 +25,8 @@ def create_approach(name: str, initial_predicates: Set[Predicate],
     """Create an approach given its name."""
     for cls in utils.get_all_subclasses(BaseApproach):
         if cls is not BaseApproach and cls.get_name() == name:
-            approach = cls(initial_predicates, initial_options,
-                           types, action_space, train_tasks)
+            approach = cls(initial_predicates, initial_options, types,
+                           action_space, train_tasks)
             break
     else:
         raise NotImplementedError(f"Unknown approach: {name}")

--- a/src/approaches/__init__.py
+++ b/src/approaches/__init__.py
@@ -1,40 +1,22 @@
-"""Default imports for approaches folder."""
+"""Handle creation of approaches."""
 
-from typing import Set, List
+import pkgutil
+from typing import Set, List, TYPE_CHECKING
 from gym.spaces import Box
 from predicators.src.approaches.base_approach import BaseApproach, \
     ApproachTimeout, ApproachFailure
-from predicators.src.approaches.random_actions_approach import \
-    RandomActionsApproach
-from predicators.src.approaches.random_options_approach import \
-    RandomOptionsApproach
-from predicators.src.approaches.gnn_policy_approach import \
-    GNNPolicyApproach
-from predicators.src.approaches.bilevel_planning_approach import \
-    BilevelPlanningApproach
-from predicators.src.approaches.oracle_approach import OracleApproach
-from predicators.src.approaches.nsrt_learning_approach import \
-    NSRTLearningApproach
-from predicators.src.approaches.interactive_learning_approach import \
-    InteractiveLearningApproach
-from predicators.src.approaches.grammar_search_invention_approach import \
-    GrammarSearchInventionApproach
 from predicators.src.structs import Predicate, ParameterizedOption, \
     Type, Task
+from predicators.src import utils
 
-__all__ = [
-    "BaseApproach",
-    "OracleApproach",
-    "RandomActionsApproach",
-    "RandomOptionsApproach",
-    "GNNPolicyApproach",
-    "BilevelPlanningApproach",
-    "NSRTLearningApproach",
-    "InteractiveLearningApproach",
-    "GrammarSearchInventionApproach",
-    "ApproachTimeout",
-    "ApproachFailure",
-]
+__all__ = ["BaseApproach", "ApproachTimeout", "ApproachFailure"]
+
+
+if not TYPE_CHECKING:
+    # Load all modules so that utils.get_all_subclasses() works.
+    for loader, module_name, _ in pkgutil.walk_packages(__path__):
+        if "__init__" not in module_name:
+            loader.find_module(module_name).load_module(module_name)
 
 
 def create_approach(name: str, initial_predicates: Set[Predicate],
@@ -42,26 +24,11 @@ def create_approach(name: str, initial_predicates: Set[Predicate],
                     types: Set[Type], action_space: Box,
                     train_tasks: List[Task]) -> BaseApproach:
     """Create an approach given its name."""
-    if name == "oracle":
-        return OracleApproach(initial_predicates, initial_options, types,
-                              action_space, train_tasks)
-    if name == "random_actions":
-        return RandomActionsApproach(initial_predicates, initial_options,
-                                     types, action_space, train_tasks)
-    if name == "random_options":
-        return RandomOptionsApproach(initial_predicates, initial_options,
-                                     types, action_space, train_tasks)
-    if name == "gnn_policy":
-        return GNNPolicyApproach(initial_predicates, initial_options, types,
-                                 action_space, train_tasks)
-    if name == "nsrt_learning":
-        return NSRTLearningApproach(initial_predicates, initial_options, types,
-                                    action_space, train_tasks)
-    if name == "interactive_learning":
-        return InteractiveLearningApproach(initial_predicates, initial_options,
-                                           types, action_space, train_tasks)
-    if name == "grammar_search_invention":
-        return GrammarSearchInventionApproach(initial_predicates,
-                                              initial_options, types,
-                                              action_space, train_tasks)
-    raise NotImplementedError(f"Unknown approach: {name}")
+    for cls in utils.get_all_subclasses(BaseApproach):
+        if cls is not BaseApproach and cls.get_name() == name:
+            approach = cls(initial_predicates, initial_options,
+                           types, action_space, train_tasks)
+            break
+    else:
+        raise NotImplementedError(f"Unknown approach: {name}")
+    return approach

--- a/src/approaches/base_approach.py
+++ b/src/approaches/base_approach.py
@@ -28,6 +28,14 @@ class BaseApproach(abc.ABC):
         self._metrics: Metrics = defaultdict(float)
         self.seed(CFG.seed)
 
+    @classmethod
+    @abc.abstractmethod
+    def get_name(cls) -> str:
+        """Get the unique name of this approach, used as the argument
+        to `--approach`.
+        """
+        raise NotImplementedError("Override me!")
+
     @property
     @abc.abstractmethod
     def is_learning_based(self) -> bool:

--- a/src/approaches/base_approach.py
+++ b/src/approaches/base_approach.py
@@ -31,9 +31,8 @@ class BaseApproach(abc.ABC):
     @classmethod
     @abc.abstractmethod
     def get_name(cls) -> str:
-        """Get the unique name of this approach, used as the argument
-        to `--approach`.
-        """
+        """Get the unique name of this approach, used as the argument to
+        `--approach`."""
         raise NotImplementedError("Override me!")
 
     @property

--- a/src/approaches/bilevel_planning_approach.py
+++ b/src/approaches/bilevel_planning_approach.py
@@ -39,6 +39,10 @@ class BilevelPlanningApproach(BaseApproach):
         self._num_calls = 0
         self._last_plan: List[_Option] = []
 
+    @classmethod
+    def get_name(cls) -> str:
+        return "bilevel_planning"
+
     def _solve(self, task: Task, timeout: int) -> Callable[[State], Action]:
         self._num_calls += 1
         # ensure random over successive calls

--- a/src/approaches/gnn_policy_approach.py
+++ b/src/approaches/gnn_policy_approach.py
@@ -49,6 +49,10 @@ class GNNPolicyApproach(BaseApproach):
         # Seed torch.
         torch.manual_seed(self._seed)
 
+    @classmethod
+    def get_name(cls) -> str:
+        return "gnn_policy"
+
     @property
     def is_learning_based(self) -> bool:
         return True

--- a/src/approaches/grammar_search_invention_approach.py
+++ b/src/approaches/grammar_search_invention_approach.py
@@ -12,7 +12,8 @@ from typing import Set, Callable, List, Sequence, FrozenSet, Iterator, Tuple, \
     Dict
 from gym.spaces import Box
 from predicators.src import utils
-from predicators.src.approaches import NSRTLearningApproach
+from predicators.src.approaches.nsrt_learning_approach import \
+    NSRTLearningApproach
 from predicators.src.nsrt_learning.strips_learning import learn_strips_operators
 from predicators.src.nsrt_learning.segmentation import segment_trajectory
 from predicators.src.structs import State, Predicate, ParameterizedOption, \
@@ -610,6 +611,10 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
                          action_space, train_tasks)
         self._learned_predicates: Set[Predicate] = set()
         self._num_inventions = 0
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "grammar_search_invention"
 
     def _get_current_predicates(self) -> Set[Predicate]:
         return self._initial_predicates | self._learned_predicates

--- a/src/approaches/interactive_learning_approach.py
+++ b/src/approaches/interactive_learning_approach.py
@@ -6,8 +6,11 @@ import dill as pkl
 import numpy as np
 from gym.spaces import Box
 from predicators.src import utils
-from predicators.src.approaches import NSRTLearningApproach, \
-    ApproachTimeout, ApproachFailure, RandomOptionsApproach
+from predicators.src.approaches.nsrt_learning_approach import \
+    NSRTLearningApproach
+from predicators.src.approaches.random_options_approach import \
+    RandomOptionsApproach
+from predicators.src.approaches import ApproachTimeout, ApproachFailure
 from predicators.src.structs import State, Predicate, ParameterizedOption, \
     Type, Task, Dataset, GroundAtom, LowLevelTrajectory, InteractionRequest, \
     InteractionResult, Action, GroundAtomsHoldQuery, GroundAtomsHoldResponse, \
@@ -32,6 +35,10 @@ class InteractiveLearningApproach(NSRTLearningApproach):
         self._predicates_to_learn: Set[Predicate] = set()
         self._online_learning_cycle = 0
         self._pred_to_ensemble: Dict[str, MLPClassifierEnsemble] = {}
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "interactive_learning"
 
     def _get_current_predicates(self) -> Set[Predicate]:
         return self._initial_predicates | self._predicates_to_learn

--- a/src/approaches/nsrt_learning_approach.py
+++ b/src/approaches/nsrt_learning_approach.py
@@ -8,7 +8,8 @@ import logging
 from typing import Set, List, Optional
 import dill as pkl
 from gym.spaces import Box
-from predicators.src.approaches import BilevelPlanningApproach
+from predicators.src.approaches.bilevel_planning_approach import \
+    BilevelPlanningApproach
 from predicators.src.structs import Dataset, NSRT, ParameterizedOption, \
     Predicate, Type, Task, LowLevelTrajectory
 from predicators.src.nsrt_learning.nsrt_learning_main import \
@@ -26,6 +27,10 @@ class NSRTLearningApproach(BilevelPlanningApproach):
         super().__init__(initial_predicates, initial_options, types,
                          action_space, train_tasks)
         self._nsrts: Set[NSRT] = set()
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "nsrt_learning"
 
     @property
     def is_learning_based(self) -> bool:

--- a/src/approaches/oracle_approach.py
+++ b/src/approaches/oracle_approach.py
@@ -8,7 +8,8 @@ generated at all.
 
 from typing import Set, List
 from predicators.src.structs import NSRT, _Option
-from predicators.src.approaches import BilevelPlanningApproach
+from predicators.src.approaches.bilevel_planning_approach import \
+    BilevelPlanningApproach
 from predicators.src.ground_truth_nsrts import get_gt_nsrts
 
 
@@ -25,6 +26,10 @@ class OracleApproach(BilevelPlanningApproach):
         hood.
         """
         return self._last_plan
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "oracle"
 
     @property
     def is_learning_based(self) -> bool:

--- a/src/approaches/random_actions_approach.py
+++ b/src/approaches/random_actions_approach.py
@@ -8,6 +8,10 @@ from predicators.src.structs import State, Task, Action
 class RandomActionsApproach(BaseApproach):
     """Samples random low-level actions."""
 
+    @classmethod
+    def get_name(cls) -> str:
+        return "random_actions"
+
     @property
     def is_learning_based(self) -> bool:
         return False

--- a/src/approaches/random_options_approach.py
+++ b/src/approaches/random_options_approach.py
@@ -10,6 +10,10 @@ from predicators.src import utils
 class RandomOptionsApproach(BaseApproach):
     """Samples random options (and random parameters for those options)."""
 
+    @classmethod
+    def get_name(cls) -> str:
+        return "random_options"
+
     @property
     def is_learning_based(self) -> bool:
         return False

--- a/src/datasets/demo_only.py
+++ b/src/datasets/demo_only.py
@@ -3,8 +3,8 @@
 import logging
 import os
 from typing import List
-from predicators.src.approaches import OracleApproach, ApproachTimeout, \
-    ApproachFailure
+from predicators.src.approaches.oracle_approach import OracleApproach
+from predicators.src.approaches import ApproachTimeout, ApproachFailure
 from predicators.src.envs import BaseEnv
 from predicators.src.structs import Dataset, Task, LowLevelTrajectory
 from predicators.src.settings import CFG

--- a/src/envs/__init__.py
+++ b/src/envs/__init__.py
@@ -9,7 +9,6 @@ from predicators.src import utils
 __all__ = ["BaseEnv"]
 _MOST_RECENT_ENV_INSTANCE = {}
 
-
 if not TYPE_CHECKING:
     # Load all modules so that utils.get_all_subclasses() works.
     for loader, module_name, _ in pkgutil.walk_packages(__path__):

--- a/src/envs/__init__.py
+++ b/src/envs/__init__.py
@@ -1,77 +1,32 @@
-"""Default imports for envs folder."""
+"""Handle creation of environments."""
 
+import pkgutil
 import logging
+from typing import TYPE_CHECKING
 from predicators.src.envs.base_env import BaseEnv
-from predicators.src.envs.cover import CoverEnv, CoverEnvTypedOptions, \
-    CoverEnvHierarchicalTypes, CoverMultistepOptions, \
-    CoverMultistepOptionsFixedTasks, CoverEnvRegrasp
-from predicators.src.envs.behavior import BehaviorEnv
-from predicators.src.envs.cluttered_table import ClutteredTableEnv, \
-    ClutteredTablePlaceEnv
-from predicators.src.envs.blocks import BlocksEnv
-from predicators.src.envs.painting import PaintingEnv
-from predicators.src.envs.tools import ToolsEnv
-from predicators.src.envs.playroom import PlayroomEnv
-from predicators.src.envs.repeated_nextto import RepeatedNextToEnv
-from predicators.src.envs.pybullet_blocks import PyBulletBlocksEnv
+from predicators.src import utils
 
-__all__ = [
-    "BaseEnv",
-    "CoverEnv",
-    "CoverEnvTypedOptions",
-    "CoverEnvHierarchicalTypes",
-    "CoverEnvRegrasp",
-    "CoverMultistepOptions",
-    "CoverMultistepOptionsFixedTasks",
-    "ClutteredTableEnv",
-    "BlocksEnv",
-    "PaintingEnv",
-    "ToolsEnv",
-    "PlayroomEnv",
-    "BehaviorEnv",
-    "RepeatedNextToEnv",
-    "PyBulletBlocksEnv",
-]
-
+__all__ = ["BaseEnv"]
 _MOST_RECENT_ENV_INSTANCE = {}
 
 
-def create_new_env(name: str, do_cache: bool = False) -> BaseEnv:
+if not TYPE_CHECKING:
+    # Load all modules so that utils.get_all_subclasses() works.
+    for loader, module_name, _ in pkgutil.walk_packages(__path__):
+        if "__init__" not in module_name:
+            loader.find_module(module_name).load_module(module_name)
+
+
+def create_new_env(name: str, do_cache: bool = True) -> BaseEnv:
     """Create a new instance of an environment from its name.
 
     If do_cache is True, then cache this env instance so that it can
     later be loaded using get_or_create_env().
     """
-    if name == "cover":
-        env: BaseEnv = CoverEnv()
-    elif name == "cover_typed_options":
-        env = CoverEnvTypedOptions()
-    elif name == "cover_hierarchical_types":
-        env = CoverEnvHierarchicalTypes()
-    elif name == "cover_regrasp":
-        env = CoverEnvRegrasp()
-    elif name == "cover_multistep_options":
-        env = CoverMultistepOptions()
-    elif name == "cover_multistep_options_fixed_tasks":
-        env = CoverMultistepOptionsFixedTasks()
-    elif name == "cluttered_table":
-        env = ClutteredTableEnv()
-    elif name == "cluttered_table_place":
-        env = ClutteredTablePlaceEnv()
-    elif name == "blocks":
-        env = BlocksEnv()
-    elif name == "painting":
-        env = PaintingEnv()
-    elif name == "tools":
-        env = ToolsEnv()
-    elif name == "playroom":
-        env = PlayroomEnv()
-    elif name == "behavior":
-        env = BehaviorEnv()  # pragma: no cover
-    elif name == "repeated_nextto":
-        env = RepeatedNextToEnv()
-    elif name == "pybullet_blocks":
-        env = PyBulletBlocksEnv()
+    for cls in utils.get_all_subclasses(BaseEnv):
+        if cls is not BaseEnv and cls.get_name() == name:
+            env = cls()
+            break
     else:
         raise NotImplementedError(f"Unknown env: {name}")
     if do_cache:

--- a/src/envs/base_env.py
+++ b/src/envs/base_env.py
@@ -23,6 +23,14 @@ class BaseEnv(abc.ABC):
         self._train_tasks: List[Task] = []
         self._test_tasks: List[Task] = []
 
+    @classmethod
+    @abc.abstractmethod
+    def get_name(cls) -> str:
+        """Get the unique name of this environment, used as the argument
+        to `--env`.
+        """
+        raise NotImplementedError("Override me!")
+
     @abc.abstractmethod
     def simulate(self, state: State, action: Action) -> State:
         """Get the next state, given a state and an action.

--- a/src/envs/base_env.py
+++ b/src/envs/base_env.py
@@ -26,9 +26,8 @@ class BaseEnv(abc.ABC):
     @classmethod
     @abc.abstractmethod
     def get_name(cls) -> str:
-        """Get the unique name of this environment, used as the argument
-        to `--env`.
-        """
+        """Get the unique name of this environment, used as the argument to
+        `--env`."""
         raise NotImplementedError("Override me!")
 
     @abc.abstractmethod

--- a/src/envs/behavior.py
+++ b/src/envs/behavior.py
@@ -117,6 +117,10 @@ class BehaviorEnv(BaseEnv):
                 )
                 self._options.add(option)
 
+    @classmethod
+    def get_name(cls) -> str:
+        return "behavior"
+
     def simulate(self, state: State, action: Action) -> State:
         assert isinstance(state.simulator_state, str)
         self.task_num = int(state.simulator_state.split("-")[0])

--- a/src/envs/blocks.py
+++ b/src/envs/blocks.py
@@ -90,6 +90,10 @@ class BlocksEnv(BaseEnv):
         # Static objects (always exist no matter the settings).
         self._robot = Object("robby", self._robot_type)
 
+    @classmethod
+    def get_name(cls) -> str:
+        return "blocks"
+
     def simulate(self, state: State, action: Action) -> State:
         assert self.action_space.contains(action.arr)
         x, y, z, fingers = action.arr

--- a/src/envs/cluttered_table.py
+++ b/src/envs/cluttered_table.py
@@ -38,6 +38,10 @@ class ClutteredTableEnv(BaseEnv):
         self._Dump = utils.SingletonParameterizedOption(
             "Dump", self._Dump_policy)
 
+    @classmethod
+    def get_name(cls) -> str:
+        return "cluttered_table"
+
     def simulate(self, state: State, action: Action) -> State:
         assert self.action_space.contains(action.arr)
         next_state = state.copy()
@@ -308,6 +312,10 @@ class ClutteredTablePlaceEnv(ClutteredTableEnv):
             self._Grasp_policy,
             types=[self._can_type],
             params_space=Box(np.array([0, 0, 0, 0]), np.array([1, 1, 1, 1])))
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "cluttered_table_place"
 
     @property
     def options(self) -> Set[ParameterizedOption]:

--- a/src/envs/cover.py
+++ b/src/envs/cover.py
@@ -46,6 +46,10 @@ class CoverEnv(BaseEnv):
         # Static objects (always exist no matter the settings).
         self._robot = Object("robby", self._robot_type)
 
+    @classmethod
+    def get_name(cls) -> str:
+        return "cover"
+
     def simulate(self, state: State, action: Action) -> State:
         assert self.action_space.contains(action.arr)
         pose = action.arr.item()
@@ -368,6 +372,10 @@ class CoverEnvTypedOptions(CoverEnv):
             types=[self._target_type],
             params_space=Box(0, 1, (1, )))
 
+    @classmethod
+    def get_name(cls) -> str:
+        return "cover_typed_options"
+
     @property
     def options(self) -> Set[ParameterizedOption]:
         return {self._Pick, self._Place}
@@ -394,6 +402,10 @@ class CoverEnvHierarchicalTypes(CoverEnv):
             "block_derived",
             ["is_block", "is_target", "width", "pose", "grasp"],
             parent=self._parent_block_type)
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "cover_hierarchical_types"
 
     @property
     def types(self) -> Set[Type]:
@@ -427,6 +439,10 @@ class CoverEnvRegrasp(CoverEnv):
         # covered targets.
         self._Clear = Predicate("Clear", [self._target_type],
                                 self._Clear_holds)
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "cover_regrasp"
 
     @property
     def predicates(self) -> Set[Predicate]:
@@ -552,6 +568,10 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
             policy=self._Place_learned_equivalent_policy,
             initiable=self._Place_learned_equivalent_initiable,
             terminal=self._Place_learned_equivalent_terminal)
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "cover_multistep_options"
 
     @property
     def options(self) -> Set[ParameterizedOption]:
@@ -1219,6 +1239,10 @@ class CoverMultistepOptionsFixedTasks(CoverMultistepOptions):
     Note that like the parent env, there are three possible goals:
     Cover(block0, target0), Cover(block1, target1), or both.
     """
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "cover_multistep_options_fixed_tasks"
 
     def _create_initial_state(self, blocks: List[Object],
                               targets: List[Object],

--- a/src/envs/painting.py
+++ b/src/envs/painting.py
@@ -141,6 +141,10 @@ class PaintingEnv(BaseEnv):
         self._shelf = Object("receptacle_shelf", self._shelf_type)
         self._robot = Object("robby", self._robot_type)
 
+    @classmethod
+    def get_name(cls) -> str:
+        return "painting"
+
     def simulate(self, state: State, action: Action) -> State:
         assert self.action_space.contains(action.arr)
         arr = action.arr

--- a/src/envs/playroom.py
+++ b/src/envs/playroom.py
@@ -5,7 +5,7 @@ import numpy as np
 from gym.spaces import Box
 from matplotlib import pyplot as plt
 from matplotlib import patches
-from predicators.src.envs import BlocksEnv
+from predicators.src.envs.blocks import BlocksEnv
 from predicators.src.structs import Type, Predicate, State, Task, \
     ParameterizedOption, Object, Action, Image, Array, GroundAtom
 from predicators.src import utils
@@ -203,6 +203,10 @@ class PlayroomEnv(BlocksEnv):
         self._region6 = Object("region6", self._region_type)
         self._region7 = Object("region7", self._region_type)
         self._dial = Object("dial", self._dial_type)
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "playroom"
 
     def simulate(self, state: State, action: Action) -> State:
         assert self.action_space.contains(action.arr)

--- a/src/envs/pybullet_blocks.py
+++ b/src/envs/pybullet_blocks.py
@@ -272,6 +272,10 @@ class PyBulletBlocksEnv(BlocksEnv):
                    shape=(4, ),
                    dtype=np.float32)
 
+    @classmethod
+    def get_name(cls) -> str:
+        return "pybullet_blocks"
+
     def simulate(self, state: State, action: Action) -> State:
         raise NotImplementedError("PyBulletBlocksEnv cannot simulate.")
 

--- a/src/envs/repeated_nextto.py
+++ b/src/envs/repeated_nextto.py
@@ -51,6 +51,10 @@ class RepeatedNextToEnv(BaseEnv):
         # Static objects (always exist no matter the settings).
         self._robot = Object("robby", self._robot_type)
 
+    @classmethod
+    def get_name(cls) -> str:
+        return "repeated_nextto"
+
     def simulate(self, state: State, action: Action) -> State:
         assert self.action_space.contains(action.arr)
         move_or_grasp, norm_robot_x, norm_dot_x = action.arr

--- a/src/envs/tools.py
+++ b/src/envs/tools.py
@@ -177,6 +177,10 @@ class ToolsEnv(BaseEnv):
         # Static objects (always exist no matter the settings).
         self._robot = Object("robby", self._robot_type)
 
+    @classmethod
+    def get_name(cls) -> str:
+        return "tools"
+
     def simulate(self, state: State, action: Action) -> State:
         assert self.action_space.contains(action.arr)
         next_state = state.copy()

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -3,8 +3,11 @@
 from typing import List, Sequence, Set, cast
 import itertools
 import numpy as np
-from predicators.src.envs import get_or_create_env, PaintingEnv, PlayroomEnv, \
-    BehaviorEnv, ToolsEnv
+from predicators.src.envs import get_or_create_env
+from predicators.src.envs.painting import PaintingEnv
+from predicators.src.envs.playroom import PlayroomEnv
+from predicators.src.envs.behavior import BehaviorEnv
+from predicators.src.envs.tools import ToolsEnv
 from predicators.src.structs import NSRT, Predicate, State, GroundAtom, \
     ParameterizedOption, Variable, Type, LiftedAtom, Object, Array
 from predicators.src.settings import CFG

--- a/src/nsrt_learning/option_learning.py
+++ b/src/nsrt_learning/option_learning.py
@@ -10,7 +10,8 @@ from predicators.src.structs import STRIPSOperator, OptionSpec, Datastore, \
 from predicators.src.approaches import ApproachFailure
 from predicators.src.settings import CFG
 from predicators.src.torch_models import MLPRegressor
-from predicators.src.envs import get_or_create_env, BlocksEnv
+from predicators.src.envs import get_or_create_env
+from predicators.src.envs.blocks import BlocksEnv
 
 
 def create_option_learner() -> _OptionLearnerBase:

--- a/src/teacher.py
+++ b/src/teacher.py
@@ -10,8 +10,8 @@ from predicators.src.structs import State, Task, Query, Response, \
     Action, PathToStateQuery, PathToStateResponse
 from predicators.src.settings import CFG, get_allowed_query_type_names
 from predicators.src.envs import get_or_create_env
-from predicators.src.approaches import OracleApproach, ApproachTimeout, \
-    ApproachFailure
+from predicators.src.approaches.oracle_approach import OracleApproach
+from predicators.src.approaches import ApproachTimeout, ApproachFailure
 from predicators.src.ground_truth_nsrts import _get_types_by_names, \
     _get_options_by_names
 from predicators.src import utils

--- a/src/utils.py
+++ b/src/utils.py
@@ -1730,7 +1730,6 @@ def get_git_commit_hash() -> str:
 
 
 def get_all_subclasses(cls: Any) -> Set[Any]:
-    """Get all subclasses of the given class.
-    """
+    """Get all subclasses of the given class."""
     return set(cls.__subclasses__()).union(
         [s for c in cls.__subclasses__() for s in get_all_subclasses(c)])

--- a/src/utils.py
+++ b/src/utils.py
@@ -1727,3 +1727,10 @@ def get_git_commit_hash() -> str:
     """Return the hash of the current git commit."""
     out = subprocess.check_output(["git", "rev-parse", "HEAD"])
     return out.decode("ascii").strip()
+
+
+def get_all_subclasses(cls: Any) -> Set[Any]:
+    """Get all subclasses of the given class.
+    """
+    return set(cls.__subclasses__()).union(
+        [s for c in cls.__subclasses__() for s in get_all_subclasses(c)])

--- a/tests/approaches/test_base_approach.py
+++ b/tests/approaches/test_base_approach.py
@@ -5,7 +5,7 @@ import pytest
 from gym.spaces import Box
 import numpy as np
 from predicators.src.approaches import BaseApproach, create_approach
-from predicators.src.envs import CoverEnv
+from predicators.src.envs.cover import CoverEnv
 from predicators.src.structs import State, Type, ParameterizedOption, \
     Predicate, Task, Action
 from predicators.src import utils
@@ -13,6 +13,10 @@ from predicators.src import utils
 
 class _DummyApproach(BaseApproach):
     """Dummy approach for testing."""
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "dummy"
 
     @property
     def is_learning_based(self):

--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -10,7 +10,7 @@ from predicators.src.approaches.grammar_search_invention_approach import (
     _SingleAttributeCompareClassifier, _NegationClassifier)
 from predicators.src.predicate_search_score_functions import \
     _count_positives_for_ops
-from predicators.src.envs import CoverEnv
+from predicators.src.envs.cover import CoverEnv
 from predicators.src.structs import Type, Predicate, STRIPSOperator, State, \
     Action, Box, LowLevelTrajectory, Dataset
 from predicators.src.nsrt_learning.segmentation import segment_trajectory

--- a/tests/approaches/test_interactive_approach.py
+++ b/tests/approaches/test_interactive_approach.py
@@ -2,10 +2,11 @@
 
 import numpy as np
 import pytest
-from predicators.src.approaches import InteractiveLearningApproach, \
-    ApproachTimeout, ApproachFailure
+from predicators.src.approaches.interactive_learning_approach import \
+    InteractiveLearningApproach
+from predicators.src.approaches import ApproachTimeout, ApproachFailure
 from predicators.src.datasets import create_dataset
-from predicators.src.envs import CoverEnv
+from predicators.src.envs.cover import CoverEnv
 from predicators.src.settings import CFG
 from predicators.src.structs import Dataset
 from predicators.src.main import _generate_interaction_results

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -3,12 +3,18 @@
 from typing import Set
 import numpy as np
 import pytest
-from predicators.src.approaches import OracleApproach
+from predicators.src.approaches.oracle_approach import OracleApproach
 from predicators.src.ground_truth_nsrts import get_gt_nsrts
-from predicators.src.envs import CoverEnv, CoverEnvTypedOptions, \
-    CoverEnvHierarchicalTypes, ClutteredTableEnv, ClutteredTablePlaceEnv, \
-    BlocksEnv, PaintingEnv, ToolsEnv, PlayroomEnv, CoverMultistepOptions, \
-    CoverMultistepOptionsFixedTasks, RepeatedNextToEnv, CoverEnvRegrasp
+from predicators.src.envs.cover import CoverEnv, CoverEnvTypedOptions, \
+    CoverEnvHierarchicalTypes, CoverMultistepOptions, \
+    CoverMultistepOptionsFixedTasks, CoverEnvRegrasp
+from predicators.src.envs.cluttered_table import ClutteredTableEnv, \
+    ClutteredTablePlaceEnv
+from predicators.src.envs.blocks import BlocksEnv
+from predicators.src.envs.painting import PaintingEnv
+from predicators.src.envs.tools import ToolsEnv
+from predicators.src.envs.playroom import PlayroomEnv
+from predicators.src.envs.repeated_nextto import RepeatedNextToEnv
 from predicators.src.structs import Action, NSRT, Variable
 from predicators.src.settings import CFG
 from predicators.src import utils

--- a/tests/approaches/test_random_actions_approach.py
+++ b/tests/approaches/test_random_actions_approach.py
@@ -1,7 +1,8 @@
 """Test cases for the random actions approach class."""
 
-from predicators.src.approaches import RandomActionsApproach
-from predicators.src.envs import CoverEnv
+from predicators.src.approaches.random_actions_approach import \
+    RandomActionsApproach
+from predicators.src.envs.cover import CoverEnv
 from predicators.src import utils
 
 

--- a/tests/approaches/test_random_options_approach.py
+++ b/tests/approaches/test_random_options_approach.py
@@ -1,7 +1,8 @@
 """Test cases for the random options approach class."""
 
 from gym.spaces import Box
-from predicators.src.approaches import RandomOptionsApproach
+from predicators.src.approaches.random_options_approach import \
+    RandomOptionsApproach
 from predicators.src.structs import Type, ParameterizedOption, State, Action, \
     Task, Predicate, DefaultState
 from predicators.src import utils

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -2,7 +2,8 @@
 
 import pytest
 from predicators.src.datasets import create_dataset
-from predicators.src.envs import CoverEnv, ClutteredTableEnv
+from predicators.src.envs.cover import CoverEnv
+from predicators.src.envs.cluttered_table import ClutteredTableEnv
 from predicators.src.approaches import ApproachTimeout
 from predicators.src.structs import Dataset, Task, GroundAtom
 from predicators.src import utils

--- a/tests/envs/test_blocks.py
+++ b/tests/envs/test_blocks.py
@@ -1,7 +1,7 @@
 """Test cases for the blocks environment."""
 
 import numpy as np
-from predicators.src.envs import BlocksEnv
+from predicators.src.envs.blocks import BlocksEnv
 from predicators.src import utils
 
 

--- a/tests/envs/test_cluttered_table.py
+++ b/tests/envs/test_cluttered_table.py
@@ -2,7 +2,8 @@
 
 import numpy as np
 from gym.spaces import Box
-from predicators.src.envs import ClutteredTableEnv, ClutteredTablePlaceEnv
+from predicators.src.envs.cluttered_table import ClutteredTableEnv, \
+    ClutteredTablePlaceEnv
 from predicators.src import utils
 from predicators.src.structs import Action, GroundAtom
 

--- a/tests/envs/test_cover.py
+++ b/tests/envs/test_cover.py
@@ -3,7 +3,7 @@
 import pytest
 import numpy as np
 from gym.spaces import Box
-from predicators.src.envs import CoverEnv, CoverEnvTypedOptions, \
+from predicators.src.envs.cover import CoverEnv, CoverEnvTypedOptions, \
     CoverMultistepOptions, CoverMultistepOptionsFixedTasks, \
     CoverEnvRegrasp
 from predicators.src.structs import Action, Task

--- a/tests/envs/test_painting.py
+++ b/tests/envs/test_painting.py
@@ -2,7 +2,7 @@
 
 import pytest
 import numpy as np
-from predicators.src.envs import PaintingEnv
+from predicators.src.envs.painting import PaintingEnv
 from predicators.src.structs import Action
 from predicators.src import utils
 

--- a/tests/envs/test_playroom.py
+++ b/tests/envs/test_playroom.py
@@ -2,7 +2,7 @@
 
 import pytest
 import numpy as np
-from predicators.src.envs import PlayroomEnv
+from predicators.src.envs.playroom import PlayroomEnv
 from predicators.src import utils
 from predicators.src.structs import Action
 

--- a/tests/envs/test_pybullet_blocks.py
+++ b/tests/envs/test_pybullet_blocks.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pytest
-from predicators.src.envs import PyBulletBlocksEnv
+from predicators.src.envs.pybullet_blocks import PyBulletBlocksEnv
 from predicators.src.structs import Object, State, Action
 from predicators.src import utils
 from predicators.src.settings import CFG

--- a/tests/envs/test_repeated_nextto.py
+++ b/tests/envs/test_repeated_nextto.py
@@ -1,7 +1,7 @@
 """Test cases for the repeated NextTo environment."""
 
 import numpy as np
-from predicators.src.envs import RepeatedNextToEnv
+from predicators.src.envs.repeated_nextto import RepeatedNextToEnv
 from predicators.src.structs import Action
 from predicators.src import utils
 

--- a/tests/envs/test_tools.py
+++ b/tests/envs/test_tools.py
@@ -2,7 +2,7 @@
 
 import pytest
 import numpy as np
-from predicators.src.envs import ToolsEnv
+from predicators.src.envs.tools import ToolsEnv
 from predicators.src import utils
 from predicators.src.structs import Action
 

--- a/tests/nsrt_learning/test_sampler_learning.py
+++ b/tests/nsrt_learning/test_sampler_learning.py
@@ -9,7 +9,7 @@ from predicators.src.structs import Type, Predicate, State, Action, \
     ParameterizedOption, LiftedAtom, Segment, LowLevelTrajectory
 from predicators.src import utils
 from predicators.src.torch_models import NeuralGaussianRegressor, MLPClassifier
-from predicators.src.envs import ClutteredTablePlaceEnv
+from predicators.src.envs.cluttered_table import ClutteredTablePlaceEnv
 
 
 def test_create_sampler_data():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,7 +7,7 @@ import sys
 import pytest
 from predicators.src.approaches import BaseApproach, ApproachFailure, \
     create_approach
-from predicators.src.envs import CoverEnv
+from predicators.src.envs.cover import CoverEnv
 from predicators.src.main import main, _run_testing
 from predicators.src.structs import State, Task, Action
 from predicators.src import utils
@@ -15,6 +15,10 @@ from predicators.src import utils
 
 class _DummyApproach(BaseApproach):
     """Dummy approach that raises ApproachFailure for testing."""
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "dummy"
 
     @property
     def is_learning_based(self):
@@ -30,6 +34,10 @@ class _DummyApproach(BaseApproach):
 
 class _DummyCoverEnv(CoverEnv):
     """Dummy cover environment that raises EnvironmentFailure for testing."""
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "dummy"
 
     def simulate(self, state, action):
         raise utils.EnvironmentFailure("", {"offending_objects": set()})

--- a/tests/test_online_learning.py
+++ b/tests/test_online_learning.py
@@ -20,6 +20,10 @@ class _MockApproach(BaseApproach):
                          action_space, train_tasks)
         self._dummy_saved = []
 
+    @classmethod
+    def get_name(cls) -> str:
+        return "dummy"
+
     @property
     def is_learning_based(self):
         return True

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -2,10 +2,10 @@
 
 import pytest
 from gym.spaces import Box
-from predicators.src.approaches import OracleApproach
+from predicators.src.approaches.oracle_approach import OracleApproach
 from predicators.src.ground_truth_nsrts import get_gt_nsrts
 from predicators.src.approaches import ApproachFailure, ApproachTimeout
-from predicators.src.envs import CoverEnv
+from predicators.src.envs.cover import CoverEnv
 from predicators.src.planning import sesame_plan, task_plan, task_plan_grounding
 from predicators.src import utils
 from predicators.src.structs import Task, NSRT, ParameterizedOption, _Option, \

--- a/tests/test_predicate_search_score_functions.py
+++ b/tests/test_predicate_search_score_functions.py
@@ -15,7 +15,8 @@ from predicators.src.predicate_search_score_functions import (
     _RelaxationHeuristicCountBasedScoreFunction,
     _ExactHeuristicCountBasedScoreFunction, _BranchingFactorScoreFunction,
     _ExpectedNodesScoreFunction)
-from predicators.src.envs import CoverEnv, BlocksEnv
+from predicators.src.envs.cover import CoverEnv
+from predicators.src.envs.blocks import BlocksEnv
 from predicators.src.nsrt_learning.segmentation import segment_trajectory
 from predicators.src.datasets import create_dataset
 from predicators.src.structs import Predicate, STRIPSOperator, Action, \

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,7 @@ from predicators.src.structs import State, Type, ParameterizedOption, \
     LowLevelTrajectory, DefaultState, Segment
 from predicators.src.ground_truth_nsrts import get_gt_nsrts, \
     _get_predicates_by_names
-from predicators.src.envs import CoverEnv
+from predicators.src.envs.cover import CoverEnv
 from predicators.src.settings import CFG
 from predicators.src import utils
 from predicators.src.utils import _TaskPlanningHeuristic, \


### PR DESCRIPTION
This PR makes us not have to touch `__init__.py` in `approaches/` or `envs/` when adding new approaches or environments. One large change is that we can't import things directly from approaches or envs anymore, e.g.:
```
from predicators.src.envs import CoverEnv
from predicators.src.approaches import OracleApproach
```
now needs to be:
```
from predicators.src.envs.cover import CoverEnv
from predicators.src.approaches.oracle_approach import OracleApproach
```

closes #558