### PR TITLE
disallow using state allclose when simulator_state is defined

### DIFF
--- a/src/structs.py
+++ b/src/structs.py
@@ -166,6 +166,10 @@ class State:
     def allclose(self, other: State) -> bool:
         """Return whether this state is close enough to another one, i.e., its
         objects are the same, and the features are close."""
+        if self.simulator_state is not None or \
+           other.simulator_state is not None:
+            raise NotImplementedError("Cannot use allclose when "
+                                      "simulator_state is not None.")
         if not sorted(self.data) == sorted(other.data):
             return False
         for obj in self.data:

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -124,6 +124,11 @@ def test_state():
     state4 = State({obj3: np.array([1, 2])}, simulator_state="dummy")
     assert state4.simulator_state == "dummy"
     assert state4.copy().simulator_state == "dummy"
+    # Cannot use allclose with non-None simulator states.
+    with pytest.raises(NotImplementedError):
+        state4.allclose(state3)
+    with pytest.raises(NotImplementedError):
+        state3.allclose(state4)
     # Test state vec with no objects
     vec = state.vec([])
     assert vec.shape == (0, )


### PR DESCRIPTION
@NishanthJKumar @wmcclinton FYI this will break behavior. to repair, we'll need to create a subclass of `State` for behavior that overrides `allclose`. I can do this when the time comes.