### PR TITLE
fix action space bound crash for option learning

### DIFF
--- a/src/approaches/nsrt_learning_approach.py
+++ b/src/approaches/nsrt_learning_approach.py
@@ -53,6 +53,7 @@ class NSRTLearningApproach(BilevelPlanningApproach):
             trajectories,
             self._train_tasks,
             self._get_current_predicates(),
+            self._action_space,
             sampler_learner=CFG.sampler_learner)
         save_path = utils.get_approach_save_path_str()
         with open(f"{save_path}_{online_learning_cycle}.NSRTs", "wb") as f:

--- a/src/nsrt_learning/nsrt_learning_main.py
+++ b/src/nsrt_learning/nsrt_learning_main.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import List, Set
 
+from gym.spaces import Box
+
 from predicators.src import utils
 from predicators.src.nsrt_learning.option_learning import create_option_learner
 from predicators.src.nsrt_learning.sampler_learning import learn_samplers
@@ -22,6 +24,7 @@ from predicators.src.structs import NSRT, LowLevelTrajectory, \
 
 def learn_nsrts_from_data(trajectories: List[LowLevelTrajectory],
                           train_tasks: List[Task], predicates: Set[Predicate],
+                          action_space: Box,
                           sampler_learner: str) -> Set[NSRT]:
     """Learn NSRTs from the given dataset of low-level transitions, using the
     given set of predicates."""
@@ -99,7 +102,7 @@ def learn_nsrts_from_data(trajectories: List[LowLevelTrajectory],
         pnads = side_pred_learner.sideline()
 
     # STEP 5: Learn options (option_learning.py) and update PNADs.
-    _learn_pnad_options(pnads)  # in-place update
+    _learn_pnad_options(pnads, action_space)  # in-place update
 
     # STEP 6: Learn samplers (sampler_learning.py) and update PNADs.
     _learn_pnad_samplers(pnads, sampler_learner)  # in-place update
@@ -113,9 +116,10 @@ def learn_nsrts_from_data(trajectories: List[LowLevelTrajectory],
     return set(nsrts)
 
 
-def _learn_pnad_options(pnads: List[PartialNSRTAndDatastore]) -> None:
+def _learn_pnad_options(pnads: List[PartialNSRTAndDatastore],
+                        action_space: Box) -> None:
     logging.info("\nDoing option learning...")
-    option_learner = create_option_learner()
+    option_learner = create_option_learner(action_space)
     strips_ops = []
     datastores = []
     for pnad in pnads:

--- a/src/nsrt_learning/option_learning.py
+++ b/src/nsrt_learning/option_learning.py
@@ -7,7 +7,6 @@ import logging
 from typing import Dict, List, Sequence, Set, Tuple
 
 import numpy as np
-from gym.spaces import Box
 
 from predicators.src.envs import get_or_create_env
 from predicators.src.envs.blocks import BlocksEnv

--- a/src/nsrt_learning/option_learning.py
+++ b/src/nsrt_learning/option_learning.py
@@ -7,6 +7,7 @@ import logging
 from typing import Dict, List, Sequence, Set, Tuple
 
 import numpy as np
+from gym.spaces import Box
 
 from predicators.src.envs import get_or_create_env
 from predicators.src.envs.blocks import BlocksEnv
@@ -18,14 +19,14 @@ from predicators.src.torch_models import MLPRegressor
 from predicators.src.utils import OptionExecutionFailure
 
 
-def create_option_learner() -> _OptionLearnerBase:
+def create_option_learner(action_space: Box) -> _OptionLearnerBase:
     """Create an option learner given its name."""
     if CFG.option_learner == "no_learning":
         return _KnownOptionsOptionLearner()
     if CFG.option_learner == "oracle":
         return _OracleOptionLearner()
     if CFG.option_learner == "neural":
-        return _NeuralOptionLearner()
+        return _NeuralOptionLearner(action_space)
     raise NotImplementedError(f"Unknown option_learner: {CFG.option_learner}")
 
 
@@ -267,7 +268,8 @@ class _LearnedNeuralParameterizedOption(ParameterizedOption):
 
     def __init__(self, name: str, operator: STRIPSOperator,
                  regressor: MLPRegressor,
-                 changing_parameters: Sequence[Variable]) -> None:
+                 changing_parameters: Sequence[Variable],
+                 action_space: Box) -> None:
         assert set(changing_parameters).issubset(set(operator.parameters))
         changing_parameter_idxs = [
             i for i, v in enumerate(operator.parameters)
@@ -282,6 +284,7 @@ class _LearnedNeuralParameterizedOption(ParameterizedOption):
         self._operator = operator
         self._regressor = regressor
         self._changing_parameter_idxs = changing_parameter_idxs
+        self._action_space = action_space
         super().__init__(name,
                          types,
                          params_space,
@@ -313,6 +316,8 @@ class _LearnedNeuralParameterizedOption(ParameterizedOption):
         action_arr = self._regressor.predict(x)
         if np.isnan(action_arr).any():
             raise OptionExecutionFailure("Option policy returned nan.")
+        action_arr = np.clip(action_arr, self._action_space.low,
+                             self._action_space.high)
         return Action(np.array(action_arr, dtype=np.float32))
 
     def _effect_based_terminal(self, state: State, memory: Dict,
@@ -345,8 +350,10 @@ class _NeuralOptionLearner(_OptionLearnerBase):
     via supervised learning) in learn_option_specs().
     """
 
-    def __init__(self) -> None:
+    def __init__(self, action_space: Box) -> None:
         super().__init__()
+        # Actions are clipped to stay within the action space.
+        self._action_space = action_space
         # While learning the policy, we record the map from each segment to
         # the option parameterization, so we don't need to recompute it in
         # update_segment_from_option_spec.
@@ -426,7 +433,7 @@ class _NeuralOptionLearner(_OptionLearnerBase):
             # Construct the ParameterizedOption for this operator.
             name = f"{op.name}LearnedOption"
             parameterized_option = _LearnedNeuralParameterizedOption(
-                name, op, regressor, changing_parameters)
+                name, op, regressor, changing_parameters, self._action_space)
             option_specs.append((parameterized_option, list(op.parameters)))
 
         return option_specs

--- a/tests/nsrt_learning/test_nsrt_learning_main.py
+++ b/tests/nsrt_learning/test_nsrt_learning_main.py
@@ -30,6 +30,7 @@ def test_nsrt_learning_specific_nsrts():
     pred2 = Predicate("Pred2", [cup_type], lambda s, o: s[o[0]][0] > 0.5)
     preds = {pred0, pred1, pred2}
     state1 = State({cup0: [0.4], cup1: [0.7], cup2: [0.1]})
+    action_space = Box(0, 1, (1, ))
     param_option1 = utils.SingletonParameterizedOption(
         "Dummy", lambda s, m, o, p: Action(p), params_space=Box(0.1, 1, (1, )))
     option1 = param_option1.ground([], np.array([0.2]))
@@ -38,7 +39,10 @@ def test_nsrt_learning_specific_nsrts():
     action1.set_option(option1)
     next_state1 = State({cup0: [0.8], cup1: [0.3], cup2: [1.0]})
     dataset = [LowLevelTrajectory([state1, next_state1], [action1])]
-    nsrts = learn_nsrts_from_data(dataset, [], preds, sampler_learner="neural")
+    nsrts = learn_nsrts_from_data(dataset, [],
+                                  preds,
+                                  action_space,
+                                  sampler_learner="neural")
     assert len(nsrts) == 1
     nsrt = nsrts.pop()
     assert str(nsrt) == """NSRT-Op0:
@@ -75,7 +79,10 @@ def test_nsrt_learning_specific_nsrts():
         LowLevelTrajectory([state1, next_state1], [action1]),
         LowLevelTrajectory([state2, next_state2], [action2])
     ]
-    nsrts = learn_nsrts_from_data(dataset, [], preds, sampler_learner="random")
+    nsrts = learn_nsrts_from_data(dataset, [],
+                                  preds,
+                                  action_space,
+                                  sampler_learner="random")
     assert len(nsrts) == 1
     nsrt = nsrts.pop()
     assert str(nsrt) == """NSRT-Op0:
@@ -117,7 +124,10 @@ def test_nsrt_learning_specific_nsrts():
         LowLevelTrajectory([state1, next_state1], [action1]),
         LowLevelTrajectory([state2, next_state2], [action2])
     ]
-    nsrts = learn_nsrts_from_data(dataset, [], preds, sampler_learner="random")
+    nsrts = learn_nsrts_from_data(dataset, [],
+                                  preds,
+                                  action_space,
+                                  sampler_learner="random")
     assert len(nsrts) == 2
     expected = {
         "Op0":
@@ -159,7 +169,10 @@ def test_nsrt_learning_specific_nsrts():
         LowLevelTrajectory([state1, next_state1], [action1]),
         LowLevelTrajectory([state2, next_state2], [action2])
     ]
-    nsrts = learn_nsrts_from_data(dataset, [], preds, sampler_learner="random")
+    nsrts = learn_nsrts_from_data(dataset, [],
+                                  preds,
+                                  action_space,
+                                  sampler_learner="random")
     assert len(nsrts) == 2
     expected = {
         "Op0":
@@ -183,7 +196,10 @@ def test_nsrt_learning_specific_nsrts():
         assert str(nsrt) == expected[nsrt.name]
     # Test minimum number of examples parameter
     utils.update_config({"min_data_for_nsrt": 3})
-    nsrts = learn_nsrts_from_data(dataset, [], preds, sampler_learner="random")
+    nsrts = learn_nsrts_from_data(dataset, [],
+                                  preds,
+                                  action_space,
+                                  sampler_learner="random")
     assert len(nsrts) == 0
     # Test max_rejection_sampling_tries = 0
     utils.update_config({
@@ -192,7 +208,10 @@ def test_nsrt_learning_specific_nsrts():
         "sampler_mlp_classifier_max_itr": 1,
         "neural_gaus_regressor_max_itr": 1
     })
-    nsrts = learn_nsrts_from_data(dataset, [], preds, sampler_learner="neural")
+    nsrts = learn_nsrts_from_data(dataset, [],
+                                  preds,
+                                  action_space,
+                                  sampler_learner="neural")
     assert len(nsrts) == 2
     for nsrt in nsrts:
         for _ in range(10):

--- a/tests/nsrt_learning/test_option_learning.py
+++ b/tests/nsrt_learning/test_option_learning.py
@@ -44,7 +44,7 @@ def test_known_options_option_learner():
     strips_ops = [pnad.op for pnad in pnads]
     datastores = [pnad.datastore for pnad in pnads]
     assert len(strips_ops) == len(datastores) == 4
-    option_learner = create_option_learner()
+    option_learner = create_option_learner(env.action_space)
     option_specs = option_learner.learn_option_specs(strips_ops, datastores)
     assert len(option_specs) == len(strips_ops) == 4
     assert len(env.options) == 1
@@ -83,7 +83,7 @@ def test_oracle_option_learner_cover():
     strips_ops = [pnad.op for pnad in pnads]
     datastores = [pnad.datastore for pnad in pnads]
     assert len(strips_ops) == len(datastores) == 3
-    option_learner = create_option_learner()
+    option_learner = create_option_learner(env.action_space)
     option_specs = option_learner.learn_option_specs(strips_ops, datastores)
     assert len(option_specs) == len(strips_ops) == 3
     assert len(env.options) == 1
@@ -127,7 +127,7 @@ def test_oracle_option_learner_blocks():
     strips_ops = [pnad.op for pnad in pnads]
     datastores = [pnad.datastore for pnad in pnads]
     assert len(strips_ops) == len(datastores) == 4
-    option_learner = create_option_learner()
+    option_learner = create_option_learner(env.action_space)
     option_specs = option_learner.learn_option_specs(strips_ops, datastores)
     assert len(option_specs) == len(strips_ops) == 4
     assert len(env.options) == 3
@@ -183,7 +183,8 @@ def test_learned_neural_parameterized_option():
     regressor.fit(X_arr_regressor, Y_arr_regressor)
     param_option = _LearnedNeuralParameterizedOption("LearnedOption1",
                                                      pick_operator, regressor,
-                                                     changing_parameters)
+                                                     changing_parameters,
+                                                     env.action_space)
     assert param_option.name == "LearnedOption1"
     assert param_option.types == [p.type for p in pick_operator.parameters]
     assert param_option.params_space.shape == (param_dim, )
@@ -231,8 +232,9 @@ def test_create_option_learner():
         "num_train_tasks": 3,
         "option_learner": "not a real option learner"
     })
+    env = create_new_env("blocks")
     with pytest.raises(NotImplementedError):
-        create_option_learner()
+        create_option_learner(env.action_space)
 
 
 @longrun


### PR DESCRIPTION
this fixes a crash where the learned option policies would suggest out of bounds actions

before this change, this crashes:
`python src/main.py --env touch_point --approach nsrt_learning --seed 1 --option_learner neural`

now it doesn't crash