### PR TITLE
handle case where option raises error during option model

### DIFF
--- a/src/option_model.py
+++ b/src/option_model.py
@@ -87,12 +87,17 @@ class _OracleOptionModel(_OptionModelBase):
             option_copy = env_param_opt.ground(option.objects, option.params)
         del option  # unused after this
         assert option_copy.initiable(state)
-        traj = utils.run_policy_with_simulator(
-            option_copy.policy,
-            self._simulator,
-            state,
-            option_copy.terminal,
-            max_num_steps=CFG.max_num_steps_option_rollout)
+        try:
+            traj = utils.run_policy_with_simulator(
+                option_copy.policy,
+                self._simulator,
+                state,
+                option_copy.terminal,
+                max_num_steps=CFG.max_num_steps_option_rollout)
+        except utils.OptionExecutionFailure:
+            # If there is a failure during the execution of the option, treat
+            # this as a noop.
+            return state, 0
         # Note that in the case of using a PyBullet environment, the
         # second return value (num_actions) will be an underestimate
         # since we are not actually rolling out the option in the full

--- a/tests/test_option_model.py
+++ b/tests/test_option_model.py
@@ -115,6 +115,21 @@ def test_default_option_model():
     assert num_act == 4
     assert remembered_next_state.allclose(next_state)
 
+    # Test case where an option execution failure occurs. Expected behavior is
+    # that the transition should function as a noop.
+    def failing_policy(s, m, o, p):
+        del s, m, o, p  # unused
+        raise utils.OptionExecutionFailure("mock error")
+
+    failing_param_opt = ParameterizedOption("FailingLearnedOption", [],
+                                            params_space, failing_policy,
+                                            initiable, terminal)
+    failing_option = failing_param_opt.ground([], params2)
+    next_state, num_act = model.get_next_state_and_num_actions(
+        state, failing_option)
+    assert num_act == 0
+    assert state.allclose(next_state)
+
 
 def test_option_model_notimplemented():
     """Tests for various NotImplementedErrors."""


### PR DESCRIPTION
before this PR, this command would fail when the learned policy returns nans:

`python src/main.py --env cover_multistep_options --approach nsrt_learning --seed 0 --option_learner neural`