### PR TITLE
fix oracle option model for learned options

### DIFF
--- a/src/option_model.py
+++ b/src/option_model.py
@@ -63,13 +63,10 @@ class _OracleOptionModel(_OptionModelBase):
         # option has memory. It is also important when using the option model
         # for one environment with options from another environment. E.g.,
         # using a non-PyBullet environment in the option model while using a
-        # PyBullet environment otherwise. Note that in this case of using a
-        # PyBullet environment, the second return value (num_actions) will be
-        # an underestimate since we are not actually rolling out the option in
-        # the full simulator, but that's okay. Finally, in the case where we
-        # are learning options, the learned options will not appear in the
-        # env.options set. (However, we still want to use the environment
-        # options during data collection when we are learning options). In this
+        # PyBullet environment otherwise. In the case where we are
+        # learning options, the learned options will not appear in the
+        # env.options set. However, we still want to use the environment
+        # options during data collection when we are learning options. In this
         # case, we make a copy of the option itself, rather than reconstructing
         # it from env.options.
         param_opt = option.parent
@@ -93,6 +90,10 @@ class _OracleOptionModel(_OptionModelBase):
             state,
             option_copy.terminal,
             max_num_steps=CFG.max_num_steps_option_rollout)
+        # Note that in the case of using a PyBullet environment, the
+        # second return value (num_actions) will be an underestimate
+        # since we are not actually rolling out the option in the full
+        # simulator, but that's okay; it leads to optimistic planning.
         return traj.states[-1], len(traj.actions)
 
 


### PR DESCRIPTION
this command crashes before this change, but not after:
```python src/main.py --env cover_multistep_options --approach nsrt_learning --seed 0 --option_learner neural --sampler_learner oracle --num_train_tasks 50```

example crash:
```
Traceback (most recent call last):
  File "/Users/tom/phd/predicators/src/main.py", line 336, in <module>
    main()
  File "/Users/tom/phd/predicators/src/main.py", line 108, in main
    _run_pipeline(env, approach, stripped_train_tasks, offline_dataset)
  File "/Users/tom/phd/predicators/src/main.py", line 131, in _run_pipeline
    results = _run_testing(env, approach)
  File "/Users/tom/phd/predicators/src/main.py", line 240, in _run_testing
    policy = approach.solve(task, timeout=CFG.timeout)
  File "/Users/tom/phd/predicators/src/approaches/base_approach.py", line 51, in solve
    pi = self._solve(task, timeout)
  File "/Users/tom/phd/predicators/src/approaches/bilevel_planning_approach.py", line 48, in _solve
    plan, metrics = sesame_plan(task,
  File "/Users/tom/phd/predicators/src/planning.py", line 98, in sesame_plan
    plan, suc = _run_low_level_search(
  File "/Users/tom/phd/predicators/src/planning.py", line 297, in _run_low_level_search
    next_state, _ = option_model.get_next_state_and_num_actions(
  File "/Users/tom/phd/predicators/src/option_model.py", line 71, in get_next_state_and_num_actions
    env_param_opt = self._name_to_parameterized_option[param_opt.name]
KeyError: 'Op0LearnedOption'
```