### PR TITLE
change git to https in requirements-dev

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,4 @@ yapf
 docformatter
 isort
 # Note: if https://github.com/python/mypy/issues/5485 gets resolved, we can install mypy from head again.
-mypy@git+git://github.com/python/mypy.git@9bd651758e8ea2494837814092af70f8d9e6f7a1
+mypy@git+https://github.com/python/mypy.git@9bd651758e8ea2494837814092af70f8d9e6f7a1


### PR DESCRIPTION
`pip install -r requirements-dev.txt` with the most recent pip fails on the mypy installation.

context: https://stackoverflow.com/questions/70663523/the-unauthenticated-git-protocol-on-port-9418-is-no-longer-supported
