### PR TITLE
allow skipping until a learning cycle

### DIFF
--- a/src/args.py
+++ b/src/args.py
@@ -23,6 +23,7 @@ def create_arg_parser(env_required: bool = True,
     parser.add_argument("--make_interaction_videos", action="store_true")
     parser.add_argument("--load_approach", action="store_true")
     parser.add_argument("--load_data", action="store_true")
+    parser.add_argument("--skip_until_cycle", default=-1, type=int)
     parser.add_argument("--experiment_id", default="", type=str)
     parser.add_argument('--debug',
                         action="store_const",

--- a/src/main.py
+++ b/src/main.py
@@ -126,14 +126,17 @@ def _run_pipeline(env: BaseEnv,
             approach.learn_from_offline_dataset(offline_dataset)
             learning_time = time.time() - learning_start
         # Run evaluation once before online learning starts.
-        results = _run_testing(env, approach)
-        results["num_transitions"] = total_num_transitions
-        results["query_cost"] = total_query_cost
-        results["learning_time"] = learning_time
-        _save_test_results(results, online_learning_cycle=None)
+        if CFG.skip_until_cycle < 0:
+            results = _run_testing(env, approach)
+            results["num_transitions"] = total_num_transitions
+            results["query_cost"] = total_query_cost
+            results["learning_time"] = learning_time
+            _save_test_results(results, online_learning_cycle=None)
         teacher = Teacher(train_tasks)
         # The online learning loop.
         for i in range(CFG.num_online_learning_cycles):
+            if i < CFG.skip_until_cycle:
+                continue
             logging.info(f"\n\nONLINE LEARNING CYCLE {i}\n")
             logging.info("Getting interaction requests...")
             if total_num_transitions > CFG.online_learning_max_transitions:

--- a/tests/test_online_learning.py
+++ b/tests/test_online_learning.py
@@ -115,3 +115,23 @@ def test_interaction():
         "load_approach": True
     })
     _run_pipeline(env, approach, train_tasks, dataset)
+    # Should crash with a load failure.
+    utils.update_config({"num_online_learning_cycles": 10})
+    with pytest.raises(IndexError):
+        _run_pipeline(env, approach, train_tasks, dataset)
+    # Should succeed because all cycles are skipped. Note that we must
+    # reset_config instead of update_config because of known issues with
+    # update_config and default args.
+    utils.reset_config({
+        "num_online_learning_cycles": 10,
+        "skip_until_cycle": 11,
+        "env": "cover",
+        "cover_initial_holding_prob": 0.0,
+        "approach": "unittest",
+        "timeout": 1,
+        "num_train_tasks": 2,
+        "num_test_tasks": 1,
+        "make_interaction_videos": True,
+        "max_num_steps_interaction_request": 3,
+    })
+    _run_pipeline(env, approach, train_tasks, dataset)


### PR DESCRIPTION
intended usage: when loading saved models from an online learning approach, it is often useful to skip to a later cycle and inspect things there, e.g., the data, the evaluation failures.

closes #654 