### PR TITLE
Revert "Change to how datastore is calculated under add effect semant…

### DIFF
--- a/src/nsrt_learning/side_predicate_learning.py
+++ b/src/nsrt_learning/side_predicate_learning.py
@@ -62,12 +62,9 @@ class SidePredicateLearner(abc.ABC):
         a datastore if, for some ground PNAD, the preconditions are
         satisfied and apply_operator() results in an abstract next state
         that is a subset of the segment's final_atoms. If semantics is
-        "add_effects", then rather than using apply_operator(), we check
-        that (1) the add effects of the segment intersected with the
-        ground op's add effects must not be empty [because otherwise, a
-        rational demonstrator would not have called this operator] and
-        (2) all the ground op's add effects must hold in the final
-        atoms.
+        "add_effects", then rather than using apply_operator(), we
+        simply check that the add effects are a subset of the segment's
+        add effects.
         """
         assert semantics in ("apply_operator", "add_effects")
         for pnad in pnads:
@@ -100,10 +97,7 @@ class SidePredicateLearner(abc.ABC):
                                 continue
                         elif semantics == "add_effects":
                             if not ground_op.add_effects.issubset(
-                                    segment.final_atoms):
-                                continue
-                            if not (segment.add_effects
-                                    & ground_op.add_effects):
+                                    segment.add_effects):
                                 continue
                         # Skip over segments that have multiple possible
                         # bindings.


### PR DESCRIPTION
…ics (#680)"

This reverts commit fc4a4811740dbeeccc0542f7575ce7225125cf87.

Necessary because we realized this intersection change is wrong and messes up our side predicate and keep effect algorithms...