### PR TITLE
derivate free optimization for implicit regressor 

### DIFF
--- a/src/nsrt_learning/option_learning.py
+++ b/src/nsrt_learning/option_learning.py
@@ -479,8 +479,12 @@ class _ImplicitBehaviorCloningOptionLearner(_BehaviorCloningOptionLearner):
     """Use an ImplicitMLPRegressor for regression."""
 
     def _create_regressor(self) -> Regressor:
+        # Pull out the constants that have long names.
         num_neg = CFG.implicit_mlp_regressor_num_negative_data_per_input
         num_sam = CFG.implicit_mlp_regressor_num_samples_per_inference
+        num_itr = CFG.implicit_mlp_regressor_derivate_free_num_iters
+        sigma = CFG.implicit_mlp_regressor_derivate_free_sigma_init
+        shrink_scale = CFG.implicit_mlp_regressor_derivate_free_shrink_scale
         return ImplicitMLPRegressor(
             seed=CFG.seed,
             hid_sizes=CFG.mlp_regressor_hid_sizes,
@@ -490,4 +494,8 @@ class _ImplicitBehaviorCloningOptionLearner(_BehaviorCloningOptionLearner):
             learning_rate=CFG.learning_rate,
             num_negative_data_per_input=num_neg,
             num_samples_per_inference=num_sam,
-            temperature=CFG.implicit_mlp_regressor_temperature)
+            temperature=CFG.implicit_mlp_regressor_temperature,
+            inference_method=CFG.implicit_mlp_regressor_inference_method,
+            derivate_free_num_iters=num_itr,
+            derivate_free_sigma_init=sigma,
+            derivate_free_shrink_scale=shrink_scale)

--- a/src/settings.py
+++ b/src/settings.py
@@ -184,6 +184,10 @@ class GlobalSettings:
     implicit_mlp_regressor_num_negative_data_per_input = 5
     implicit_mlp_regressor_num_samples_per_inference = 100
     implicit_mlp_regressor_temperature = 1.0
+    implicit_mlp_regressor_inference_method = "derivate_free"
+    implicit_mlp_regressor_derivate_free_num_iters = 3
+    implicit_mlp_regressor_derivate_free_sigma_init = 0.33
+    implicit_mlp_regressor_derivate_free_shrink_scale = 0.5
 
     # sampler learning parameters
     sampler_learner = "neural"  # "neural" or "random" or "oracle"

--- a/tests/test_torch_models.py
+++ b/tests/test_torch_models.py
@@ -55,7 +55,11 @@ def test_implicit_mlp_regressor():
                                  learning_rate=1e-3,
                                  num_samples_per_inference=100,
                                  num_negative_data_per_input=5,
-                                 temperature=1.0)
+                                 temperature=1.0,
+                                 inference_method="sample_once",
+                                 derivate_free_num_iters=3,
+                                 derivate_free_sigma_init=0.33,
+                                 derivate_free_shrink_scale=0.5)
     X = np.ones((num_samples, input_size))
     Y = np.zeros((num_samples, output_size))
     model.fit(X, Y)
@@ -72,6 +76,14 @@ def test_implicit_mlp_regressor():
     expected_y = 75 * np.ones(output_size)
     assert predicted_y.shape == expected_y.shape
     assert np.allclose(predicted_y, expected_y, atol=1e-1)
+    # Test other inference methods. Protected access is to avoid retraining.
+    model._inference_method = "derivate_free"  # pylint: disable=protected-access
+    predicted_y = model.predict(x)
+    assert predicted_y.shape == expected_y.shape
+    assert np.allclose(predicted_y, expected_y, atol=1e-1)
+    model._inference_method = "not a real inference method"  # pylint: disable=protected-access
+    with pytest.raises(NotImplementedError):
+        model.predict(x)
 
 
 def test_neural_gaussian_regressor():


### PR DESCRIPTION
`python src/main.py --approach nsrt_learning --env touch_point --option_learner implicit_bc` continues to get 50/50 on the first five seeds with this alternative inference method