### PR TITLE
remove malformed PNAD method

### DIFF
--- a/src/structs.py
+++ b/src/structs.py
@@ -1128,13 +1128,6 @@ class PartialNSRTAndDatastore:
     option_spec: OptionSpec
     # The sampler for this NSRT.
     sampler: Optional[NSRTSampler] = field(init=False, default=None)
-    # A private map from segments in the datastore to associated substitutions.
-    _segment_to_sub: Dict[Segment, VarToObjSub] = field(init=False)
-
-    def __post_init__(self) -> None:
-        self._segment_to_sub = {}
-        for seg, var_obj_sub in self.datastore:
-            self._segment_to_sub[seg] = var_obj_sub
 
     def add_to_datastore(self,
                          member: Tuple[Segment, VarToObjSub],
@@ -1166,18 +1159,12 @@ class PartialNSRTAndDatastore:
                 assert option.objects == option_args
         # Add to datastore.
         self.datastore.append(member)
-        self._segment_to_sub[seg] = var_obj_sub
 
     def make_nsrt(self) -> NSRT:
         """Make an NSRT from this PNAD."""
         assert self.sampler is not None
         param_option, option_vars = self.option_spec
         return self.op.make_nsrt(param_option, option_vars, self.sampler)
-
-    def get_sub_for_member_segment(self, segment: Segment) -> VarToObjSub:
-        """Return the VarToObjSub associated with the segment in the datastore,
-        or raise a KeyError if this segment is not in the datastore."""
-        return self._segment_to_sub[segment]
 
     def __repr__(self) -> str:
         param_option, option_vars = self.option_spec

--- a/src/utils.py
+++ b/src/utils.py
@@ -690,10 +690,10 @@ def find_substitution(
     sub_atoms: Collection[LiftedOrGroundAtom],
     allow_redundant: bool = False,
 ) -> Tuple[bool, EntToEntSub]:
-    """Find a substitution from the entities in super_atoms to the variables in
+    """Find a substitution from the entities in super_atoms to the entities in
     sub_atoms s.t. sub_atoms is a subset of super_atoms.
 
-    If allow_redundant is True, then multiple variables in sub_atoms can
+    If allow_redundant is True, then multiple entities in sub_atoms can
     refer to the same single entity in super_atoms.
 
     If no substitution exists, return (False, {}).

--- a/src/utils.py
+++ b/src/utils.py
@@ -690,11 +690,11 @@ def find_substitution(
     sub_atoms: Collection[LiftedOrGroundAtom],
     allow_redundant: bool = False,
 ) -> Tuple[bool, EntToEntSub]:
-    """Find a substitution from the objects in super_atoms to the variables in
+    """Find a substitution from the entities in super_atoms to the variables in
     sub_atoms s.t. sub_atoms is a subset of super_atoms.
 
     If allow_redundant is True, then multiple variables in sub_atoms can
-    refer to the same single object in super_atoms.
+    refer to the same single entity in super_atoms.
 
     If no substitution exists, return (False, {}).
     """

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -818,12 +818,6 @@ def test_pnad():
         pnad.add_to_datastore((segment3, var_to_obj2))
     pnad.add_to_datastore((segment3, var_to_obj2), check_effect_equality=False)
     assert len(pnad.datastore) == 3
-    assert pnad.get_sub_for_member_segment(segment1) is var_to_obj
-    assert pnad.get_sub_for_member_segment(segment2) is var_to_obj
-    assert pnad.get_sub_for_member_segment(segment3) is var_to_obj2
-    segment4 = Segment(traj, init_atoms, set(), option)
-    with pytest.raises(KeyError):  # segment4 not in datastore
-        pnad.get_sub_for_member_segment(segment4)
     assert repr(pnad) == str(pnad) == """STRIPS-Pick:
     Parameters: [?cup:cup_type, ?plate:plate_type]
     Preconditions: [On(?cup:cup_type, ?plate:plate_type)]


### PR DESCRIPTION
this should be merged right after the forthcoming refactor of sidelining by backchaining, which will remove the call to `get_sub_for_member_segment`.

also update random docstring to appease @ronuchit 