### PR TITLE
make planner raise its own Exceptions instead of using approaches'

### DIFF
--- a/scripts/skeleton_score_analysis.py
+++ b/scripts/skeleton_score_analysis.py
@@ -16,13 +16,13 @@ import numpy as np
 from numpy.typing import NDArray
 
 from predicators.src import utils
-from predicators.src.approaches import ApproachFailure, ApproachTimeout
 from predicators.src.datasets import create_dataset
 from predicators.src.envs import create_new_env
 from predicators.src.nsrt_learning.segmentation import segment_trajectory
 from predicators.src.nsrt_learning.strips_learning import \
     learn_strips_operators
-from predicators.src.planning import task_plan, task_plan_grounding
+from predicators.src.planning import PlanningFailure, PlanningTimeout, \
+    task_plan, task_plan_grounding
 from predicators.src.settings import CFG
 from predicators.src.structs import Dataset, Predicate, Task
 
@@ -174,7 +174,7 @@ def _skeleton_based_score_function(
                 result = skeleton_score_fn(plan_skeleton, plan_atoms_sequence,
                                            metrics, idx, demo_len)
                 task_results.append(result)
-        except (ApproachTimeout, ApproachFailure):
+        except (PlanningTimeout, PlanningFailure):
             # Use an upper bound on the error.
             for idx in range(len(task_results), max_skeletons):
                 task_results.append(get_default_result(idx))

--- a/src/predicate_search_score_functions.py
+++ b/src/predicate_search_score_functions.py
@@ -13,11 +13,11 @@ from typing import Callable, Collection, Dict, FrozenSet, List, Sequence, \
 import numpy as np
 
 from predicators.src import utils
-from predicators.src.approaches import ApproachFailure, ApproachTimeout
 from predicators.src.nsrt_learning.segmentation import segment_trajectory
 from predicators.src.nsrt_learning.strips_learning import \
     learn_strips_operators
-from predicators.src.planning import task_plan, task_plan_grounding
+from predicators.src.planning import PlanningFailure, PlanningTimeout, \
+    task_plan, task_plan_grounding
 from predicators.src.settings import CFG
 from predicators.src.structs import GroundAtom, GroundAtomTrajectory, \
     LowLevelTrajectory, Object, OptionSpec, Predicate, Segment, \
@@ -261,7 +261,7 @@ class _TaskPlanningScoreFunction(_OperatorLearningBasedScoreFunction):
                 node_expansions = metrics["num_nodes_expanded"]
                 assert node_expansions < node_expansion_upper_bound
                 score += node_expansions
-            except (ApproachFailure, ApproachTimeout):
+            except (PlanningFailure, PlanningTimeout):
                 score += node_expansion_upper_bound
         return score
 
@@ -355,7 +355,7 @@ class _ExpectedNodesScoreFunction(_OperatorLearningBasedScoreFunction):
                         expected_planning_time += p * w
                     # Update the probability that no skeleton yet is refinable.
                     refinable_skeleton_not_found_prob *= (1 - refinement_prob)
-            except (ApproachTimeout, ApproachFailure):
+            except (PlanningTimeout, PlanningFailure):
                 # Note if we failed to find any skeleton, the next lines add
                 # the upper bound with refinable_skeleton_not_found_prob = 1.0,
                 # so no special action is required.
@@ -703,7 +703,7 @@ class _ExactHeuristicBasedScoreFunction(_HeuristicBasedScoreFunction):
                               CFG.seed,
                               CFG.grammar_search_task_planning_timeout,
                               max_skeletons_optimized=1))
-            except (ApproachFailure, ApproachTimeout):
+            except (PlanningFailure, PlanningTimeout):
                 return float("inf")
             assert atoms_sequence[0] == atoms
             for i, actual_atoms in enumerate(atoms_sequence):


### PR DESCRIPTION
avoids some circular import issues that were arising when running standalone test files

this was surprisingly not as painful as i thought it would be. i tested a couple of things, but we need to rerun our nightly. cc @tomsilver 