### PR TITLE
fix bug in pybullet kinematic chain computer

### DIFF
--- a/src/envs/pybullet_utils.py
+++ b/src/envs/pybullet_utils.py
@@ -15,7 +15,7 @@ def get_kinematic_chain(robot: int, end_effector: int,
     Includes the end effector.
     """
     kinematic_chain = []
-    while end_effector > 0:
+    while end_effector > -1:
         joint_info = p.getJointInfo(robot,
                                     end_effector,
                                     physicsClientId=physics_client_id)


### PR DESCRIPTION
this happened to not matter when we were using fetch, because the joint with ID 0 was not in the kinematic chain for the arm. but for panda, the joint with ID 0 _is_ in the kinematic chain for the arm, and because of this bug, we were excluding a joint from inverse kinematics, which was making end effector position control not work (cc @williamshen-nz ). the correct value is -1 because that is what pybullet uses for the base.