### PR TITLE
make rnt goals slightly harder

### DIFF
--- a/src/envs/repeated_nextto.py
+++ b/src/envs/repeated_nextto.py
@@ -147,10 +147,14 @@ class RepeatedNextToEnv(BaseEnv):
         for i in range(CFG.repeated_nextto_num_dots):
             dots.append(Object(f"dot{i}", self._dot_type))
         goal1 = {GroundAtom(self._Grasped, [self._robot, dots[0]])}
-        goal2 = {GroundAtom(self._Grasped, [self._robot, dots[1]])}
+        goal2 = {
+            GroundAtom(self._Grasped, [self._robot, dots[0]]),
+            GroundAtom(self._Grasped, [self._robot, dots[1]]),
+        }
         goal3 = {
             GroundAtom(self._Grasped, [self._robot, dots[0]]),
-            GroundAtom(self._Grasped, [self._robot, dots[1]])
+            GroundAtom(self._Grasped, [self._robot, dots[1]]),
+            GroundAtom(self._Grasped, [self._robot, dots[2]]),
         }
         goals = [goal1, goal2, goal3]
         for i in range(num):


### PR DESCRIPTION
@NishanthJKumar: this will change all the seeding, so let's only merge it after you're pretty confident your implementation is working on the current RNT, just to test a harder set of goals.

Supercloud results:
```
              NUM_TRAIN_TASKS    NUM_SOLVED AVG_NUM_PREDS AVG_TEST_TIME AVG_NODES_CREATED LEARNING_TIME  NUM_SEEDS
EXPERIMENT_ID
rnt_backchain    50.00 (0.00)  50.00 (0.00)   3.00 (0.00)   0.05 (0.01)      87.35 (3.21)  11.45 (0.88)         50
rnt_oracle        0.00 (0.00)  50.00 (0.00)   3.00 (0.00)   0.01 (0.00)      87.35 (3.21)   0.00 (0.00)         50
```