### PR TITLE
fix weird memory error in supercloud

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1735,6 +1735,7 @@ def null_sampler(state: State, goal: Set[GroundAtom], rng: np.random.Generator,
     return np.array([], dtype=np.float32)  # no continuous parameters
 
 
+@functools.lru_cache(maxsize=None)
 def get_git_commit_hash() -> str:
     """Return the hash of the current git commit."""
     out = subprocess.check_output(["git", "rev-parse", "HEAD"])


### PR DESCRIPTION
example stack trace:
```
Tasks solved: 50 / 50
Average time for successes: 0.16820 seconds
Traceback (most recent call last):
  File "/home/gridsan/ronuchit/predicators/src/main.py", line 344, in <module>
    main()
  File "/home/gridsan/ronuchit/predicators/src/main.py", line 104, in main
    _run_pipeline(env, approach, stripped_train_tasks, offline_dataset)
  File "/home/gridsan/ronuchit/predicators/src/main.py", line 133, in _run_pipeline
    _save_test_results(results, online_learning_cycle=None)
  File "/home/gridsan/ronuchit/predicators/src/main.py", line 335, in _save_test_results
    "git_commit_hash": utils.get_git_commit_hash()
  File "/home/gridsan/ronuchit/predicators/src/utils.py", line 1740, in get_git_commit_hash
    out = subprocess.check_output(["git", "rev-parse", "HEAD"])
  File "/home/gridsan/ronuchit/.conda/envs/predicators/lib/python3.9/subprocess.py", line 424, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/home/gridsan/ronuchit/.conda/envs/predicators/lib/python3.9/subprocess.py", line 505, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/home/gridsan/ronuchit/.conda/envs/predicators/lib/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/home/gridsan/ronuchit/.conda/envs/predicators/lib/python3.9/subprocess.py", line 1754, in _execute_child
    self.pid = _posixsubprocess.fork_exec(
OSError: [Errno 12] Cannot allocate memory
```