### PR TITLE
Change to how datastore is calculated under add effect semantics

### DIFF
--- a/scripts/supercloud/run_sidelining_experiments.sh
+++ b/scripts/supercloud/run_sidelining_experiments.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 
 START_SEED=456
-NUM_SEEDS=100
+NUM_SEEDS=10
 FILE="scripts/supercloud/submit_supercloud_job.py"
 
 for SEED in $(seq $START_SEED $((NUM_SEEDS+START_SEED-1))); do
     # repeated_nextto
-    # python $FILE --experiment_id rnt_oracle --env repeated_nextto --approach oracle --seed $SEED --num_train_tasks 0
-    # python $FILE --experiment_id rnt_no_sidepreds --env repeated_nextto --approach nsrt_learning --side_predicate_learner no_learning --seed $SEED --num_train_tasks 50
-    # python $FILE --experiment_id rnt_harmlessness --env repeated_nextto --approach nsrt_learning --side_predicate_learner preserve_skeletons_hill_climbing --seed $SEED --num_train_tasks 50
-    # python $FILE --experiment_id rnt_pred_error --env repeated_nextto --approach nsrt_learning --side_predicate_learner prediction_error_hill_climbing --seed $SEED --num_train_tasks 50
+    python $FILE --experiment_id rnt_oracle --env repeated_nextto --approach oracle --seed $SEED --num_train_tasks 0
+    python $FILE --experiment_id rnt_no_sidepreds --env repeated_nextto --approach nsrt_learning --side_predicate_learner no_learning --seed $SEED --num_train_tasks 50
+    python $FILE --experiment_id rnt_harmlessness --env repeated_nextto --approach nsrt_learning --side_predicate_learner preserve_skeletons_hill_climbing --seed $SEED --num_train_tasks 50
+    python $FILE --experiment_id rnt_pred_error --env repeated_nextto --approach nsrt_learning --side_predicate_learner prediction_error_hill_climbing --seed $SEED --num_train_tasks 50
     python $FILE --experiment_id rnt_backchain --env repeated_nextto --approach nsrt_learning --side_predicate_learner backchaining --seed $SEED --num_train_tasks 50
 
     # repeated_nextto_single_option
-    # python $FILE --experiment_id rnt_single_option_oracle --env repeated_nextto_single_option --approach oracle --seed $SEED --num_train_tasks 0
-    # python $FILE --experiment_id rnt_single_option_no_sidepreds --env repeated_nextto_single_option --approach nsrt_learning --side_predicate_learner no_learning --seed $SEED --num_train_tasks 50
-    # python $FILE --experiment_id rnt_single_option_harmlessness --env repeated_nextto_single_option --approach nsrt_learning --side_predicate_learner preserve_skeletons_hill_climbing --seed $SEED --num_train_tasks 50
-    # python $FILE --experiment_id rnt_single_option_pred_error --env repeated_nextto_single_option --approach nsrt_learning --side_predicate_learner prediction_error_hill_climbing --seed $SEED --num_train_tasks 50
+    python $FILE --experiment_id rnt_single_option_oracle --env repeated_nextto_single_option --approach oracle --seed $SEED --num_train_tasks 0
+    python $FILE --experiment_id rnt_single_option_no_sidepreds --env repeated_nextto_single_option --approach nsrt_learning --side_predicate_learner no_learning --seed $SEED --num_train_tasks 50
+    python $FILE --experiment_id rnt_single_option_harmlessness --env repeated_nextto_single_option --approach nsrt_learning --side_predicate_learner preserve_skeletons_hill_climbing --seed $SEED --num_train_tasks 50
+    python $FILE --experiment_id rnt_single_option_pred_error --env repeated_nextto_single_option --approach nsrt_learning --side_predicate_learner prediction_error_hill_climbing --seed $SEED --num_train_tasks 50
     python $FILE --experiment_id rnt_single_option_backchain --env repeated_nextto_single_option --approach nsrt_learning --side_predicate_learner backchaining --seed $SEED --num_train_tasks 50
 
     # repeated_nextto_painting
-    # python $FILE --experiment_id rnt_painting_oracle --env repeated_nextto_painting --approach oracle --seed $SEED --num_train_tasks 0
+    python $FILE --experiment_id rnt_painting_oracle --env repeated_nextto_painting --approach oracle --seed $SEED --num_train_tasks 0
 done

--- a/scripts/supercloud/run_sidelining_experiments.sh
+++ b/scripts/supercloud/run_sidelining_experiments.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 
 START_SEED=456
-NUM_SEEDS=10
+NUM_SEEDS=100
 FILE="scripts/supercloud/submit_supercloud_job.py"
 
 for SEED in $(seq $START_SEED $((NUM_SEEDS+START_SEED-1))); do
     # repeated_nextto
-    python $FILE --experiment_id rnt_oracle --env repeated_nextto --approach oracle --seed $SEED --num_train_tasks 0
-    python $FILE --experiment_id rnt_no_sidepreds --env repeated_nextto --approach nsrt_learning --side_predicate_learner no_learning --seed $SEED --num_train_tasks 50
-    python $FILE --experiment_id rnt_harmlessness --env repeated_nextto --approach nsrt_learning --side_predicate_learner preserve_skeletons_hill_climbing --seed $SEED --num_train_tasks 50
-    python $FILE --experiment_id rnt_pred_error --env repeated_nextto --approach nsrt_learning --side_predicate_learner prediction_error_hill_climbing --seed $SEED --num_train_tasks 50
+    # python $FILE --experiment_id rnt_oracle --env repeated_nextto --approach oracle --seed $SEED --num_train_tasks 0
+    # python $FILE --experiment_id rnt_no_sidepreds --env repeated_nextto --approach nsrt_learning --side_predicate_learner no_learning --seed $SEED --num_train_tasks 50
+    # python $FILE --experiment_id rnt_harmlessness --env repeated_nextto --approach nsrt_learning --side_predicate_learner preserve_skeletons_hill_climbing --seed $SEED --num_train_tasks 50
+    # python $FILE --experiment_id rnt_pred_error --env repeated_nextto --approach nsrt_learning --side_predicate_learner prediction_error_hill_climbing --seed $SEED --num_train_tasks 50
     python $FILE --experiment_id rnt_backchain --env repeated_nextto --approach nsrt_learning --side_predicate_learner backchaining --seed $SEED --num_train_tasks 50
 
     # repeated_nextto_single_option
-    python $FILE --experiment_id rnt_single_option_oracle --env repeated_nextto_single_option --approach oracle --seed $SEED --num_train_tasks 0
-    python $FILE --experiment_id rnt_single_option_no_sidepreds --env repeated_nextto_single_option --approach nsrt_learning --side_predicate_learner no_learning --seed $SEED --num_train_tasks 50
-    python $FILE --experiment_id rnt_single_option_harmlessness --env repeated_nextto_single_option --approach nsrt_learning --side_predicate_learner preserve_skeletons_hill_climbing --seed $SEED --num_train_tasks 50
-    python $FILE --experiment_id rnt_single_option_pred_error --env repeated_nextto_single_option --approach nsrt_learning --side_predicate_learner prediction_error_hill_climbing --seed $SEED --num_train_tasks 50
+    # python $FILE --experiment_id rnt_single_option_oracle --env repeated_nextto_single_option --approach oracle --seed $SEED --num_train_tasks 0
+    # python $FILE --experiment_id rnt_single_option_no_sidepreds --env repeated_nextto_single_option --approach nsrt_learning --side_predicate_learner no_learning --seed $SEED --num_train_tasks 50
+    # python $FILE --experiment_id rnt_single_option_harmlessness --env repeated_nextto_single_option --approach nsrt_learning --side_predicate_learner preserve_skeletons_hill_climbing --seed $SEED --num_train_tasks 50
+    # python $FILE --experiment_id rnt_single_option_pred_error --env repeated_nextto_single_option --approach nsrt_learning --side_predicate_learner prediction_error_hill_climbing --seed $SEED --num_train_tasks 50
     python $FILE --experiment_id rnt_single_option_backchain --env repeated_nextto_single_option --approach nsrt_learning --side_predicate_learner backchaining --seed $SEED --num_train_tasks 50
 
     # repeated_nextto_painting
-    python $FILE --experiment_id rnt_painting_oracle --env repeated_nextto_painting --approach oracle --seed $SEED --num_train_tasks 0
+    # python $FILE --experiment_id rnt_painting_oracle --env repeated_nextto_painting --approach oracle --seed $SEED --num_train_tasks 0
 done

--- a/src/nsrt_learning/side_predicate_learning.py
+++ b/src/nsrt_learning/side_predicate_learning.py
@@ -627,11 +627,7 @@ class BackchainingSidePredicateLearner(GeneralToSpecificSidePredicateLearner):
         self._recompute_datastores_from_segments([new_pnad],
                                                  semantics="add_effects")
         # Determine the preconditions.
-        try:
-            preconditions = induce_pnad_preconditions(new_pnad)
-        except AssertionError:
-            import ipdb
-            ipdb.set_trace()
+        preconditions = induce_pnad_preconditions(new_pnad)
         # Update the preconditions of the new PNAD's operator.
         new_pnad.op = new_pnad.op.copy_with(preconditions=preconditions)
         return new_pnad

--- a/src/nsrt_learning/side_predicate_learning.py
+++ b/src/nsrt_learning/side_predicate_learning.py
@@ -66,7 +66,8 @@ class SidePredicateLearner(abc.ABC):
         that (1) the add effects of the segment intersected with the
         ground op's add effects must not be empty [because otherwise, a
         rational demonstrator would not have called this operator] and
-        (2) all the ground op's add effects must hold in the final atoms.
+        (2) all the ground op's add effects must hold in the final
+        atoms.
         """
         assert semantics in ("apply_operator", "add_effects")
         for pnad in pnads:

--- a/src/nsrt_learning/side_predicate_learning.py
+++ b/src/nsrt_learning/side_predicate_learning.py
@@ -99,20 +99,22 @@ class SidePredicateLearner(abc.ABC):
                             # Assuming we only have the ground op's add effects
                             # filled in, we want all transitions in which the
                             # demonstrator might have reasonably executed this
-                            # operator. In these transitions (1) the 
-                            # preconditions of the ground op must hold, 
+                            # operator. In these transitions (1) the
+                            # preconditions of the ground op must hold,
                             # (2) the add effects of the segment intersected
                             # with the ground op's add effects must not be
-                            # empty [because otherwise, there's no point 
+                            # empty [because otherwise, there's no point
                             # calling this operator] and (3) all the ground
                             # op's add effects must hold in the final atoms
                             # [since these add effects are really just 'set'
                             # effects].
-                            if not len(segment.add_effects
-                                       & ground_op.add_effects) > 0:
-                                continue
+
                             if not ground_op.add_effects.issubset(
                                     segment.final_atoms):
+                                continue
+
+                            if not len(segment.add_effects
+                                       & ground_op.add_effects) > 0:
                                 continue
 
                         # Skip over segments that have multiple possible

--- a/src/nsrt_learning/side_predicate_learning.py
+++ b/src/nsrt_learning/side_predicate_learning.py
@@ -62,9 +62,11 @@ class SidePredicateLearner(abc.ABC):
         a datastore if, for some ground PNAD, the preconditions are
         satisfied and apply_operator() results in an abstract next state
         that is a subset of the segment's final_atoms. If semantics is
-        "add_effects", then rather than using apply_operator(), we
-        simply check that the add effects are a subset of the segment's
-        add effects.
+        "add_effects", then rather than using apply_operator(), we check
+        that (1) the add effects of the segment intersected with the
+        ground op's add effects must not be empty [because otherwise, a
+        rational demonstrator would not have called] this operator and
+        (2) all the ground op's add effects must hold in the final atoms
         """
         assert semantics in ("apply_operator", "add_effects")
         for pnad in pnads:
@@ -96,27 +98,12 @@ class SidePredicateLearner(abc.ABC):
                             if not atoms.issubset(segment.final_atoms):
                                 continue
                         elif semantics == "add_effects":
-                            # Assuming we only have the ground op's add effects
-                            # filled in, we want all transitions in which the
-                            # demonstrator might have reasonably executed this
-                            # operator. In these transitions (1) the
-                            # preconditions of the ground op must hold,
-                            # (2) the add effects of the segment intersected
-                            # with the ground op's add effects must not be
-                            # empty [because otherwise, there's no point
-                            # calling this operator] and (3) all the ground
-                            # op's add effects must hold in the final atoms
-                            # [since these add effects are really just 'set'
-                            # effects].
-
                             if not ground_op.add_effects.issubset(
                                     segment.final_atoms):
                                 continue
-
                             if not len(segment.add_effects
                                        & ground_op.add_effects) > 0:
                                 continue
-
                         # Skip over segments that have multiple possible
                         # bindings.
                         if (len(set(ground_op.objects)) != len(

--- a/src/nsrt_learning/side_predicate_learning.py
+++ b/src/nsrt_learning/side_predicate_learning.py
@@ -66,7 +66,7 @@ class SidePredicateLearner(abc.ABC):
         that (1) the add effects of the segment intersected with the
         ground op's add effects must not be empty [because otherwise, a
         rational demonstrator would not have called this operator] and
-        (2) all the ground op's add effects must hold in the final atoms
+        (2) all the ground op's add effects must hold in the final atoms.
         """
         assert semantics in ("apply_operator", "add_effects")
         for pnad in pnads:
@@ -101,8 +101,8 @@ class SidePredicateLearner(abc.ABC):
                             if not ground_op.add_effects.issubset(
                                     segment.final_atoms):
                                 continue
-                            if not len(segment.add_effects
-                                       & ground_op.add_effects) > 0:
+                            if not (segment.add_effects
+                                    & ground_op.add_effects):
                                 continue
                         # Skip over segments that have multiple possible
                         # bindings.

--- a/src/nsrt_learning/side_predicate_learning.py
+++ b/src/nsrt_learning/side_predicate_learning.py
@@ -65,7 +65,7 @@ class SidePredicateLearner(abc.ABC):
         "add_effects", then rather than using apply_operator(), we check
         that (1) the add effects of the segment intersected with the
         ground op's add effects must not be empty [because otherwise, a
-        rational demonstrator would not have called] this operator and
+        rational demonstrator would not have called this operator] and
         (2) all the ground op's add effects must hold in the final atoms
         """
         assert semantics in ("apply_operator", "add_effects")


### PR DESCRIPTION
Introduces a change to how we assign transitions to a particular PNAD's datastore under the `add_effects` semantics. This change does not affect results on RNT or RNT_single_option (Supercloud run over 100 seeds presented below), but is necessary for new keep-effect code to work on RNT_painting. Also, this new check just seems more correct.

[results_summary.csv](https://github.com/Learning-and-Intelligent-Systems/predicators/files/8445825/results_summary.csv)

