### PR TITLE
implicit regressor and implicit behavior cloning for option learning

### DIFF
--- a/src/nsrt_learning/option_learning.py
+++ b/src/nsrt_learning/option_learning.py
@@ -14,7 +14,8 @@ from predicators.src.settings import CFG
 from predicators.src.structs import Action, Array, Box, Datastore, Object, \
     OptionSpec, ParameterizedOption, Segment, State, STRIPSOperator, \
     Variable
-from predicators.src.torch_models import MLPRegressor, Regressor
+from predicators.src.torch_models import ImplicitMLPRegressor, MLPRegressor, \
+    Regressor
 from predicators.src.utils import OptionExecutionFailure
 
 
@@ -26,6 +27,8 @@ def create_option_learner(action_space: Box) -> _OptionLearnerBase:
         return _OracleOptionLearner()
     if CFG.option_learner == "direct_bc":
         return _DirectBehaviorCloningOptionLearner(action_space)
+    if CFG.option_learner == "implicit_bc":
+        return _ImplicitBehaviorCloningOptionLearner(action_space)
     raise NotImplementedError(f"Unknown option_learner: {CFG.option_learner}")
 
 
@@ -465,3 +468,10 @@ class _DirectBehaviorCloningOptionLearner(_BehaviorCloningOptionLearner):
 
     def _create_regressor(self) -> Regressor:
         return MLPRegressor()
+
+
+class _ImplicitBehaviorCloningOptionLearner(_BehaviorCloningOptionLearner):
+    """Use an ImplicitMLPRegressor for regression."""
+
+    def _create_regressor(self) -> Regressor:
+        return ImplicitMLPRegressor()

--- a/src/nsrt_learning/option_learning.py
+++ b/src/nsrt_learning/option_learning.py
@@ -419,7 +419,7 @@ class _BehaviorCloningOptionLearner(_OptionLearnerBase):
                 assert len(segment.states) == len(segment.actions) + 1
                 for state, action in zip(segment.states, segment.actions):
                     state_features = state.vec(all_objects_in_operator)
-                    # Compute the relative goal vector this segment.
+                    # Compute the relative goal vector for this segment.
                     relative_goal_vec = absolute_params - state.vec(
                         changing_objects)
                     # Add a bias term for regression.

--- a/src/nsrt_learning/option_learning.py
+++ b/src/nsrt_learning/option_learning.py
@@ -14,7 +14,7 @@ from predicators.src.settings import CFG
 from predicators.src.structs import Action, Array, Box, Datastore, Object, \
     OptionSpec, ParameterizedOption, Segment, State, STRIPSOperator, \
     Variable
-from predicators.src.torch_models import MLPRegressor
+from predicators.src.torch_models import MLPRegressor, Regressor
 from predicators.src.utils import OptionExecutionFailure
 
 
@@ -24,8 +24,8 @@ def create_option_learner(action_space: Box) -> _OptionLearnerBase:
         return _KnownOptionsOptionLearner()
     if CFG.option_learner == "oracle":
         return _OracleOptionLearner()
-    if CFG.option_learner == "neural":
-        return _NeuralOptionLearner(action_space)
+    if CFG.option_learner == "direct_bc":
+        return _DirectBehaviorCloningOptionLearner(action_space)
     raise NotImplementedError(f"Unknown option_learner: {CFG.option_learner}")
 
 
@@ -266,8 +266,7 @@ class _LearnedNeuralParameterizedOption(ParameterizedOption):
     """
 
     def __init__(self, name: str, operator: STRIPSOperator,
-                 regressor: MLPRegressor,
-                 changing_parameters: Sequence[Variable],
+                 regressor: Regressor, changing_parameters: Sequence[Variable],
                  action_space: Box) -> None:
         assert set(changing_parameters).issubset(set(operator.parameters))
         changing_parameter_idxs = [
@@ -337,7 +336,7 @@ class _LearnedNeuralParameterizedOption(ParameterizedOption):
         return False
 
 
-class _NeuralOptionLearner(_OptionLearnerBase):
+class _BehaviorCloningOptionLearner(_OptionLearnerBase):
     """Learn _LearnedNeuralParameterizedOption objects by behavior cloning.
 
     See the docstring for _LearnedNeuralParameterizedOption for a description
@@ -358,6 +357,10 @@ class _NeuralOptionLearner(_OptionLearnerBase):
         # update_segment_from_option_spec.
         self._segment_to_grounding: Dict[Segment, Tuple[Sequence[Object],
                                                         Array]] = {}
+
+    @abc.abstractmethod
+    def _create_regressor(self) -> Regressor:
+        raise NotImplementedError("Override me!")
 
     def learn_option_specs(self, strips_ops: List[STRIPSOperator],
                            datastores: List[Datastore]) -> List[OptionSpec]:
@@ -423,7 +426,7 @@ class _NeuralOptionLearner(_OptionLearnerBase):
 
             X_arr_regressor = np.array(X_regressor, dtype=np.float32)
             Y_arr_regressor = np.array(Y_regressor, dtype=np.float32)
-            regressor = MLPRegressor()
+            regressor = self._create_regressor()
             logging.info("Fitting regressor with X shape: "
                          f"{X_arr_regressor.shape}, Y shape: "
                          f"{Y_arr_regressor.shape}.")
@@ -455,3 +458,10 @@ class _NeuralOptionLearner(_OptionLearnerBase):
         assert all(o.type == v.type for o, v in zip(objects, opt_vars))
         option = param_opt.ground(objects, params)
         segment.set_option(option)
+
+
+class _DirectBehaviorCloningOptionLearner(_BehaviorCloningOptionLearner):
+    """Use an MLPRegressor for regression."""
+
+    def _create_regressor(self) -> Regressor:
+        return MLPRegressor()

--- a/src/settings.py
+++ b/src/settings.py
@@ -332,7 +332,7 @@ class GlobalSettings:
 def get_allowed_query_type_names() -> Set[str]:
     """Get the set of names of query types that the teacher is allowed to
     answer, computed based on the configuration CFG."""
-    if CFG.option_learner == "neural":
+    if CFG.option_learner == "direct_bc":
         return {"PathToStateQuery"}
     if CFG.approach == "interactive_learning":
         return {"GroundAtomsHoldQuery"}

--- a/src/settings.py
+++ b/src/settings.py
@@ -181,6 +181,7 @@ class GlobalSettings:
     neural_gaus_regressor_hid_sizes = [32, 32]
     neural_gaus_regressor_max_itr = 1000
     mlp_classifier_n_iter_no_change = 5000
+    implicit_mlp_regressor_max_itr = 10000
     implicit_mlp_regressor_num_negative_data_per_input = 5
     implicit_mlp_regressor_num_samples_per_inference = 100
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -181,6 +181,8 @@ class GlobalSettings:
     neural_gaus_regressor_hid_sizes = [32, 32]
     neural_gaus_regressor_max_itr = 1000
     mlp_classifier_n_iter_no_change = 5000
+    implicit_mlp_regressor_num_negative_data_per_input = 5
+    implicit_mlp_regressor_num_samples_per_inference = 100
 
     # sampler learning parameters
     sampler_learner = "neural"  # "neural" or "random" or "oracle"

--- a/src/torch_models.py
+++ b/src/torch_models.py
@@ -148,7 +148,11 @@ class MLPRegressor(Regressor, nn.Module):
 
 
 class ImplicitMLPRegressor(Regressor):
-    """A regressor implemented via an energy function (binary classifier).
+    """A regressor implemented via an "energy function".
+
+    Currently the energy function is treated as a binary classifier, which is
+    not consistent with how energy functions are usually treated/trained.
+    This will change soon.
 
     Negative examples are generated within the class.
 

--- a/src/torch_models.py
+++ b/src/torch_models.py
@@ -180,7 +180,8 @@ class ImplicitMLPRegressor(Regressor):
         self._y_dim = Y.shape[1]
         max_itr = CFG.implicit_mlp_regressor_max_itr
         self._classifier = MLPClassifier(in_size=(self._x_dim + self._y_dim),
-                                         max_itr=max_itr, balance_data=False)
+                                         max_itr=max_itr,
+                                         balance_data=False)
         # Create the negative data.
         neg_X, neg_Y = self._create_negative_data(X, Y)
         # Set up the data for the classifier.

--- a/src/torch_models.py
+++ b/src/torch_models.py
@@ -18,7 +18,27 @@ from predicators.src.structs import Array, Object, State
 torch.use_deterministic_algorithms(mode=True)  # type: ignore
 
 
-class MLPRegressor(nn.Module):
+class Regressor(abc.ABC):
+    """ABC for regressor classes."""
+
+    @abc.abstractmethod
+    def fit(self, X: Array, Y: Array) -> None:
+        """Train regressor on the given data.
+
+        X and Y are both multi-dimensional.
+        """
+        raise NotImplementedError("Override me")
+
+    @abc.abstractmethod
+    def predict(self, arr: Array) -> Array:
+        """Return a prediction for the given datapoint.
+
+        arr is single-dimensional.
+        """
+        raise NotImplementedError("Override me")
+
+
+class MLPRegressor(Regressor, nn.Module):
     """A basic multilayer perceptron regressor."""
 
     def __init__(self) -> None:  # pylint: disable=useless-super-delegation
@@ -47,9 +67,9 @@ class MLPRegressor(nn.Module):
         x = self._linears[-1](x)
         return x
 
-    def predict(self, inputs: Array) -> Array:
+    def predict(self, arr: Array) -> Array:
         """Normalize, predict, un-normalize, and convert to array."""
-        x = torch.from_numpy(np.array(inputs, dtype=np.float32))
+        x = torch.from_numpy(np.array(arr, dtype=np.float32))
         x = x.unsqueeze(dim=0)
         # Normalize input
         x = (x - self._input_shift) / self._input_scale

--- a/src/torch_models.py
+++ b/src/torch_models.py
@@ -113,7 +113,8 @@ class MLPRegressor(Regressor, nn.Module):
         X, self._input_shift, self._input_scale = self._normalize_data(X)
         Y, self._output_shift, self._output_scale = self._normalize_data(Y)
         # Train
-        logging.info(f"Training MLPRegressor on {num_data} datapoints")
+        logging.info(f"Training {self.__class__.__name__} on {num_data} "
+                     "datapoints")
         self.train()  # switch to train mode
         itr = 0
         max_itrs = CFG.mlp_regressor_max_itr
@@ -198,12 +199,14 @@ class ImplicitMLPRegressor(Regressor):
         """This makes the assumption that negative data are far, far more
         common than positive data.
 
-        Under this assumption, the negative data are simply randomly
-        sampled. There may be false negatives in general, but they
-        should be rare, under the assumption.
+        Under this assumption, the negative y data are simply randomly
+        sampled from a uniform distribution bounded by the min/max seen
+        in the data. There may be false negatives in general, but they
+        should be rare, under the assumption. The x values are taken
+        directly from the X array, not sampled.
         """
         # Note that the data has already been normalized.
-        del Y  # unused for now, but may be used in the future.
+        del Y  # unused for now, but may be used in the future
         num_samples = CFG.implicit_mlp_regressor_num_negative_data_per_input
         neg_input_lst = []
         neg_output_lst = []
@@ -232,9 +235,9 @@ class ImplicitMLPRegressor(Regressor):
         scores = self._classifier.predict_proba(concat_xy)
         # Find the highest probability sample.
         sample_idx = np.argmax(scores)
-        unnorm_y = sample_ys[sample_idx]
+        norm_y = sample_ys[sample_idx]
         # Denormalize.
-        denorm_y = (unnorm_y * self._output_scale) + self._output_shift
+        denorm_y = (norm_y * self._output_scale) + self._output_shift
         return denorm_y
 
     @staticmethod

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -127,7 +127,7 @@ def test_neural_option_learning():
                    approach_name="nsrt_learning",
                    try_solving=False,
                    sampler_learner="random",
-                   option_learner="neural",
+                   option_learner="direct_bc",
                    check_solution=False,
                    additional_settings={
                        "cover_multistep_thr_percent": 0.99,

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -133,6 +133,17 @@ def test_neural_option_learning():
                        "cover_multistep_thr_percent": 0.99,
                        "cover_multistep_bhr_percent": 0.99,
                    })
+    _test_approach(env_name="touch_point",
+                   approach_name="nsrt_learning",
+                   try_solving=False,
+                   sampler_learner="random",
+                   option_learner="implicit_bc",
+                   check_solution=False,
+                   additional_settings={
+                       "implicit_mlp_regressor_max_itr": 10,
+                       "implicit_mlp_regressor_num_negative_data_per_input": 1,
+                       "implicit_mlp_regressor_num_samples_per_inference": 1,
+                   })
 
 
 def test_oracle_samplers():

--- a/tests/nsrt_learning/test_option_learning.py
+++ b/tests/nsrt_learning/test_option_learning.py
@@ -156,7 +156,7 @@ def test_learned_neural_parameterized_option():
     # Create a _LearnedNeuralParameterizedOption() for the cover Pick operator.
     utils.reset_config({
         "env": "cover_multistep_options",
-        "option_learner": "neural",
+        "option_learner": "direct_bc",
         "mlp_regressor_max_itr": 10,
         "cover_multistep_thr_percent": 0.99,
         "cover_multistep_bhr_percent": 0.99,
@@ -243,7 +243,7 @@ def test_option_learning_approach_multistep_cover():
     utils.reset_config({
         "env": "cover_multistep_options",
         "approach": "nsrt_learning",
-        "option_learner": "neural",
+        "option_learner": "direct_bc",
         "sampler_learner": "oracle",
         "num_train_tasks": 10,
         "num_test_tasks": 10,

--- a/tests/nsrt_learning/test_option_learning.py
+++ b/tests/nsrt_learning/test_option_learning.py
@@ -11,8 +11,7 @@ from predicators.src.datasets.demo_replay import create_demo_replay_data
 from predicators.src.envs import create_new_env
 from predicators.src.ground_truth_nsrts import get_gt_nsrts
 from predicators.src.nsrt_learning.option_learning import \
-    _ImplicitBehaviorCloningOptionLearner, _LearnedNeuralParameterizedOption, \
-    create_option_learner
+    _LearnedNeuralParameterizedOption, create_option_learner
 from predicators.src.nsrt_learning.segmentation import segment_trajectory
 from predicators.src.nsrt_learning.strips_learning import \
     learn_strips_operators
@@ -231,17 +230,9 @@ def test_create_option_learner():
         "env": "blocks",
         "approach": "nsrt_learning",
         "num_train_tasks": 3,
-        "option_learner": "implicit_bc"
-    })
-    env = create_new_env("blocks")
-    option_learner = create_option_learner(env.action_space)
-    assert isinstance(option_learner, _ImplicitBehaviorCloningOptionLearner)
-    utils.reset_config({
-        "env": "blocks",
-        "approach": "nsrt_learning",
-        "num_train_tasks": 3,
         "option_learner": "not a real option learner"
     })
+    env = create_new_env("blocks")
     with pytest.raises(NotImplementedError):
         create_option_learner(env.action_space)
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -9,7 +9,7 @@ def test_get_allowed_query_type_names():
     utils.reset_config()
     assert get_allowed_query_type_names() == set()
     utils.reset_config({
-        "option_learner": "neural",
+        "option_learner": "direct_bc",
     })
     assert get_allowed_query_type_names() == {"PathToStateQuery"}
     utils.reset_config({

--- a/tests/test_torch_models.py
+++ b/tests/test_torch_models.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from predicators.src import utils
 from predicators.src.torch_models import MLPClassifier, MLPRegressor, \
-    NeuralGaussianRegressor
+    NeuralGaussianRegressor, ImplicitMLPRegressor
 
 
 def test_basic_mlp_regressor():
@@ -35,6 +35,31 @@ def test_basic_mlp_regressor():
     expected_y = 75 * np.ones(output_size)
     assert predicted_y.shape == expected_y.shape
     assert np.allclose(predicted_y, expected_y, atol=1e-2)
+
+
+def test_implicit_mlp_regressor():
+    """Tests for ImplicitMLPRegressor."""
+    utils.reset_config({"mlp_regressor_max_itr": 100})
+    input_size = 3
+    output_size = 1
+    num_samples = 5
+    model = ImplicitMLPRegressor()
+    X = np.ones((num_samples, input_size))
+    Y = np.zeros((num_samples, output_size))
+    model.fit(X, Y)
+    x = np.ones(input_size)
+    predicted_y = model.predict(x)
+    expected_y = np.zeros(output_size)
+    assert predicted_y.shape == expected_y.shape
+    assert np.allclose(predicted_y, expected_y, atol=1e-1)
+    # Test with nonzero outputs.
+    Y = 75 * np.ones((num_samples, output_size))
+    model.fit(X, Y)
+    x = np.ones(input_size)
+    predicted_y = model.predict(x)
+    expected_y = 75 * np.ones(output_size)
+    assert predicted_y.shape == expected_y.shape
+    assert np.allclose(predicted_y, expected_y, atol=1e-1)
 
 
 def test_neural_gaussian_regressor():

--- a/tests/test_torch_models.py
+++ b/tests/test_torch_models.py
@@ -5,8 +5,8 @@ import time
 import numpy as np
 
 from predicators.src import utils
-from predicators.src.torch_models import MLPClassifier, MLPRegressor, \
-    NeuralGaussianRegressor, ImplicitMLPRegressor
+from predicators.src.torch_models import ImplicitMLPRegressor, MLPClassifier, \
+    MLPRegressor, NeuralGaussianRegressor
 
 
 def test_basic_mlp_regressor():
@@ -39,7 +39,7 @@ def test_basic_mlp_regressor():
 
 def test_implicit_mlp_regressor():
     """Tests for ImplicitMLPRegressor."""
-    utils.reset_config({"mlp_regressor_max_itr": 100})
+    utils.reset_config({"implicit_mlp_regressor_max_itr": 100})
     input_size = 3
     output_size = 1
     num_samples = 5


### PR DESCRIPTION
Results below on seeds 0-4 with the touch point environment. Results on cover are no good yet, likely due to higher dimensional action space.

## Direct BC
```python src/main.py --approach nsrt_learning --env touch_point --option_learner direct_bc```
*Results*: 47, 45, 45, 48, 40

## Implicit BC
```python src/main.py --approach nsrt_learning --env touch_point --option_learner implicit_bc```
*Results*: 49, 50, 50, 50, 50

### Visualization of the learned energy function
![good_touch_point_learned_energy](https://user-images.githubusercontent.com/2816502/161654972-6fb083cc-e803-4dba-ba2f-c14356e2e05d.gif)

