### PR TITLE
updates to ground truth nsrts for rnt painting

### DIFF
--- a/src/envs/painting.py
+++ b/src/envs/painting.py
@@ -279,8 +279,7 @@ class PaintingEnv(BaseEnv):
         if receptacle == "table" and \
            collider is not None and \
            collider != held_obj:
-            raise utils.EnvironmentFailure("Collision during place on table.",
-                                           {"offending_objects": {collider}})
+            return next_state
         # Execute place
         next_state.set(self._robot, "fingers", 1.0)
         next_state.set(held_obj, "pose_x", x)

--- a/src/envs/repeated_nextto_painting.py
+++ b/src/envs/repeated_nextto_painting.py
@@ -33,8 +33,6 @@ class RepeatedNextToPaintingEnv(PaintingEnv):
                                       self._NextTo_holds)
         self._NextToTable = Predicate("NextToTable", [self._robot_type],
                                       self._NextToTable_holds)
-        self._NextToNothing = Predicate("NextToNothing", [self._robot_type],
-                                        self._NextToNothing_holds)
         # Additional Options
         self._MoveToObj = utils.SingletonParameterizedOption(
             "MoveToObj",
@@ -108,8 +106,7 @@ class RepeatedNextToPaintingEnv(PaintingEnv):
     @property
     def predicates(self) -> Set[Predicate]:
         return super().predicates | {
-            self._NextTo, self._NextToBox, self._NextToShelf,
-            self._NextToTable, self._NextToNothing
+            self._NextTo, self._NextToBox, self._NextToShelf, self._NextToTable
         }
 
     @property
@@ -165,11 +162,3 @@ class RepeatedNextToPaintingEnv(PaintingEnv):
                            objects: Sequence[Object]) -> bool:
         robot, = objects
         return self.table_lb < state.get(robot, "pose_y") < self.table_ub
-
-    def _NextToNothing_holds(self, state: State,
-                             objects: Sequence[Object]) -> bool:
-        robot, = objects
-        types_to_check = {self._obj_type, self._box_type, self._shelf_type}
-        return not any(
-            self._NextTo_holds(state, [robot, obj])
-            for obj in state if obj.type in types_to_check)

--- a/src/envs/repeated_nextto_painting.py
+++ b/src/envs/repeated_nextto_painting.py
@@ -31,8 +31,7 @@ class RepeatedNextToPaintingEnv(PaintingEnv):
         self._NextToShelf = Predicate("NextToShelf",
                                       [self._robot_type, self._shelf_type],
                                       self._NextTo_holds)
-        self._NextToTable = Predicate("NextToTable",
-                                      [self._robot_type],
+        self._NextToTable = Predicate("NextToTable", [self._robot_type],
                                       self._NextToTable_holds)
         self._NextToNothing = Predicate("NextToNothing", [self._robot_type],
                                         self._NextToNothing_holds)
@@ -109,8 +108,8 @@ class RepeatedNextToPaintingEnv(PaintingEnv):
     @property
     def predicates(self) -> Set[Predicate]:
         return super().predicates | {
-            self._NextTo, self._NextToBox, self._NextToShelf, self._NextToTable,
-            self._NextToNothing
+            self._NextTo, self._NextToBox, self._NextToShelf,
+            self._NextToTable, self._NextToNothing
         }
 
     @property
@@ -162,7 +161,8 @@ class RepeatedNextToPaintingEnv(PaintingEnv):
         return abs(state.get(robot, "pose_y") -
                    state.get(obj, "pose_y")) < self.nextto_thresh
 
-    def _NextToTable_holds(self, state: State, objects: Sequence[Object]) -> bool:
+    def _NextToTable_holds(self, state: State,
+                           objects: Sequence[Object]) -> bool:
         robot, = objects
         return self.table_lb < state.get(robot, "pose_y") < self.table_ub
 

--- a/src/envs/repeated_nextto_painting.py
+++ b/src/envs/repeated_nextto_painting.py
@@ -31,6 +31,9 @@ class RepeatedNextToPaintingEnv(PaintingEnv):
         self._NextToShelf = Predicate("NextToShelf",
                                       [self._robot_type, self._shelf_type],
                                       self._NextTo_holds)
+        self._NextToTable = Predicate("NextToTable",
+                                      [self._robot_type],
+                                      self._NextToTable_holds)
         self._NextToNothing = Predicate("NextToNothing", [self._robot_type],
                                         self._NextToNothing_holds)
         # Additional Options
@@ -106,7 +109,7 @@ class RepeatedNextToPaintingEnv(PaintingEnv):
     @property
     def predicates(self) -> Set[Predicate]:
         return super().predicates | {
-            self._NextTo, self._NextToBox, self._NextToShelf,
+            self._NextTo, self._NextToBox, self._NextToShelf, self._NextToTable,
             self._NextToNothing
         }
 
@@ -158,6 +161,10 @@ class RepeatedNextToPaintingEnv(PaintingEnv):
         robot, obj = objects
         return abs(state.get(robot, "pose_y") -
                    state.get(obj, "pose_y")) < self.nextto_thresh
+
+    def _NextToTable_holds(self, state: State, objects: Sequence[Object]) -> bool:
+        robot, = objects
+        return self.table_lb < state.get(robot, "pose_y") < self.table_ub
 
     def _NextToNothing_holds(self, state: State,
                              objects: Sequence[Object]) -> bool:

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -638,10 +638,9 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         CFG.env, ["Pick", "Wash", "Dry", "Paint", "Place", "OpenLid"])
 
     if CFG.env == "repeated_nextto_painting":
-        (NextTo, NextToBox, NextToShelf, NextToTable, NextToNothing) = \
+        (NextTo, NextToBox, NextToShelf, NextToTable) = \
          _get_predicates_by_names(
-             CFG.env, ["NextTo", "NextToBox", "NextToShelf", "NextToTable",
-                       "NextToNothing"])
+             CFG.env, ["NextTo", "NextToBox", "NextToShelf", "NextToTable"])
         MoveToObj, MoveToBox, MoveToShelf = _get_options_by_names(
             CFG.env, ["MoveToObj", "MoveToBox", "MoveToShelf"])
 
@@ -729,7 +728,6 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
     preconditions = {
         LiftedAtom(Holding, [obj]),
         LiftedAtom(IsWet, [obj]),
-        LiftedAtom(IsClean, [obj])
     }
     if CFG.env == "repeated_nextto_painting":
         preconditions.add(LiftedAtom(NextTo, [robot, obj]))
@@ -990,9 +988,8 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
             LiftedAtom(NextToTable, [robot])
         }
         delete_effects = set()
-        # Moving could have us end up NextTo other objects. It could also
-        # include NextToNothing as a delete effect.
-        side_predicates = {NextTo, NextToBox, NextToShelf, NextToNothing}
+        # Moving could have us end up NextTo other objects.
+        side_predicates = {NextTo, NextToBox, NextToShelf}
 
         movetoobj_nsrt = NSRT("MoveToObj", parameters, preconditions,
                               add_effects, delete_effects, side_predicates,
@@ -1018,9 +1015,8 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
             LiftedAtom(NextToTable, [robot]),
             LiftedAtom(OnTable, [obj])
         }
-        # Moving could have us end up NextTo other objects. It could also
-        # include NextToNothing as a delete effect.
-        side_predicates = {NextTo, NextToBox, NextToShelf, NextToNothing}
+        # Moving could have us end up NextTo other objects.
+        side_predicates = {NextTo, NextToBox, NextToShelf}
         movetobox_nsrt = NSRT("MoveToBox", parameters, preconditions,
                               add_effects, delete_effects, side_predicates,
                               option, option_vars, moveto_sampler)
@@ -1045,9 +1041,8 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
             LiftedAtom(NextToTable, [robot]),
             LiftedAtom(OnTable, [obj])
         }
-        # Moving could have us end up NextTo other objects. It could also
-        # include NextToNothing as a delete effect.
-        side_predicates = {NextTo, NextToBox, NextToShelf, NextToNothing}
+        # Moving could have us end up NextTo other objects.
+        side_predicates = {NextTo, NextToBox, NextToShelf}
         movetoshelf_nsrt = NSRT("MoveToShelf", parameters, preconditions,
                                 add_effects, delete_effects, side_predicates,
                                 option, option_vars, moveto_sampler)

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -640,7 +640,8 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
     if CFG.env == "repeated_nextto_painting":
         (NextTo, NextToBox, NextToShelf, NextToTable, NextToNothing) = \
          _get_predicates_by_names(
-             CFG.env, ["NextTo", "NextToBox", "NextToShelf", "NextToTable", "NextToNothing"])
+             CFG.env, ["NextTo", "NextToBox", "NextToShelf", "NextToTable",
+                       "NextToNothing"])
         MoveToObj, MoveToBox, MoveToShelf = _get_options_by_names(
             CFG.env, ["MoveToObj", "MoveToBox", "MoveToShelf"])
 
@@ -669,8 +670,8 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         return np.array([1.0], dtype=np.float32)
 
     pickfromtop_nsrt = NSRT("PickFromTop", parameters, preconditions,
-                            add_effects, delete_effects, set(),
-                            option, option_vars, pickfromtop_sampler)
+                            add_effects, delete_effects, set(), option,
+                            option_vars, pickfromtop_sampler)
     nsrts.add(pickfromtop_nsrt)
 
     # PickFromSide
@@ -695,8 +696,8 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         return np.array([0.0], dtype=np.float32)
 
     pickfromside_nsrt = NSRT("PickFromSide", parameters, preconditions,
-                             add_effects, delete_effects, set(),
-                             option, option_vars, pickfromside_sampler)
+                             add_effects, delete_effects, set(), option,
+                             option_vars, pickfromside_sampler)
     nsrts.add(pickfromside_nsrt)
 
     # Wash
@@ -725,8 +726,11 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
     parameters = [obj, robot]
     option_vars = [robot]
     option = Dry
-    preconditions = {LiftedAtom(Holding, [obj]), LiftedAtom(IsWet, [obj]),
-                     LiftedAtom(IsClean, [obj])}
+    preconditions = {
+        LiftedAtom(Holding, [obj]),
+        LiftedAtom(IsWet, [obj]),
+        LiftedAtom(IsClean, [obj])
+    }
     if CFG.env == "repeated_nextto_painting":
         preconditions.add(LiftedAtom(NextTo, [robot, obj]))
     add_effects = {LiftedAtom(IsDry, [obj])}
@@ -761,8 +765,8 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         return np.array([box_color], dtype=np.float32)
 
     painttobox_nsrt = NSRT("PaintToBox", parameters, preconditions,
-                           add_effects, delete_effects, set(),
-                           option, option_vars, painttobox_sampler)
+                           add_effects, delete_effects, set(), option,
+                           option_vars, painttobox_sampler)
     nsrts.add(painttobox_nsrt)
 
     # PaintToShelf
@@ -790,8 +794,8 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         return np.array([shelf_color], dtype=np.float32)
 
     painttoshelf_nsrt = NSRT("PaintToShelf", parameters, preconditions,
-                             add_effects, delete_effects, set(),
-                             option, option_vars, painttoshelf_sampler)
+                             add_effects, delete_effects, set(), option,
+                             option_vars, painttoshelf_sampler)
     nsrts.add(painttoshelf_nsrt)
 
     # PlaceInBox
@@ -838,8 +842,8 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         return np.array([x, y, z], dtype=np.float32)
 
     placeinbox_nsrt = NSRT("PlaceInBox", parameters, preconditions,
-                           add_effects, delete_effects, set(),
-                           option, option_vars, placeinbox_sampler)
+                           add_effects, delete_effects, set(), option,
+                           option_vars, placeinbox_sampler)
     nsrts.add(placeinbox_nsrt)
 
     # PlaceInShelf
@@ -885,8 +889,8 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         return np.array([x, y, z], dtype=np.float32)
 
     placeinshelf_nsrt = NSRT("PlaceInShelf", parameters, preconditions,
-                             add_effects, delete_effects, set(),
-                             option, option_vars, placeinshelf_sampler)
+                             add_effects, delete_effects, set(), option,
+                             option_vars, placeinshelf_sampler)
     nsrts.add(placeinshelf_nsrt)
 
     # OpenLid
@@ -934,8 +938,6 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         LiftedAtom(HoldingSide, [obj]),
     }
 
-    # TODO: spurious Place operator
-
     def placeontable_sampler(state: State, goal: Set[GroundAtom],
                              rng: np.random.Generator,
                              objs: Sequence[Object]) -> Array:
@@ -950,16 +952,18 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
             # Release the object at a randomly-chosen position on the table
             # such that it is NextTo the robot.
             robot_y = state.get(objs[1], "pose_y")
-            assert RepeatedNextToPaintingEnv.table_lb < robot_y < RepeatedNextToPaintingEnv.table_ub
-            y_sample_lb = robot_y - RepeatedNextToPaintingEnv.nextto_thresh
-            y_sample_ub = robot_y + RepeatedNextToPaintingEnv.nextto_thresh
+            table_lb = RepeatedNextToPaintingEnv.table_lb
+            table_ub = RepeatedNextToPaintingEnv.table_ub
+            assert table_lb < robot_y < table_ub
+            nextto_thresh = RepeatedNextToPaintingEnv.nextto_thresh
+            y_sample_lb = max(table_lb, robot_y - nextto_thresh)
+            y_sample_ub = min(table_ub, robot_y + nextto_thresh)
             y = rng.uniform(y_sample_lb, y_sample_ub)
             z = RepeatedNextToPaintingEnv.obj_z
         return np.array([x, y, z], dtype=np.float32)
 
-    placeontable_nsrt = NSRT("PlaceOnTable",
-                             parameters, preconditions, add_effects,
-                             delete_effects, set(), option,
+    placeontable_nsrt = NSRT("PlaceOnTable", parameters, preconditions,
+                             add_effects, delete_effects, set(), option,
                              option_vars, placeontable_sampler)
     nsrts.add(placeontable_nsrt)
 
@@ -978,9 +982,14 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         parameters = [robot, targetobj]
         option_vars = [robot, targetobj]
         option = MoveToObj
-        preconditions = set()
-        add_effects = {LiftedAtom(NextTo, [robot, targetobj]),
-                       LiftedAtom(NextToTable, [robot])}
+        preconditions = {
+            LiftedAtom(GripperOpen, [robot]),
+            LiftedAtom(OnTable, [targetobj])
+        }
+        add_effects = {
+            LiftedAtom(NextTo, [robot, targetobj]),
+            LiftedAtom(NextToTable, [robot])
+        }
         delete_effects = set()
         # Moving could have us end up NextTo other objects. It could also
         # include NextToNothing as a delete effect.
@@ -998,14 +1007,22 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         parameters = [robot, targetbox, obj]
         option_vars = [robot, targetbox]
         option = MoveToBox
-        preconditions = {LiftedAtom(NextTo, [robot, obj])}
-        add_effects = {LiftedAtom(NextToBox, [robot, targetbox]),
-                       LiftedAtom(NextTo, [robot, obj])}
-        delete_effects = {LiftedAtom(NextToTable, [robot])}
+        preconditions = {
+            LiftedAtom(NextTo, [robot, obj]),
+            LiftedAtom(Holding, [obj]),
+            LiftedAtom(OnTable, [obj]),
+        }
+        add_effects = {
+            LiftedAtom(NextToBox, [robot, targetbox]),
+            LiftedAtom(NextTo, [robot, obj])
+        }
+        delete_effects = {
+            LiftedAtom(NextToTable, [robot]),
+            LiftedAtom(OnTable, [obj])
+        }
         # Moving could have us end up NextTo other objects. It could also
         # include NextToNothing as a delete effect.
-        side_predicates = {NextTo, NextToBox, NextToShelf, NextToNothing,
-                           OnTable}
+        side_predicates = {NextTo, NextToBox, NextToShelf, NextToNothing}
         movetobox_nsrt = NSRT("MoveToBox", parameters, preconditions,
                               add_effects, delete_effects, side_predicates,
                               option, option_vars, moveto_sampler)
@@ -1018,20 +1035,26 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         parameters = [robot, targetshelf, obj]
         option_vars = [robot, targetshelf]
         option = MoveToShelf
-        preconditions = {LiftedAtom(NextTo, [robot, obj])}
-        add_effects = {LiftedAtom(NextToShelf, [robot, targetshelf]),
-                       LiftedAtom(NextTo, [robot, obj])}
-        delete_effects = {LiftedAtom(NextToTable, [robot])}
+        preconditions = {
+            LiftedAtom(NextTo, [robot, obj]),
+            LiftedAtom(Holding, [obj]),
+            LiftedAtom(OnTable, [obj]),
+        }
+        add_effects = {
+            LiftedAtom(NextToShelf, [robot, targetshelf]),
+            LiftedAtom(NextTo, [robot, obj])
+        }
+        delete_effects = {
+            LiftedAtom(NextToTable, [robot]),
+            LiftedAtom(OnTable, [obj])
+        }
         # Moving could have us end up NextTo other objects. It could also
         # include NextToNothing as a delete effect.
-        side_predicates = {NextTo, NextToBox, NextToShelf, NextToNothing,
-                           OnTable}
+        side_predicates = {NextTo, NextToBox, NextToShelf, NextToNothing}
         movetoshelf_nsrt = NSRT("MoveToShelf", parameters, preconditions,
                                 add_effects, delete_effects, side_predicates,
                                 option, option_vars, moveto_sampler)
         nsrts.add(movetoshelf_nsrt)
-    for nsrt in sorted(nsrts):
-        print(nsrt)
 
     return nsrts
 

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -650,28 +650,15 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
     parameters = [obj, robot]
     option_vars = [robot, obj]
     option = Pick
-    if CFG.env == "painting":
-        preconditions = {
-            LiftedAtom(GripperOpen, [robot]),
-            LiftedAtom(OnTable, [obj])
-        }
-    elif CFG.env == "repeated_nextto_painting":
-        preconditions = {
-            LiftedAtom(GripperOpen, [robot]),
-            LiftedAtom(OnTable, [obj]),
-            LiftedAtom(NextTo, [robot, obj])
-        }
+    preconditions = {
+        LiftedAtom(GripperOpen, [robot]),
+        LiftedAtom(OnTable, [obj])
+    }
+    if CFG.env == "repeated_nextto_painting":
+        preconditions.add(LiftedAtom(NextTo, [robot, obj]))
 
     add_effects = {LiftedAtom(Holding, [obj]), LiftedAtom(HoldingTop, [obj])}
-    if CFG.env == "painting":
-        delete_effects = {LiftedAtom(GripperOpen, [robot])}
-        side_predicates = set()
-    elif CFG.env == "repeated_nextto_painting":
-        delete_effects = {
-            LiftedAtom(GripperOpen, [robot]),
-            LiftedAtom(OnTable, [obj])
-        }
-        side_predicates = {NextToNothing}
+    delete_effects = {LiftedAtom(GripperOpen, [robot])}
 
     def pickfromtop_sampler(state: State, goal: Set[GroundAtom],
                             rng: np.random.Generator,
@@ -680,7 +667,7 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         return np.array([1.0], dtype=np.float32)
 
     pickfromtop_nsrt = NSRT("PickFromTop", parameters, preconditions,
-                            add_effects, delete_effects, side_predicates,
+                            add_effects, delete_effects, set(),
                             option, option_vars, pickfromtop_sampler)
     nsrts.add(pickfromtop_nsrt)
 
@@ -690,27 +677,14 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
     parameters = [obj, robot]
     option_vars = [robot, obj]
     option = Pick
-    if CFG.env == "painting":
-        preconditions = {
-            LiftedAtom(GripperOpen, [robot]),
-            LiftedAtom(OnTable, [obj])
-        }
-    elif CFG.env == "repeated_nextto_painting":
-        preconditions = {
-            LiftedAtom(GripperOpen, [robot]),
-            LiftedAtom(OnTable, [obj]),
-            LiftedAtom(NextTo, [robot, obj])
-        }
+    preconditions = {
+        LiftedAtom(GripperOpen, [robot]),
+        LiftedAtom(OnTable, [obj])
+    }
+    if CFG.env == "repeated_nextto_painting":
+        preconditions.add(LiftedAtom(NextTo, [robot, obj]))
     add_effects = {LiftedAtom(Holding, [obj]), LiftedAtom(HoldingSide, [obj])}
-    if CFG.env == "painting":
-        delete_effects = {LiftedAtom(GripperOpen, [robot])}
-        side_predicates = set()
-    elif CFG.env == "repeated_nextto_painting":
-        delete_effects = {
-            LiftedAtom(GripperOpen, [robot]),
-            LiftedAtom(OnTable, [obj])
-        }
-        side_predicates = {NextToNothing}
+    delete_effects = {LiftedAtom(GripperOpen, [robot])}
 
     def pickfromside_sampler(state: State, goal: Set[GroundAtom],
                              rng: np.random.Generator,
@@ -719,7 +693,7 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         return np.array([0.0], dtype=np.float32)
 
     pickfromside_nsrt = NSRT("PickFromSide", parameters, preconditions,
-                             add_effects, delete_effects, side_predicates,
+                             add_effects, delete_effects, set(),
                              option, option_vars, pickfromside_sampler)
     nsrts.add(pickfromside_nsrt)
 
@@ -734,6 +708,8 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         LiftedAtom(IsDry, [obj]),
         LiftedAtom(IsDirty, [obj])
     }
+    if CFG.env == "repeated_nextto_painting":
+        preconditions.add(LiftedAtom(NextTo, [robot, obj]))
     add_effects = {LiftedAtom(IsWet, [obj]), LiftedAtom(IsClean, [obj])}
     delete_effects = {LiftedAtom(IsDry, [obj]), LiftedAtom(IsDirty, [obj])}
 
@@ -747,7 +723,10 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
     parameters = [obj, robot]
     option_vars = [robot]
     option = Dry
-    preconditions = {LiftedAtom(Holding, [obj]), LiftedAtom(IsWet, [obj])}
+    preconditions = {LiftedAtom(Holding, [obj]), LiftedAtom(IsWet, [obj]),
+                     LiftedAtom(IsClean, [obj])}
+    if CFG.env == "repeated_nextto_painting":
+        preconditions.add(LiftedAtom(NextTo, [robot, obj]))
     add_effects = {LiftedAtom(IsDry, [obj])}
     delete_effects = {LiftedAtom(IsWet, [obj])}
 
@@ -767,12 +746,10 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         LiftedAtom(IsDry, [obj]),
         LiftedAtom(IsClean, [obj])
     }
+    if CFG.env == "repeated_nextto_painting":
+        preconditions.add(LiftedAtom(NextTo, [robot, obj]))
     add_effects = {LiftedAtom(IsBoxColor, [obj, box])}
     delete_effects = set()
-    if CFG.env == "painting":
-        side_predicates = set()
-    elif CFG.env == "repeated_nextto_painting":
-        side_predicates = {NextTo, NextToNothing}
 
     def painttobox_sampler(state: State, goal: Set[GroundAtom],
                            rng: np.random.Generator,
@@ -782,7 +759,7 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         return np.array([box_color], dtype=np.float32)
 
     painttobox_nsrt = NSRT("PaintToBox", parameters, preconditions,
-                           add_effects, delete_effects, side_predicates,
+                           add_effects, delete_effects, set(),
                            option, option_vars, painttobox_sampler)
     nsrts.add(painttobox_nsrt)
 
@@ -798,12 +775,10 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         LiftedAtom(IsDry, [obj]),
         LiftedAtom(IsClean, [obj])
     }
+    if CFG.env == "repeated_nextto_painting":
+        preconditions.add(LiftedAtom(NextTo, [robot, obj]))
     add_effects = {LiftedAtom(IsShelfColor, [obj, shelf])}
     delete_effects = set()
-    if CFG.env == "painting":
-        side_predicates = set()
-    elif CFG.env == "repeated_nextto_painting":
-        side_predicates = {NextTo, NextToNothing}
 
     def painttoshelf_sampler(state: State, goal: Set[GroundAtom],
                              rng: np.random.Generator,
@@ -813,7 +788,7 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         return np.array([shelf_color], dtype=np.float32)
 
     painttoshelf_nsrt = NSRT("PaintToShelf", parameters, preconditions,
-                             add_effects, delete_effects, side_predicates,
+                             add_effects, delete_effects, set(),
                              option, option_vars, painttoshelf_sampler)
     nsrts.add(painttoshelf_nsrt)
 
@@ -824,35 +799,26 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
     parameters = [obj, box, robot]
     option_vars = [robot]
     option = Place
-    if CFG.env == "painting":
-        preconditions = {
-            LiftedAtom(Holding, [obj]),
-            LiftedAtom(HoldingTop, [obj])
-        }
-    elif CFG.env == "repeated_nextto_painting":
-        preconditions = {
-            LiftedAtom(Holding, [obj]),
-            LiftedAtom(HoldingTop, [obj]),
-            LiftedAtom(NextToBox, [robot, box])
-        }
+    preconditions = {
+        LiftedAtom(Holding, [obj]),
+        LiftedAtom(HoldingTop, [obj]),
+    }
+    if CFG.env == "repeated_nextto_painting":
+        preconditions.add(LiftedAtom(NextToBox, [robot, box]))
+        preconditions.add(LiftedAtom(NextTo, [robot, obj]))
 
     add_effects = {
         LiftedAtom(InBox, [obj, box]),
-        LiftedAtom(GripperOpen, [robot])
+        LiftedAtom(GripperOpen, [robot]),
     }
-    if CFG.env == "painting":
-        delete_effects = {
-            LiftedAtom(HoldingTop, [obj]),
-            LiftedAtom(Holding, [obj]),
-            LiftedAtom(OnTable, [obj])
-        }
-        side_predicates = set()
-    elif CFG.env == "repeated_nextto_painting":
-        delete_effects = {
-            LiftedAtom(HoldingTop, [obj]),
-            LiftedAtom(Holding, [obj])
-        }
-        side_predicates = {NextTo, NextToNothing}
+    delete_effects = {
+        LiftedAtom(HoldingTop, [obj]),
+        LiftedAtom(Holding, [obj]),
+        LiftedAtom(OnTable, [obj]),
+    }
+    if CFG.env == "repeated_nextto_painting":
+        # OnTable is removed by moving in rnt_painting.
+        delete_effects.remove(LiftedAtom(OnTable, [obj]))
 
     def placeinbox_sampler(state: State, goal: Set[GroundAtom],
                            rng: np.random.Generator,
@@ -869,7 +835,7 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         return np.array([x, y, z], dtype=np.float32)
 
     placeinbox_nsrt = NSRT("PlaceInBox", parameters, preconditions,
-                           add_effects, delete_effects, side_predicates,
+                           add_effects, delete_effects, set(),
                            option, option_vars, placeinbox_sampler)
     nsrts.add(placeinbox_nsrt)
 
@@ -880,35 +846,25 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
     parameters = [obj, shelf, robot]
     option_vars = [robot]
     option = Place
-    if CFG.env == "painting":
-        preconditions = {
-            LiftedAtom(Holding, [obj]),
-            LiftedAtom(HoldingSide, [obj])
-        }
-    elif CFG.env == "repeated_nextto_painting":
-        preconditions = {
-            LiftedAtom(Holding, [obj]),
-            LiftedAtom(HoldingSide, [obj]),
-            LiftedAtom(NextToShelf, [robot, shelf])
-        }
-
+    preconditions = {
+        LiftedAtom(Holding, [obj]),
+        LiftedAtom(HoldingSide, [obj]),
+    }
+    if CFG.env == "repeated_nextto_painting":
+        preconditions.add(LiftedAtom(NextToShelf, [robot, shelf]))
+        preconditions.add(LiftedAtom(NextTo, [robot, obj]))
     add_effects = {
         LiftedAtom(InShelf, [obj, shelf]),
-        LiftedAtom(GripperOpen, [robot])
+        LiftedAtom(GripperOpen, [robot]),
     }
-    if CFG.env == "painting":
-        delete_effects = {
-            LiftedAtom(HoldingSide, [obj]),
-            LiftedAtom(Holding, [obj]),
-            LiftedAtom(OnTable, [obj])
-        }
-        side_predicates = set()
-    elif CFG.env == "repeated_nextto_painting":
-        delete_effects = {
-            LiftedAtom(HoldingSide, [obj]),
-            LiftedAtom(Holding, [obj])
-        }
-        side_predicates = {NextTo, NextToNothing}
+    delete_effects = {
+        LiftedAtom(HoldingSide, [obj]),
+        LiftedAtom(Holding, [obj]),
+        LiftedAtom(OnTable, [obj]),
+    }
+    if CFG.env == "repeated_nextto_painting":
+        # OnTable is removed by moving in rnt_painting.
+        delete_effects.remove(LiftedAtom(OnTable, [obj]))
 
     def placeinshelf_sampler(state: State, goal: Set[GroundAtom],
                              rng: np.random.Generator,
@@ -925,7 +881,7 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         return np.array([x, y, z], dtype=np.float32)
 
     placeinshelf_nsrt = NSRT("PlaceInShelf", parameters, preconditions,
-                             add_effects, delete_effects, side_predicates,
+                             add_effects, delete_effects, set(),
                              option, option_vars, placeinshelf_sampler)
     nsrts.add(placeinshelf_nsrt)
 
@@ -944,72 +900,68 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
                         set(), option, option_vars, null_sampler)
     nsrts.add(openlid_nsrt)
 
-    # PlaceOnTable (from somewhere else on the table)
-    for holding_rot_pred in [HoldingSide, HoldingTop]:
-        obj = Variable("?obj", obj_type)
-        robot = Variable("?robot", robot_type)
-        parameters = [obj, robot]
-        option_vars = [robot]
-        option = Place
-        if CFG.env == "painting":
-            preconditions = {
-                LiftedAtom(Holding, [obj]),
-                LiftedAtom(holding_rot_pred, [obj]),
-                LiftedAtom(OnTable, [obj]),
-            }
-            add_effects = {
-                LiftedAtom(GripperOpen, [robot]),
-            }
-        elif CFG.env == "repeated_nextto_painting":
-            preconditions = {
-                LiftedAtom(Holding, [obj]),
-                LiftedAtom(holding_rot_pred, [obj])
-            }
-            add_effects = {
-                LiftedAtom(GripperOpen, [robot]),
-                LiftedAtom(OnTable, [obj])
-            }
-
-        delete_effects = {
+    # PlaceOnTable
+    obj = Variable("?obj", obj_type)
+    robot = Variable("?robot", robot_type)
+    parameters = [obj, robot]
+    option_vars = [robot]
+    option = Place
+    if CFG.env == "painting":
+        preconditions = {
             LiftedAtom(Holding, [obj]),
-            LiftedAtom(holding_rot_pred, [obj]),
+            LiftedAtom(OnTable, [obj]),
         }
+        add_effects = {
+            LiftedAtom(GripperOpen, [robot]),
+        }
+    elif CFG.env == "repeated_nextto_painting":
+        preconditions = {
+            LiftedAtom(Holding, [obj]),
+            LiftedAtom(NextTo, [robot, obj]),
+        }
+        add_effects = {
+            LiftedAtom(GripperOpen, [robot]),
+            LiftedAtom(OnTable, [obj]),
+        }
+    delete_effects = {
+        LiftedAtom(Holding, [obj]),
+        LiftedAtom(HoldingTop, [obj]),
+        LiftedAtom(HoldingSide, [obj]),
+    }
+
+    # TODO: spurious Place operator
+
+    def placeontable_sampler(state: State, goal: Set[GroundAtom],
+                             rng: np.random.Generator,
+                             objs: Sequence[Object]) -> Array:
+        del goal  # unused
+        x = state.get(objs[0], "pose_x")
         if CFG.env == "painting":
-            side_predicates = set()
+            # Always release the object where it is, to avoid the
+            # possibility of collisions with other objects.
+            y = state.get(objs[0], "pose_y")
+            z = state.get(objs[0], "pose_z")
         elif CFG.env == "repeated_nextto_painting":
-            side_predicates = {NextTo, NextToNothing}
+            # Release the object at a randomly-chosen position on the table
+            # such that it is NextTo the robot.
+            robot_y = state.get(objs[1], "pose_y")
+            y_sample_lb = max([
+                RepeatedNextToPaintingEnv.table_lb,
+                robot_y - RepeatedNextToPaintingEnv.nextto_thresh
+            ])
+            y_sample_ub = min([
+                RepeatedNextToPaintingEnv.table_ub,
+                robot_y + RepeatedNextToPaintingEnv.nextto_thresh
+            ])
+            y = rng.uniform(y_sample_lb, y_sample_ub)
+            z = RepeatedNextToPaintingEnv.obj_z
+        return np.array([x, y, z], dtype=np.float32)
 
-        def placeontable_sampler(state: State, goal: Set[GroundAtom],
-                                 rng: np.random.Generator,
-                                 objs: Sequence[Object]) -> Array:
-            del goal  # unused
-            x = state.get(objs[0], "pose_x")
-            if CFG.env == "painting":
-                # Always release the object where it is, to avoid the
-                # possibility of collisions with other objects.
-                y = state.get(objs[0], "pose_y")
-                z = state.get(objs[0], "pose_z")
-            elif CFG.env == "repeated_nextto_painting":
-                # Release the object at a randomly-chosen position on the table
-                # such that it is NextTo the robot.
-                robot_y = state.get(objs[1], "pose_y")
-                y_sample_lb = max([
-                    RepeatedNextToPaintingEnv.table_lb,
-                    robot_y - RepeatedNextToPaintingEnv.nextto_thresh
-                ])
-                y_sample_ub = min([
-                    RepeatedNextToPaintingEnv.table_ub,
-                    robot_y + RepeatedNextToPaintingEnv.nextto_thresh
-                ])
-                y = rng.uniform(y_sample_lb, y_sample_ub)
-                z = RepeatedNextToPaintingEnv.obj_z
-            return np.array([x, y, z], dtype=np.float32)
-
-        placeontable_nsrt = NSRT(f"PlaceOnTable-{holding_rot_pred.name}",
-                                 parameters, preconditions, add_effects,
-                                 delete_effects, side_predicates, option,
-                                 option_vars, placeontable_sampler)
-        nsrts.add(placeontable_nsrt)
+    placeontable_nsrt = NSRT("PlaceOnTable",
+                             parameters, preconditions, add_effects,
+                             delete_effects, set(), option,
+                             option_vars, placeontable_sampler)
+    nsrts.add(placeontable_nsrt)
 
     if CFG.env == "repeated_nextto_painting":
 
@@ -1041,11 +993,13 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         # MoveToBox
         robot = Variable("?robot", robot_type)
         targetbox = Variable("?targetbox", box_type)
-        parameters = [robot, targetbox]
+        obj = Variable("?obj", obj_type)
+        parameters = [robot, targetbox, obj]
         option_vars = [robot, targetbox]
         option = MoveToBox
-        preconditions = set()
-        add_effects = {LiftedAtom(NextToBox, [robot, targetbox])}
+        preconditions = {LiftedAtom(NextTo, [robot, obj])}
+        add_effects = {LiftedAtom(NextToBox, [robot, targetbox]),
+                       LiftedAtom(NextTo, [robot, obj])}
         delete_effects = set()
         # Moving could have us end up NextTo other objects. It could also
         # include NextToNothing as a delete effect.
@@ -1058,11 +1012,13 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         # MoveToShelf
         robot = Variable("?robot", robot_type)
         targetshelf = Variable("?targetshelf", shelf_type)
-        parameters = [robot, targetshelf]
+        obj = Variable("?obj", obj_type)
+        parameters = [robot, targetshelf, obj]
         option_vars = [robot, targetshelf]
         option = MoveToShelf
-        preconditions = set()
-        add_effects = {LiftedAtom(NextToShelf, [robot, targetshelf])}
+        preconditions = {LiftedAtom(NextTo, [robot, obj])}
+        add_effects = {LiftedAtom(NextToShelf, [robot, targetshelf]),
+                       LiftedAtom(NextTo, [robot, obj])}
         delete_effects = set()
         # Moving could have us end up NextTo other objects. It could also
         # include NextToNothing as a delete effect.

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -984,7 +984,6 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         option = MoveToObj
         preconditions = {
             LiftedAtom(GripperOpen, [robot]),
-            LiftedAtom(OnTable, [targetobj])
         }
         add_effects = {
             LiftedAtom(NextTo, [robot, targetobj]),
@@ -1010,7 +1009,6 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         preconditions = {
             LiftedAtom(NextTo, [robot, obj]),
             LiftedAtom(Holding, [obj]),
-            LiftedAtom(OnTable, [obj]),
         }
         add_effects = {
             LiftedAtom(NextToBox, [robot, targetbox]),
@@ -1038,7 +1036,6 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
         preconditions = {
             LiftedAtom(NextTo, [robot, obj]),
             LiftedAtom(Holding, [obj]),
-            LiftedAtom(OnTable, [obj]),
         }
         add_effects = {
             LiftedAtom(NextToShelf, [robot, targetshelf]),

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -614,7 +614,7 @@ def test_repeated_nextto_painting_get_gt_nsrts():
     # Test PlaceOnTable
     nsrts = get_gt_nsrts(env.predicates, env.options)
     ptables = [nsrt for nsrt in nsrts if nsrt.name.startswith("PlaceOnTable")]
-    assert len(ptables) == 2
+    assert len(ptables) == 1
     ptable = ptables[0]
     opt = ptable.ground([obj0, robby]).sample_option(init, set(), rng)
     assert opt.objects == [robby]

--- a/tests/envs/test_painting.py
+++ b/tests/envs/test_painting.py
@@ -119,14 +119,14 @@ def test_painting_failure_cases():
     # In the first initial state, we are holding an object, because
     # painting_initial_holding_prob = 1.0
     assert Holding([obj0]) in atoms
-    # Placing it on another object causes a collision
-    with pytest.raises(utils.EnvironmentFailure):
-        x = state.get(obj1, "pose_x")
-        y = state.get(obj1, "pose_y")
-        z = state.get(obj1, "pose_z")
-        act = Place.ground([robot], np.array([x, y, z],
-                                             dtype=np.float32)).policy(state)
-        env.simulate(state, act)
+    # Placing it on another object causes a collision (noop)
+    x = state.get(obj1, "pose_x")
+    y = state.get(obj1, "pose_y")
+    z = state.get(obj1, "pose_z")
+    act = Place.ground([robot], np.array([x, y, z],
+                                         dtype=np.float32)).policy(state)
+    next_state = env.simulate(state, act)
+    assert state.allclose(next_state)
     # Advance to a state where we are not holding anything
     x = state.get(obj0, "pose_x")
     y = state.get(obj0, "pose_y")

--- a/tests/envs/test_repeated_nextto_painting.py
+++ b/tests/envs/test_repeated_nextto_painting.py
@@ -19,7 +19,7 @@ def test_repeated_nextto_painting():
     for task in env.get_test_tasks():
         for obj in task.init:
             assert len(obj.type.feature_names) == len(task.init[obj])
-    assert len(env.predicates) == 17
+    assert len(env.predicates) == 18
     assert {pred.name for pred in env.goal_predicates} == \
         {"InBox", "IsBoxColor", "InShelf", "IsShelfColor"}
     assert len(env.options) == 9

--- a/tests/envs/test_repeated_nextto_painting.py
+++ b/tests/envs/test_repeated_nextto_painting.py
@@ -19,7 +19,7 @@ def test_repeated_nextto_painting():
     for task in env.get_test_tasks():
         for obj in task.init:
             assert len(obj.type.feature_names) == len(task.init[obj])
-    assert len(env.predicates) == 18
+    assert len(env.predicates) == 17
     assert {pred.name for pred in env.goal_predicates} == \
         {"InBox", "IsBoxColor", "InShelf", "IsShelfColor"}
     assert len(env.options) == 9


### PR DESCRIPTION
the hope is to get them closer to what we would expect to learn with sidelining / operator learning

things I tested on seeds 0 - 4:
* `python src/main.py --env repeated_nextto_painting --approach oracle`
* `python src/main.py --env painting --approach oracle`
* `python src/main.py --env repeated_nextto_painting --approach oracle --painting_goal_receptacles box`
* `python src/main.py --env repeated_nextto_painting --approach oracle --painting_goal_receptacles shelf`