### PR TITLE
fix edge case for min_skeletons_optimized metric

### DIFF
--- a/src/approaches/bilevel_planning_approach.py
+++ b/src/approaches/bilevel_planning_approach.py
@@ -86,10 +86,8 @@ class BilevelPlanningApproach(BaseApproach):
 
     def reset_metrics(self) -> None:
         super().reset_metrics()
-        # Initialize min to self._max_skeletons_optimized (max gets initialized
-        # to 0 by default)
-        self._metrics[
-            "min_num_skeletons_optimized"] = self._max_skeletons_optimized
+        # Initialize min to inf (max gets initialized to 0 by default).
+        self._metrics["min_num_skeletons_optimized"] = float("inf")
 
     @abc.abstractmethod
     def _get_current_nsrts(self) -> Set[NSRT]:

--- a/src/main.py
+++ b/src/main.py
@@ -298,7 +298,8 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
     metrics["avg_suc_time"] = (total_suc_time /
                                num_solved if num_solved > 0 else float("inf"))
     metrics["min_skeletons_optimized"] = approach.metrics[
-        "min_num_skeletons_optimized"]
+        "min_num_skeletons_optimized"] if approach.metrics[
+            "min_num_skeletons_optimized"] < float("inf") else 0
     metrics["max_skeletons_optimized"] = approach.metrics[
         "max_num_skeletons_optimized"]
     metrics["avg_execution_failures"] = (


### PR DESCRIPTION
example: ```python src/main.py --env cover --approach oracle --seed 0 --num_test_tasks 1 --timeout 0.001```

before:
```
Test results: defaultdict(<class 'float'>, {... 'min_skeletons_optimized': 8, 'max_skeletons_optimized': 0.0, ...})
```

after:
```
Test results: defaultdict(<class 'float'>, {... 'min_skeletons_optimized': 0, 'max_skeletons_optimized': 0.0, ...})
```
