### PR TITLE
execution failure metric tweak & plotting different error types for interactive learning

### DIFF
--- a/scripts/analyze_results_directory.py
+++ b/scripts/analyze_results_directory.py
@@ -38,7 +38,7 @@ COLUMN_NAMES_AND_KEYS = [
     # ("AVG_NUM_NSRTS", "avg_num_nsrts"),
     # ("AVG_DISCOVERED_FAILURES", "avg_num_failures_discovered"),
     # ("AVG_PLAN_LEN", "avg_plan_length"),
-    # ("AVG_EXECUTION_FAILURES", "avg_execution_failures"),
+    # ("NUM_EXECUTION_FAILURES", "num_execution_failures"),
     # ("NUM_TRANSITIONS", "num_transitions"),
     # ("QUERY_COST", "query_cost"),
 ]

--- a/scripts/create_bar_plots.py
+++ b/scripts/create_bar_plots.py
@@ -26,7 +26,6 @@ GROUPS = [
     "APPROACH",
     "EXCLUDED_PREDICATES",
     "EXPERIMENT_ID",
-    # "NUM_TRAIN_TASKS", "CYCLE"
 ]
 
 # All column names and keys to load into the pandas tables.
@@ -36,23 +35,10 @@ COLUMN_NAMES_AND_KEYS = [
     ("EXCLUDED_PREDICATES", "excluded_predicates"),
     ("EXPERIMENT_ID", "experiment_id"),
     ("SEED", "seed"),
-    # ("NUM_TRAIN_TASKS", "num_train_tasks"),
-    # ("CYCLE", "cycle"),
-    # ("NUM_SOLVED", "num_solved"),
-    # ("AVG_NUM_PREDS", "avg_num_preds"),
     ("AVG_TEST_TIME", "avg_suc_time"),
     ("AVG_NODES_CREATED", "avg_num_nodes_created"),
     ("LEARNING_TIME", "learning_time"),
     ("PERC_SOLVED", "perc_solved"),
-    # ("AVG_SKELETONS", "avg_num_skeletons_optimized"),
-    # ("MIN_SKELETONS", "min_skeletons_optimized"),
-    # ("MAX_SKELETONS", "max_skeletons_optimized"),
-    # ("AVG_NODES_EXPANDED", "avg_num_nodes_expanded"),
-    # ("AVG_NUM_NSRTS", "avg_num_nsrts"),
-    # ("AVG_DISCOVERED_FAILURES", "avg_num_failures_discovered"),
-    # ("AVG_PLAN_LEN", "avg_plan_length"),
-    # ("AVG_EXECUTION_FAILURES", "avg_execution_failures"),
-    # ("NUM_TRANSITIONS", "num_transitions"),
 ]
 
 DERIVED_KEYS = [("perc_solved",

--- a/scripts/create_interactive_predicate_learning_plots.py
+++ b/scripts/create_interactive_predicate_learning_plots.py
@@ -33,8 +33,7 @@ COLUMN_NAMES_AND_KEYS = [
 ]
 
 DERIVED_KEYS = [
-    ("perc_solved",
-     lambda r: 100 * r["num_solved"] / r["num_test_tasks"]),
+    ("perc_solved", lambda r: 100 * r["num_solved"] / r["num_test_tasks"]),
     ("perc_exec_fail",
      lambda r: 100 * r["num_execution_failures"] / r["num_test_tasks"]),
     ("perc_plan_fail",

--- a/scripts/create_interactive_predicate_learning_plots.py
+++ b/scripts/create_interactive_predicate_learning_plots.py
@@ -28,10 +28,15 @@ COLUMN_NAMES_AND_KEYS = [
     ("PERC_SOLVED", "perc_solved"),
     ("NUM_TRANSITIONS", "num_transitions"),
     ("QUERY_COST", "query_cost"),
+    ("NUM_EXECUTION_FAILURES", "num_execution_failures"),
+    ("NUM_PLANNING_FAILURES", "num_planning_failures"),
 ]
 
 DERIVED_KEYS = [("perc_solved",
-                 lambda r: 100 * r["num_solved"] / r["num_test_tasks"])]
+                 lambda r: 100 * r["num_solved"] / r["num_test_tasks"]),
+                ("num_planning_failures",
+                 lambda r: r["num_test_tasks"] - r["num_solved"] \
+                           - r["num_execution_failures"])]
 
 # The first element is the name of the metric that will be plotted on the
 # x axis. See COLUMN_NAMES_AND_KEYS for all available metrics. The second
@@ -44,6 +49,8 @@ X_KEY_AND_LABEL = [
 Y_KEY_AND_LABEL = [
     ("PERC_SOLVED", "% Evaluation Tasks Solved"),
     ("QUERY_COST", "Cumulative Query Cost"),
+    ("NUM_EXECUTION_FAILURES", "# Execution Failures"),
+    ("NUM_PLANNING_FAILURES", "# Planning Failures"),
 ]
 
 # PLOT_GROUPS is a nested dict where each outer dict corresponds to one plot,

--- a/scripts/create_interactive_predicate_learning_plots.py
+++ b/scripts/create_interactive_predicate_learning_plots.py
@@ -28,15 +28,18 @@ COLUMN_NAMES_AND_KEYS = [
     ("PERC_SOLVED", "perc_solved"),
     ("NUM_TRANSITIONS", "num_transitions"),
     ("QUERY_COST", "query_cost"),
-    ("NUM_EXECUTION_FAILURES", "num_execution_failures"),
-    ("NUM_PLANNING_FAILURES", "num_planning_failures"),
+    ("PERC_EXEC_FAIL", "perc_exec_fail"),
+    ("PERC_PLAN_FAIL", "perc_plan_fail"),
 ]
 
-DERIVED_KEYS = [("perc_solved",
-                 lambda r: 100 * r["num_solved"] / r["num_test_tasks"]),
-                ("num_planning_failures",
-                 lambda r: r["num_test_tasks"] - r["num_solved"] \
-                           - r["num_execution_failures"])]
+DERIVED_KEYS = [
+    ("perc_solved",
+     lambda r: 100 * r["num_solved"] / r["num_test_tasks"]),
+    ("perc_exec_fail",
+     lambda r: 100 * r["num_execution_failures"] / r["num_test_tasks"]),
+    ("perc_plan_fail",
+     lambda r: 100 * r["num_solve_failures"] / r["num_test_tasks"]),
+]
 
 # The first element is the name of the metric that will be plotted on the
 # x axis. See COLUMN_NAMES_AND_KEYS for all available metrics. The second
@@ -49,8 +52,8 @@ X_KEY_AND_LABEL = [
 Y_KEY_AND_LABEL = [
     ("PERC_SOLVED", "% Evaluation Tasks Solved"),
     ("QUERY_COST", "Cumulative Query Cost"),
-    ("NUM_EXECUTION_FAILURES", "# Execution Failures"),
-    ("NUM_PLANNING_FAILURES", "# Planning Failures"),
+    ("PERC_EXEC_FAIL", "% Execution Failures"),
+    ("PERC_PLAN_FAIL", "% Planning Failures"),
 ]
 
 # PLOT_GROUPS is a nested dict where each outer dict corresponds to one plot,
@@ -170,6 +173,8 @@ def _main() -> None:
                 ax.set_title(plot_title)
                 ax.set_xlabel(x_label)
                 ax.set_ylabel(y_label)
+                if y_key.startswith("PERC"):
+                    ax.set_ylim((-5, 105))
                 plt.tight_layout()
                 filename = f"{plot_title}_{x_key}_{y_key}.png"
                 filename = filename.replace(" ", "_").lower()

--- a/scripts/create_latex_tables.py
+++ b/scripts/create_latex_tables.py
@@ -18,7 +18,6 @@ GROUPS = [
     "APPROACH",
     "EXCLUDED_PREDICATES",
     "EXPERIMENT_ID",
-    # "NUM_TRAIN_TASKS", "CYCLE"
 ]
 
 # All column names and keys to load into the pandas tables.
@@ -28,23 +27,10 @@ COLUMN_NAMES_AND_KEYS = [
     ("EXCLUDED_PREDICATES", "excluded_predicates"),
     ("EXPERIMENT_ID", "experiment_id"),
     ("SEED", "seed"),
-    # ("NUM_TRAIN_TASKS", "num_train_tasks"),
-    # ("CYCLE", "cycle"),
-    # ("NUM_SOLVED", "num_solved"),
-    # ("AVG_NUM_PREDS", "avg_num_preds"),
     ("AVG_TEST_TIME", "avg_suc_time"),
     ("AVG_NODES_CREATED", "avg_num_nodes_created"),
     ("LEARNING_TIME", "learning_time"),
     ("PERC_SOLVED", "perc_solved"),
-    # ("AVG_SKELETONS", "avg_num_skeletons_optimized"),
-    # ("MIN_SKELETONS", "min_skeletons_optimized"),
-    # ("MAX_SKELETONS", "max_skeletons_optimized"),
-    # ("AVG_NODES_EXPANDED", "avg_num_nodes_expanded"),
-    # ("AVG_NUM_NSRTS", "avg_num_nsrts"),
-    # ("AVG_DISCOVERED_FAILURES", "avg_num_failures_discovered"),
-    # ("AVG_PLAN_LEN", "avg_plan_length"),
-    # ("AVG_EXECUTION_FAILURES", "avg_execution_failures"),
-    # ("NUM_TRANSITIONS", "num_transitions"),
 ]
 
 DERIVED_KEYS = [("perc_solved",

--- a/scripts/create_plots.py
+++ b/scripts/create_plots.py
@@ -40,15 +40,6 @@ COLUMN_NAMES_AND_KEYS = [
     ("AVG_NODES_CREATED", "avg_num_nodes_created"),
     ("LEARNING_TIME", "learning_time"),
     ("PERC_SOLVED", "perc_solved"),
-    # ("AVG_SKELETONS", "avg_num_skeletons_optimized"),
-    # ("MIN_SKELETONS", "min_skeletons_optimized"),
-    # ("MAX_SKELETONS", "max_skeletons_optimized"),
-    # ("AVG_NODES_EXPANDED", "avg_num_nodes_expanded"),
-    # ("AVG_NUM_NSRTS", "avg_num_nsrts"),
-    # ("AVG_DISCOVERED_FAILURES", "avg_num_failures_discovered"),
-    # ("AVG_PLAN_LEN", "avg_plan_length"),
-    # ("AVG_EXECUTION_FAILURES", "avg_execution_failures"),
-    # ("NUM_TRANSITIONS", "num_transitions"),
 ]
 
 DERIVED_KEYS = [("perc_solved",

--- a/src/main.py
+++ b/src/main.py
@@ -311,9 +311,7 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
             "min_num_skeletons_optimized"] < float("inf") else 0
     metrics["max_skeletons_optimized"] = approach.metrics[
         "max_num_skeletons_optimized"]
-    metrics["avg_execution_failures"] = (
-        total_num_execution_failures /
-        num_found_policy if num_found_policy > 0 else float("inf"))
+    metrics["num_execution_failures"] = total_num_execution_failures
     # Handle computing averages of total approach metrics wrt the
     # number of found policies. Note: this is different from computing
     # an average wrt the number of solved tasks, which might be more

--- a/src/main.py
+++ b/src/main.py
@@ -241,6 +241,7 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
     approach.reset_metrics()
     total_suc_time = 0.0
     total_num_execution_failures = 0
+    total_num_solve_failures = 0
     video_prefix = utils.get_config_path_str()
     for test_task_idx, task in enumerate(test_tasks):
         solve_start = time.time()
@@ -249,6 +250,7 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
         except (ApproachTimeout, ApproachFailure) as e:
             logging.info(f"Task {test_task_idx+1} / {len(test_tasks)}: "
                          f"Approach failed to solve with error: {e}")
+            total_num_solve_failures += 1
             if CFG.make_failure_videos and e.info.get("partial_refinements"):
                 video = utils.create_video_from_partial_refinements(
                     e.info["partial_refinements"], env, "test", test_task_idx,
@@ -312,6 +314,7 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
     metrics["max_skeletons_optimized"] = approach.metrics[
         "max_num_skeletons_optimized"]
     metrics["num_execution_failures"] = total_num_execution_failures
+    metrics["num_solve_failures"] = total_num_solve_failures
     # Handle computing averages of total approach metrics wrt the
     # number of found policies. Note: this is different from computing
     # an average wrt the number of solved tasks, which might be more


### PR DESCRIPTION
closes #729

also removed commented out / unused code from analysis scripts. to see what columns are available, we can refer to `analyze_results_directory.py`, we don't need them listed in the other files.

I tested the update to the interactive learning plot by running the "silent kid" command over 3 seeds and 1 learning cycle, and then ran the script. the plots from that are below. (the data are not meaningful, this just shows that the script runs and the axes are what we want.)

![coverenv_excluding_covers,holding_num_transitions_perc_plan_fail](https://user-images.githubusercontent.com/2816502/163815773-724a730a-a34a-4646-a610-cb3e6dd5e662.png)
![coverenv_excluding_covers,holding_num_transitions_perc_exec_fail](https://user-images.githubusercontent.com/2816502/163815776-d3aa9a8d-c4c1-4e18-92d8-3ba9ef5c9343.png)
![coverenv_excluding_covers,holding_num_transitions_query_cost](https://user-images.githubusercontent.com/2816502/163815777-da274823-19a9-4e92-b200-2dfd8c9e6af0.png)
![coverenv_excluding_covers,holding_num_transitions_perc_solved](https://user-images.githubusercontent.com/2816502/163815779-13d62cf2-3a0d-494b-b4b1-cdd134d005de.png)

