### PR TITLE
add box only or shelf only setting for painting

### DIFF
--- a/src/envs/painting.py
+++ b/src/envs/painting.py
@@ -504,13 +504,22 @@ class PaintingEnv(BaseEnv):
                 max_objs_in_goal = (CFG.rnt_painting_max_objs_in_goal
                                     if CFG.env == "repeated_nextto_painting"
                                     else CFG.painting_max_objs_in_goal)
-                if j == num_objs - 1:
-                    # Last object must go in the box
-                    goal.add(GroundAtom(self._InBox, [obj, self._box]))
-                    goal.add(GroundAtom(self._IsBoxColor, [obj, self._box]))
-                elif j < max_objs_in_goal - 1:
+                assert CFG.painting_goal_receptacles in ("box_and_shelf",
+                                                         "box", "shelf")
+                if CFG.painting_goal_receptacles == "shelf":
+                    # No box; all max_objs_in_goal objects must go in the shelf
+                    shelf_j_upper = max_objs_in_goal
+                else:
                     # The last object is destined for the box, so the remaining
                     # (max_objs_in_goal - 1) objects must go in the shelf
+                    shelf_j_upper = max_objs_in_goal - 1
+                if CFG.painting_goal_receptacles in (
+                        "box_and_shelf", "box") and j == num_objs - 1:
+                    # If we're using the box, the last object must go in it
+                    goal.add(GroundAtom(self._InBox, [obj, self._box]))
+                    goal.add(GroundAtom(self._IsBoxColor, [obj, self._box]))
+                elif CFG.painting_goal_receptacles in (
+                        "box_and_shelf", "shelf") and j < shelf_j_upper:
                     goal.add(GroundAtom(self._InShelf, [obj, self._shelf]))
                     goal.add(GroundAtom(self._IsShelfColor,
                                         [obj, self._shelf]))

--- a/src/settings.py
+++ b/src/settings.py
@@ -75,6 +75,7 @@ class GlobalSettings:
     painting_num_objs_train = [2, 3]
     painting_num_objs_test = [3, 4]
     painting_max_objs_in_goal = float("inf")
+    painting_goal_receptacles = "box_and_shelf"  # box_and_shelf, box, shelf
 
     # repeated_nextto_painting (rnt_painting) env parameters
     rnt_painting_num_objs_train = [8, 9, 10]

--- a/tests/envs/test_painting.py
+++ b/tests/envs/test_painting.py
@@ -60,6 +60,32 @@ def test_painting():
             env.render_state(state, task, caption="caption")
 
 
+def test_painting_goals():
+    """Tests for various settings of CFG.painting_goal_receptacles and
+    CFG.painting_max_objs_in_goal."""
+    for max_objs_in_goal, goal_receptacles, expected_num_goal_atoms in [
+        (float("inf"), "box_and_shelf", 10),
+            # When "painting_goal_receptacles" is "box", the goal is always to
+            # paint a single object and put it into the box, since only one
+            # object can fit inside the box. So len(goal) == 2.
+        (float("inf"), "box", 2),
+        (float("inf"), "shelf", 10),
+        (3, "box_and_shelf", 6),
+        (3, "box", 2),
+        (3, "shelf", 6),
+    ]:
+        utils.reset_config({
+            "env": "painting",
+            "num_test_tasks": 5,
+            "painting_num_objs_test": [5],
+            "painting_max_objs_in_goal": max_objs_in_goal,
+            "painting_goal_receptacles": goal_receptacles,
+        })
+        env = PaintingEnv()
+        for task in env.get_test_tasks():
+            assert len(task.goal) == expected_num_goal_atoms
+
+
 def test_painting_failure_cases():
     """Tests for the cases where simulate() is a no-op or
     EnvironmentFailure."""


### PR DESCRIPTION
* no functional change to default code path (verified)
* checked that with box only or shelf only goals, nsrt_learning produces
1:1 operators/options that don't have any HoldingSide/HoldingTop
anywhere respectively, *as long as you also set
painting_initial_holding_prob to 0.0*