### PR TITLE
initial hacky implementation of backchaining idea for sidelining

### DIFF
--- a/src/nsrt_learning/nsrt_learning_main.py
+++ b/src/nsrt_learning/nsrt_learning_main.py
@@ -11,7 +11,8 @@ from predicators.src.nsrt_learning.sampler_learning import learn_samplers
 from predicators.src.nsrt_learning.segmentation import segment_trajectory
 from predicators.src.nsrt_learning.side_predicate_learning import \
     PredictionErrorHillClimbingSidePredicateLearner, \
-    PreserveSkeletonsHillClimbingSidePredicateLearner, SidePredicateLearner
+    PreserveSkeletonsHillClimbingSidePredicateLearner, SidePredicateLearner, \
+    BackchainingSidePredicateLearner
 from predicators.src.nsrt_learning.strips_learning import \
     learn_strips_operators
 from predicators.src.settings import CFG
@@ -88,6 +89,9 @@ def learn_nsrts_from_data(trajectories: List[LowLevelTrajectory],
                 PreserveSkeletonsHillClimbingSidePredicateLearner(
                     pnads, trajectories, train_tasks, predicates,
                     segmented_trajs)
+        elif CFG.side_predicate_learner == "backchaining":
+            side_pred_learner = BackchainingSidePredicateLearner(
+                pnads, trajectories, train_tasks, predicates, segmented_trajs)
         else:
             raise ValueError(
                 f"side_predicate_learner {CFG.side_predicate_learner} not " +


### PR DESCRIPTION
currently learns these operators:

```
Learned NSRTs:
NSRT-MoveLearnedOp:
    Parameters: [?x0:dot, ?x1:robot]
    Preconditions: []
    Add Effects: [NextTo(?x1:robot, ?x0:dot)]
    Delete Effects: []
    Side Predicates: [NextTo, NextToNothing]
    Option Spec: Move(?x1:robot, ?x0:dot)
NSRT-GraspLearnedOp:
    Parameters: [?x0:dot, ?x1:robot]
    Preconditions: [NextTo(?x1:robot, ?x0:dot)]
    Add Effects: [Grasped(?x1:robot, ?x0:dot)]
    Delete Effects: []
    Side Predicates: [NextTo, NextToNothing]
    Option Spec: Grasp(?x1:robot, ?x0:dot)
```

result:
```
Tasks solved: 50 / 50
Average time for successes: 0.04202 seconds
Test results: defaultdict(<class 'float'>, {'num_solved': 50, 'num_total': 50, 'avg_suc_time': 0.042019286155700684, 'min_skeletons_optimized': 1.0, 'max_skeletons_optimized': 1.0, 'avg_execution_failures': 0.0, 'avg_num_skeletons_optimized': 1.0, 'avg_num_nodes_expanded': 3.0, 'avg_num_nodes_created': 47.66, 'avg_num_nsrts': 2.0, 'avg_num_preds': 3.0, 'avg_plan_length': 2.64, 'avg_num_failures_discovered': 0.0, 'num_transitions': 132, 'query_cost': 0.0, 'learning_time': 8.083026885986328})
```