### PR TITLE
(Hacky) Intersection-based sidelining

### DIFF
--- a/scripts/supercloud/run_sidelining_experiments.sh
+++ b/scripts/supercloud/run_sidelining_experiments.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 START_SEED=456
-NUM_SEEDS=200
+NUM_SEEDS=1000
 FILE="scripts/supercloud/submit_supercloud_job.py"
 
 for SEED in $(seq $START_SEED $((NUM_SEEDS+START_SEED-1))); do

--- a/scripts/supercloud/run_sidelining_experiments.sh
+++ b/scripts/supercloud/run_sidelining_experiments.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+START_SEED=456
+NUM_SEEDS=200
+FILE="scripts/supercloud/submit_supercloud_job.py"
+
+for SEED in $(seq $START_SEED $((NUM_SEEDS+START_SEED-1))); do
+    # repeated_nextto
+    python $FILE --experiment_id rnt_no_sidepreds --env repeated_nextto --approach nsrt_learning --side_predicate_learner backchaining --seed $SEED --num_train_tasks 50
+
+    # python $FILE --experiment_id rnt_oracle --env repeated_nextto --approach oracle --seed $SEED --num_train_tasks 0
+    # python $FILE --experiment_id rnt_no_sidepreds --env repeated_nextto --approach nsrt_learning --side_predicate_learner no_learning --seed $SEED --num_train_tasks 50
+    # python $FILE --experiment_id rnt_pred_error --env repeated_nextto --approach nsrt_learning --side_predicate_learner prediction_error_hill_climbing --seed $SEED --num_train_tasks 50
+    # python $FILE --experiment_id rnt_harmlessness --env repeated_nextto --approach nsrt_learning --side_predicate_learner preserve_skeletons_hill_climbing --seed $SEED --num_train_tasks 50
+
+    # # repeated_nextto_painting
+    # python $FILE --experiment_id rnt_painting_oracle --env repeated_nextto_painting --approach oracle --seed $SEED --num_train_tasks 0
+done

--- a/scripts/supercloud/run_sidelining_experiments.sh
+++ b/scripts/supercloud/run_sidelining_experiments.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
 START_SEED=456
-NUM_SEEDS=1000
+NUM_SEEDS=50
 FILE="scripts/supercloud/submit_supercloud_job.py"
 
 for SEED in $(seq $START_SEED $((NUM_SEEDS+START_SEED-1))); do
     # repeated_nextto
-    python $FILE --experiment_id rnt_no_sidepreds --env repeated_nextto --approach nsrt_learning --side_predicate_learner backchaining --seed $SEED --num_train_tasks 50
+    python $FILE --experiment_id rnt_backchain --env repeated_nextto --approach nsrt_learning --side_predicate_learner backchaining --seed $SEED --num_train_tasks 50
+    python $FILE --experiment_id rnt_backchain --env repeated_nextto --approach nsrt_learning --side_predicate_learner intersection --seed $SEED --num_train_tasks 50
 
     # python $FILE --experiment_id rnt_oracle --env repeated_nextto --approach oracle --seed $SEED --num_train_tasks 0
     # python $FILE --experiment_id rnt_no_sidepreds --env repeated_nextto --approach nsrt_learning --side_predicate_learner no_learning --seed $SEED --num_train_tasks 50

--- a/scripts/supercloud/run_sidelining_experiments.sh
+++ b/scripts/supercloud/run_sidelining_experiments.sh
@@ -6,8 +6,8 @@ FILE="scripts/supercloud/submit_supercloud_job.py"
 
 for SEED in $(seq $START_SEED $((NUM_SEEDS+START_SEED-1))); do
     # repeated_nextto
-    python $FILE --experiment_id rnt_backchain --env repeated_nextto --approach nsrt_learning --side_predicate_learner backchaining --seed $SEED --num_train_tasks 50
-    python $FILE --experiment_id rnt_backchain --env repeated_nextto --approach nsrt_learning --side_predicate_learner intersection --seed $SEED --num_train_tasks 50
+    python $FILE --experiment_id side_pred_backchainer --env repeated_nextto --approach nsrt_learning --side_predicate_learner backchaining --seed $SEED --num_train_tasks 50
+    python $FILE --experiment_id side_pred_intersector --env repeated_nextto --approach nsrt_learning --side_predicate_learner intersection --seed $SEED --num_train_tasks 50
 
     # python $FILE --experiment_id rnt_oracle --env repeated_nextto --approach oracle --seed $SEED --num_train_tasks 0
     # python $FILE --experiment_id rnt_no_sidepreds --env repeated_nextto --approach nsrt_learning --side_predicate_learner no_learning --seed $SEED --num_train_tasks 50

--- a/src/nsrt_learning/nsrt_learning_main.py
+++ b/src/nsrt_learning/nsrt_learning_main.py
@@ -12,7 +12,7 @@ from predicators.src.nsrt_learning.segmentation import segment_trajectory
 from predicators.src.nsrt_learning.side_predicate_learning import \
     PredictionErrorHillClimbingSidePredicateLearner, \
     PreserveSkeletonsHillClimbingSidePredicateLearner, SidePredicateLearner, \
-    BackchainingSidePredicateLearner
+    BackchainingSidePredicateLearner, IntersectionSidePredicateLearner
 from predicators.src.nsrt_learning.strips_learning import \
     learn_strips_operators
 from predicators.src.settings import CFG
@@ -91,6 +91,9 @@ def learn_nsrts_from_data(trajectories: List[LowLevelTrajectory],
                     segmented_trajs)
         elif CFG.side_predicate_learner == "backchaining":
             side_pred_learner = BackchainingSidePredicateLearner(
+                pnads, trajectories, train_tasks, predicates, segmented_trajs)
+        elif CFG.side_predicate_learner == "intersection":
+            side_pred_learner = IntersectionSidePredicateLearner(
                 pnads, trajectories, train_tasks, predicates, segmented_trajs)
         else:
             raise ValueError(

--- a/src/nsrt_learning/side_predicate_learning.py
+++ b/src/nsrt_learning/side_predicate_learning.py
@@ -509,9 +509,6 @@ class IntersectionSidePredicateLearner(GeneralToSpecificSidePredicateLearner):
                 param_option_to_spec_and_effects[param_option] = {
                     "option_vars": option_vars,
                     "add": set(),
-                    # TODO: is this the right way to handle delete effects?
-                    # Probably not, because this will never lead to any
-                    # delete effects... Not sure what to do.
                     "delete": set(),
                     "side": side_predicates
                 }
@@ -529,8 +526,6 @@ class IntersectionSidePredicateLearner(GeneralToSpecificSidePredicateLearner):
             new_op_add_effects = set()
             new_op_delete_effects = set()
             new_op_side_preds: Set[Predicate] = set()
-            curr_ground_add_effects = set()
-            curr_ground_delete_effects = set()
             for i, (segment, var_to_obj) in enumerate(pnad.datastore):
                 objects = set(var_to_obj.values())
                 obj_to_var = {o: v for v, o in var_to_obj.items()}
@@ -615,11 +610,6 @@ class IntersectionSidePredicateLearner(GeneralToSpecificSidePredicateLearner):
 
                     new_op_add_effects &= lifted_seg_add_effects
                     new_op_delete_effects &= lifted_seg_delete_effects
-
-                # Update the grounded add and delete effects after having updated the
-                # lifted ones.
-                # curr_ground_add_effects = {a.ground(var_to_obj) for a in new_op_add_effects}
-                # curr_ground_delete_effects = {a.ground(var_to_obj) for a in new_op_delete_effects}
 
             
             # Replace the operator with one that contains the newly learned

--- a/src/nsrt_learning/side_predicate_learning.py
+++ b/src/nsrt_learning/side_predicate_learning.py
@@ -457,3 +457,17 @@ class BackchainingSidePredicateLearner(SidePredicateLearner):
                 pnad.op.delete_effects,
                 new_side_predicates)
         return pnads
+
+
+class IntersectionSidePredicateLearner(SidePredicateLearner):
+    """Sideline by simply (1) clustering all transitions by option and then
+    (2) taking the intersection over preconditions and effects."""
+    
+    def _sideline(self) -> List[PartialNSRTAndDatastore]:
+        # Step 0. Remove all non-goal atoms from the 
+        # final state in every trajectory. This will be leveraged during
+        # Step 2.
+        # Step 1. Cluster all transitions by option
+        # Step 2. Learn effects
+        # Step 3. Learn preconditions
+        pass

--- a/src/nsrt_learning/side_predicate_learning.py
+++ b/src/nsrt_learning/side_predicate_learning.py
@@ -529,6 +529,8 @@ class IntersectionSidePredicateLearner(GeneralToSpecificSidePredicateLearner):
             new_op_add_effects = set()
             new_op_delete_effects = set()
             new_op_side_preds: Set[Predicate] = set()
+            curr_ground_add_effects = set()
+            curr_ground_delete_effects = set()
             for i, (segment, var_to_obj) in enumerate(pnad.datastore):
                 objects = set(var_to_obj.values())
                 obj_to_var = {o: v for v, o in var_to_obj.items()}
@@ -540,7 +542,7 @@ class IntersectionSidePredicateLearner(GeneralToSpecificSidePredicateLearner):
                 lifted_init_atoms = {atom.lift(obj_to_var) for atom in init_atoms}
                 
                 # Code to lift up add effects 
-                curr_ground_add_effects = {a.ground(var_to_obj) for a in new_op_add_effects}
+                # curr_ground_add_effects = {a.ground(var_to_obj) for a in new_op_add_effects}
                 if len(segment.add_effects) > 0:
                     missing_add_effects = segment.add_effects - curr_ground_add_effects
                     all_objects = {o for a in missing_add_effects
@@ -569,7 +571,7 @@ class IntersectionSidePredicateLearner(GeneralToSpecificSidePredicateLearner):
                 # Code to lift up delete effects
                 # TODO: This is the same as the add_effects code above
                 # write a function or otherwise simplify to avoid code duplication!
-                curr_ground_delete_effects = {a.ground(var_to_obj) for a in new_op_delete_effects}
+                # curr_ground_delete_effects = {a.ground(var_to_obj) for a in new_op_delete_effects}
                 if len(segment.delete_effects) > 0:
                     missing_delete_effects = segment.delete_effects - curr_ground_delete_effects
                     all_objects = {o for a in missing_delete_effects
@@ -610,8 +612,15 @@ class IntersectionSidePredicateLearner(GeneralToSpecificSidePredicateLearner):
                     eff_diff = add_eff_diff.union(del_eff_diff)
                     for eff in eff_diff:
                         new_op_side_preds.add(eff.predicate)
+
                     new_op_add_effects &= lifted_seg_add_effects
                     new_op_delete_effects &= lifted_seg_delete_effects
+
+                # Update the grounded add and delete effects after having updated the
+                # lifted ones.
+                curr_ground_add_effects = {a.ground(var_to_obj) for a in new_op_add_effects}
+                curr_ground_delete_effects = {a.ground(var_to_obj) for a in new_op_delete_effects}
+
             
             # Replace the operator with one that contains the newly learned
             # preconditions, add effects and delete effects. 

--- a/src/nsrt_learning/side_predicate_learning.py
+++ b/src/nsrt_learning/side_predicate_learning.py
@@ -542,9 +542,9 @@ class IntersectionSidePredicateLearner(GeneralToSpecificSidePredicateLearner):
                 lifted_init_atoms = {atom.lift(obj_to_var) for atom in init_atoms}
                 
                 # Code to lift up add effects 
-                # curr_ground_add_effects = {a.ground(var_to_obj) for a in new_op_add_effects}
                 if len(segment.add_effects) > 0:
-                    missing_add_effects = segment.add_effects - curr_ground_add_effects
+                    # missing_add_effects = segment.add_effects - curr_ground_add_effects
+                    missing_add_effects = segment.add_effects
                     all_objects = {o for a in missing_add_effects
                                 for o in a.objects}
                     unbound_objects = all_objects - set(obj_to_var)
@@ -571,9 +571,9 @@ class IntersectionSidePredicateLearner(GeneralToSpecificSidePredicateLearner):
                 # Code to lift up delete effects
                 # TODO: This is the same as the add_effects code above
                 # write a function or otherwise simplify to avoid code duplication!
-                # curr_ground_delete_effects = {a.ground(var_to_obj) for a in new_op_delete_effects}
                 if len(segment.delete_effects) > 0:
-                    missing_delete_effects = segment.delete_effects - curr_ground_delete_effects
+                    # missing_delete_effects = segment.delete_effects - curr_ground_delete_effects
+                    missing_delete_effects = segment.delete_effects
                     all_objects = {o for a in missing_delete_effects
                                 for o in a.objects}
                     unbound_objects = all_objects - set(obj_to_var)
@@ -618,8 +618,8 @@ class IntersectionSidePredicateLearner(GeneralToSpecificSidePredicateLearner):
 
                 # Update the grounded add and delete effects after having updated the
                 # lifted ones.
-                curr_ground_add_effects = {a.ground(var_to_obj) for a in new_op_add_effects}
-                curr_ground_delete_effects = {a.ground(var_to_obj) for a in new_op_delete_effects}
+                # curr_ground_add_effects = {a.ground(var_to_obj) for a in new_op_add_effects}
+                # curr_ground_delete_effects = {a.ground(var_to_obj) for a in new_op_delete_effects}
 
             
             # Replace the operator with one that contains the newly learned


### PR DESCRIPTION
Does sidelining by simply (1) clustering all transitions by option and then (2) inducing add and delete effects as well as preconditions via intersection over states (things not in the intersection are sidelined).

Code quality is poor (rewrite necessary) but fundamental idea seems to work on rnt env! Changes build from #604 