### PR TITLE
move two generic option creators into pybullet robot

### DIFF
--- a/src/envs/pybullet_env.py
+++ b/src/envs/pybullet_env.py
@@ -25,7 +25,7 @@ class PyBulletEnv(BaseEnv):
     # General robot parameters.
     _max_vel_norm: ClassVar[float] = 0.05
     _grasp_tol: ClassVar[float] = 0.05
-    _finger_action_tol: ClassVar[float] = 0.0001
+    _finger_action_tol: ClassVar[float] = 1e-4
 
     # Object parameters.
     _obj_mass: ClassVar[float] = 0.5

--- a/src/envs/pybullet_env.py
+++ b/src/envs/pybullet_env.py
@@ -4,8 +4,7 @@ Contains useful common code.
 """
 
 import abc
-from typing import Callable, ClassVar, Dict, List, Optional, Sequence, Tuple, \
-    cast
+from typing import ClassVar, List, Optional, Sequence, Tuple, cast
 
 import numpy as np
 import pybullet as p
@@ -15,8 +14,8 @@ from predicators.src import utils
 from predicators.src.envs import BaseEnv
 from predicators.src.envs.pybullet_robots import _SingleArmPyBulletRobot
 from predicators.src.settings import CFG
-from predicators.src.structs import Action, Array, Image, Object, \
-    ParameterizedOption, Pose3D, State, Task, Type
+from predicators.src.structs import Action, Array, Image, Pose3D, State, Task
+from predicators.src.utils import PyBulletState
 
 
 class PyBulletEnv(BaseEnv):
@@ -26,9 +25,7 @@ class PyBulletEnv(BaseEnv):
     # General robot parameters.
     _max_vel_norm: ClassVar[float] = 0.05
     _grasp_tol: ClassVar[float] = 0.05
-    _move_to_pose_tol: ClassVar[float] = 0.0001
     _finger_action_tol: ClassVar[float] = 0.0001
-    _finger_action_nudge_magnitude: ClassVar[float] = 0.001
 
     # Object parameters.
     _obj_mass: ClassVar[float] = 0.5
@@ -137,7 +134,7 @@ class PyBulletEnv(BaseEnv):
     def reset(self, train_or_test: str, task_idx: int) -> State:
         state = super().reset(train_or_test, task_idx)
         self._reset_state(state)
-        # Converts the State into a _PyBulletState.
+        # Converts the State into a PyBulletState.
         self._current_state = self._get_state()
         return self._current_state.copy()
 
@@ -302,7 +299,7 @@ class PyBulletEnv(BaseEnv):
 
     def _get_finger_state(self, state: State) -> float:
         # Arbitrarily use the left finger as reference.
-        state = cast(_PyBulletState, state)
+        state = cast(PyBulletState, state)
         joint_idx = self._pybullet_robot.left_finger_joint_idx
         return state.joint_state[joint_idx]
 
@@ -310,140 +307,6 @@ class PyBulletEnv(BaseEnv):
         finger_state = self._get_finger_state(self._current_state)
         target = action.arr[-1]
         return target - finger_state
-
-    def _create_move_end_effector_to_pose_option(
-        self,
-        name: str,
-        types: Sequence[Type],
-        params_space: Box,
-        get_current_and_target_pose_and_finger_status: Callable[
-            [State, Sequence[Object], Array], Tuple[Pose3D, Pose3D, str]],
-    ) -> ParameterizedOption:
-        """A generic utility that creates a ParameterizedOption for moving the
-        end effector to a target pose, given a function that takes in the
-        current state, objects, and parameters, and returns the current pose
-        and target pose of the end effector, and the finger status.
-
-        Fingers drift if left alone. When the fingers are not explicitly
-        being opened or closed, we nudge the fingers toward being open
-        or closed according to the finger status.
-        """
-
-        def _policy(state: State, memory: Dict, objects: Sequence[Object],
-                    params: Array) -> Action:
-            del memory  # unused
-            # First handle the main arm joints.
-            current, target, finger_status = \
-                get_current_and_target_pose_and_finger_status(
-                    state, objects, params)
-            # Run IK to determine the target joint positions.
-            ee_delta = np.subtract(target, current)
-            # Reduce the target to conform to the max velocity constraint.
-            ee_norm = np.linalg.norm(ee_delta)  # type: ignore
-            if ee_norm > self._max_vel_norm:
-                ee_delta = ee_delta * self._max_vel_norm / ee_norm
-            ee_action = np.add(current, ee_delta)
-            # We assume that the robot is already close enough to the target
-            # position that IK will succeed with one call, so validate is False.
-            # Furthermore, updating the state of the robot during simulation,
-            # which validate=True would do, is discouraged by PyBullet.
-            joint_state = self._pybullet_robot.run_inverse_kinematics(
-                (ee_action[0], ee_action[1], ee_action[2]), validate=False)
-            # Handle the fingers.
-            if finger_status == "open":
-                finger_delta = self._finger_action_nudge_magnitude
-            else:
-                assert finger_status == "closed"
-                finger_delta = -self._finger_action_nudge_magnitude
-            # Extract the current finger state from the simulator state.
-            finger_state = self._get_finger_state(state)
-            # The finger action is an absolute joint position for the fingers.
-            f_action = finger_state + finger_delta
-            # Override the meaningless finger values in joint_action.
-            joint_state[self._pybullet_robot.left_finger_joint_idx] = f_action
-            joint_state[self._pybullet_robot.right_finger_joint_idx] = f_action
-            action_arr = np.array(joint_state, dtype=np.float32)
-            # This clipping is needed sometimes for the finger joint limits.
-            action_arr = np.clip(action_arr, self.action_space.low,
-                                 self.action_space.high)
-            assert self.action_space.contains(action_arr)
-            return Action(action_arr)
-
-        def _terminal(state: State, memory: Dict, objects: Sequence[Object],
-                      params: Array) -> bool:
-            del memory  # unused
-            current, target, _ = \
-                get_current_and_target_pose_and_finger_status(
-                    state, objects, params)
-            squared_dist = np.sum(np.square(np.subtract(current, target)))
-            return squared_dist < self._move_to_pose_tol
-
-        return ParameterizedOption(name,
-                                   types=types,
-                                   params_space=params_space,
-                                   policy=_policy,
-                                   initiable=lambda _1, _2, _3, _4: True,
-                                   terminal=_terminal)
-
-    def _create_change_fingers_option(
-        self, name: str, types: Sequence[Type], params_space: Box,
-        get_current_and_target_val: Callable[[State, Sequence[Object], Array],
-                                             Tuple[float, float]]
-    ) -> ParameterizedOption:
-        """A generic utility that creates a ParameterizedOption for changing
-        the robot fingers, given a function that takes in the current state,
-        objects, and parameters, and returns the current and target finger
-        joint values."""
-
-        def _policy(state: State, memory: Dict, objects: Sequence[Object],
-                    params: Array) -> Action:
-            del memory  # unused
-            current_val, target_val = get_current_and_target_val(
-                state, objects, params)
-            f_delta = target_val - current_val
-            f_delta = np.clip(f_delta, -self._max_vel_norm, self._max_vel_norm)
-            f_action = current_val + f_delta
-            # Don't change the rest of the joints.
-            state = cast(_PyBulletState, state)
-            target = np.array(state.joint_state, dtype=np.float32)
-            target[self._pybullet_robot.left_finger_joint_idx] = f_action
-            target[self._pybullet_robot.right_finger_joint_idx] = f_action
-            assert self.action_space.contains(target)
-            return Action(target)
-
-        def _terminal(state: State, memory: Dict, objects: Sequence[Object],
-                      params: Array) -> bool:
-            del memory  # unused
-            current_val, target_val = get_current_and_target_val(
-                state, objects, params)
-            squared_dist = (target_val - current_val)**2
-            return squared_dist < self._grasp_tol
-
-        return ParameterizedOption(name,
-                                   types=types,
-                                   params_space=params_space,
-                                   policy=_policy,
-                                   initiable=lambda _1, _2, _3, _4: True,
-                                   terminal=_terminal)
-
-
-class _PyBulletState(State):
-    """A PyBullet state that stores the robot joint states in addition to the
-    features that are exposed in the object-centric state."""
-
-    @property
-    def joint_state(self) -> Sequence[float]:
-        """Expose the current joint state in the simulator_state."""
-        return cast(Sequence[float], self.simulator_state)
-
-    def allclose(self, other: State) -> bool:
-        # Ignores the simulator state.
-        return State(self.data).allclose(State(other.data))
-
-    def copy(self) -> State:
-        state_dict_copy = super().copy().data
-        simulator_state_copy = list(self.joint_state)
-        return _PyBulletState(state_dict_copy, simulator_state_copy)
 
 
 def create_pybullet_block(color: Tuple[float, float, float, float],

--- a/src/envs/pybullet_robots.py
+++ b/src/envs/pybullet_robots.py
@@ -1,7 +1,7 @@
 """Interfaces to PyBullet robots."""
 
 import abc
-from typing import ClassVar, List, Sequence
+from typing import Callable, ClassVar, Dict, List, Sequence, Tuple, cast
 
 import numpy as np
 import pybullet as p
@@ -9,7 +9,8 @@ from gym.spaces import Box
 
 from predicators.src import utils
 from predicators.src.settings import CFG
-from predicators.src.structs import Array, Pose3D
+from predicators.src.structs import Action, Array, Object, \
+    ParameterizedOption, Pose3D, State, Type
 
 
 class _SingleArmPyBulletRobot(abc.ABC):
@@ -22,7 +23,7 @@ class _SingleArmPyBulletRobot(abc.ABC):
     """
 
     def __init__(self, ee_home_pose: Pose3D, open_fingers: float,
-                 closed_fingers: float, max_vel_norm: float,
+                 closed_fingers: float, max_vel_norm: float, grasp_tol: float,
                  physics_client_id: int) -> None:
         # Initial position for the end effector.
         self._ee_home_pose = ee_home_pose
@@ -32,6 +33,8 @@ class _SingleArmPyBulletRobot(abc.ABC):
         self._closed_fingers = closed_fingers
         # Used for the action space.
         self._max_vel_norm = max_vel_norm
+        # Used for detecting when an object is considered grasped.
+        self._grasp_tol = grasp_tol
         self._physics_client_id = physics_client_id
         # These get overridden in initialize(), but type checking needs to be
         # aware that it exists.
@@ -133,9 +136,30 @@ class _SingleArmPyBulletRobot(abc.ABC):
         raise NotImplementedError("Override me!")
 
     @abc.abstractmethod
-    def run_inverse_kinematics(self, end_effector_pose: Pose3D,
-                               validate: bool) -> List[float]:
-        """Run inverse kinematics."""
+    def create_move_end_effector_to_pose_option(
+        self,
+        name: str,
+        types: Sequence[Type],
+        params_space: Box,
+        get_current_and_target_pose_and_finger_status: Callable[
+            [State, Sequence[Object], Array], Tuple[Pose3D, Pose3D, str]],
+    ) -> ParameterizedOption:
+        """A generic utility that creates a ParameterizedOption for moving the
+        end effector to a target pose, given a function that takes in the
+        current state, objects, and parameters, and returns the current pose
+        and target pose of the end effector, and the finger status."""
+        raise NotImplementedError("Override me!")
+
+    @abc.abstractmethod
+    def create_change_fingers_option(
+        self, name: str, types: Sequence[Type], params_space: Box,
+        get_current_and_target_val: Callable[[State, Sequence[Object], Array],
+                                             Tuple[float, float]]
+    ) -> ParameterizedOption:
+        """A generic utility that creates a ParameterizedOption for changing
+        the robot fingers, given a function that takes in the current state,
+        objects, and parameters, and returns the current and target finger
+        joint values."""
         raise NotImplementedError("Override me!")
 
 
@@ -146,6 +170,8 @@ class FetchPyBulletRobot(_SingleArmPyBulletRobot):
     _base_pose: ClassVar[Pose3D] = (0.75, 0.7441, 0.0)
     _base_orientation: ClassVar[Sequence[float]] = [0., 0., 0., 1.]
     _ee_orientation: ClassVar[Sequence[float]] = [1., 0., -1., 0.]
+    _finger_action_nudge_magnitude: ClassVar[float] = 0.001
+    _move_to_pose_tol: ClassVar[float] = 0.0001
 
     def _initialize(self) -> None:
         self._fetch_id = p.loadURDF(
@@ -177,7 +203,7 @@ class FetchPyBulletRobot(_SingleArmPyBulletRobot):
         self._arm_joints.append(self._left_finger_id)
         self._arm_joints.append(self._right_finger_id)
 
-        self._initial_joint_values = self.run_inverse_kinematics(
+        self._initial_joint_values = self._run_inverse_kinematics(
             self._ee_home_pose, validate=True)
         # The initial joint values for the fingers should be open. IK may
         # return anything for them.
@@ -284,8 +310,8 @@ class FetchPyBulletRobot(_SingleArmPyBulletRobot):
                                     targetPosition=joint_val,
                                     physicsClientId=self._physics_client_id)
 
-    def run_inverse_kinematics(self, end_effector_pose: Pose3D,
-                               validate: bool) -> List[float]:
+    def _run_inverse_kinematics(self, end_effector_pose: Pose3D,
+                                validate: bool) -> List[float]:
         return inverse_kinematics(self._fetch_id,
                                   self._ee_id,
                                   end_effector_pose,
@@ -294,15 +320,124 @@ class FetchPyBulletRobot(_SingleArmPyBulletRobot):
                                   physics_client_id=self._physics_client_id,
                                   validate=validate)
 
+    def create_move_end_effector_to_pose_option(
+        self,
+        name: str,
+        types: Sequence[Type],
+        params_space: Box,
+        get_current_and_target_pose_and_finger_status: Callable[
+            [State, Sequence[Object], Array], Tuple[Pose3D, Pose3D, str]],
+    ) -> ParameterizedOption:
+        """Fingers drift if left alone.
+
+        When the fingers are not explicitly being opened or closed, we
+        nudge the fingers toward being open or closed according to the
+        finger status.
+        """
+
+        def _policy(state: State, memory: Dict, objects: Sequence[Object],
+                    params: Array) -> Action:
+            del memory  # unused
+            # First handle the main arm joints.
+            current, target, finger_status = \
+                get_current_and_target_pose_and_finger_status(
+                    state, objects, params)
+            # Run IK to determine the target joint positions.
+            ee_delta = np.subtract(target, current)
+            # Reduce the target to conform to the max velocity constraint.
+            ee_norm = np.linalg.norm(ee_delta)  # type: ignore
+            if ee_norm > self._max_vel_norm:
+                ee_delta = ee_delta * self._max_vel_norm / ee_norm
+            ee_action = np.add(current, ee_delta)
+            # We assume that the robot is already close enough to the target
+            # position that IK will succeed with one call, so validate is False.
+            # Furthermore, updating the state of the robot during simulation,
+            # which validate=True would do, is discouraged by PyBullet.
+            joint_state = self._run_inverse_kinematics(
+                (ee_action[0], ee_action[1], ee_action[2]), validate=False)
+            # Handle the fingers.
+            if finger_status == "open":
+                finger_delta = self._finger_action_nudge_magnitude
+            else:
+                assert finger_status == "closed"
+                finger_delta = -self._finger_action_nudge_magnitude
+            # Extract the current finger state.
+            state = cast(utils.PyBulletState, state)
+            finger_state = state.joint_state[self.left_finger_joint_idx]
+            # The finger action is an absolute joint position for the fingers.
+            f_action = finger_state + finger_delta
+            # Override the meaningless finger values in joint_action.
+            joint_state[self.left_finger_joint_idx] = f_action
+            joint_state[self.right_finger_joint_idx] = f_action
+            action_arr = np.array(joint_state, dtype=np.float32)
+            # This clipping is needed sometimes for the finger joint limits.
+            action_arr = np.clip(action_arr, self.action_space.low,
+                                 self.action_space.high)
+            assert self.action_space.contains(action_arr)
+            return Action(action_arr)
+
+        def _terminal(state: State, memory: Dict, objects: Sequence[Object],
+                      params: Array) -> bool:
+            del memory  # unused
+            current, target, _ = \
+                get_current_and_target_pose_and_finger_status(
+                    state, objects, params)
+            squared_dist = np.sum(np.square(np.subtract(current, target)))
+            return squared_dist < self._move_to_pose_tol
+
+        return ParameterizedOption(name,
+                                   types=types,
+                                   params_space=params_space,
+                                   policy=_policy,
+                                   initiable=lambda _1, _2, _3, _4: True,
+                                   terminal=_terminal)
+
+    def create_change_fingers_option(
+        self, name: str, types: Sequence[Type], params_space: Box,
+        get_current_and_target_val: Callable[[State, Sequence[Object], Array],
+                                             Tuple[float, float]]
+    ) -> ParameterizedOption:
+
+        def _policy(state: State, memory: Dict, objects: Sequence[Object],
+                    params: Array) -> Action:
+            del memory  # unused
+            current_val, target_val = get_current_and_target_val(
+                state, objects, params)
+            f_delta = target_val - current_val
+            f_delta = np.clip(f_delta, -self._max_vel_norm, self._max_vel_norm)
+            f_action = current_val + f_delta
+            # Don't change the rest of the joints.
+            state = cast(utils.PyBulletState, state)
+            target = np.array(state.joint_state, dtype=np.float32)
+            target[self.left_finger_joint_idx] = f_action
+            target[self.right_finger_joint_idx] = f_action
+            assert self.action_space.contains(target)
+            return Action(target)
+
+        def _terminal(state: State, memory: Dict, objects: Sequence[Object],
+                      params: Array) -> bool:
+            del memory  # unused
+            current_val, target_val = get_current_and_target_val(
+                state, objects, params)
+            squared_dist = (target_val - current_val)**2
+            return squared_dist < self._grasp_tol
+
+        return ParameterizedOption(name,
+                                   types=types,
+                                   params_space=params_space,
+                                   policy=_policy,
+                                   initiable=lambda _1, _2, _3, _4: True,
+                                   terminal=_terminal)
+
 
 def create_single_arm_pybullet_robot(
         robot_name: str, ee_home_pose: Pose3D, open_fingers: float,
-        closed_fingers: float, max_vel_norm: float,
+        closed_fingers: float, max_vel_norm: float, grasp_tol: float,
         physics_client_id: int) -> _SingleArmPyBulletRobot:
     """Create a single-arm PyBullet robot."""
     if robot_name == "fetch":
         return FetchPyBulletRobot(ee_home_pose, open_fingers, closed_fingers,
-                                  max_vel_norm, physics_client_id)
+                                  max_vel_norm, grasp_tol, physics_client_id)
     raise NotImplementedError(f"Unrecognized robot name: {robot_name}.")
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -520,6 +520,25 @@ class SingletonParameterizedOption(ParameterizedOption):
                          terminal=_terminal)
 
 
+class PyBulletState(State):
+    """A PyBullet state that stores the robot joint states in addition to the
+    features that are exposed in the object-centric state."""
+
+    @property
+    def joint_state(self) -> Sequence[float]:
+        """Expose the current joint state in the simulator_state."""
+        return cast(Sequence[float], self.simulator_state)
+
+    def allclose(self, other: State) -> bool:
+        # Ignores the simulator state.
+        return State(self.data).allclose(State(other.data))
+
+    def copy(self) -> State:
+        state_dict_copy = super().copy().data
+        simulator_state_copy = list(self.joint_state)
+        return PyBulletState(state_dict_copy, simulator_state_copy)
+
+
 class Monitor(abc.ABC):
     """Observes states and actions during environment interaction."""
 

--- a/tests/envs/test_pybullet_blocks.py
+++ b/tests/envs/test_pybullet_blocks.py
@@ -5,7 +5,7 @@ import pytest
 
 from predicators.src import utils
 from predicators.src.envs.pybullet_blocks import PyBulletBlocksEnv, \
-    _PyBulletState
+    PyBulletState
 from predicators.src.settings import CFG
 from predicators.src.structs import Object, State
 from predicators.tests.conftest import longrun
@@ -52,8 +52,7 @@ class _ExposedPyBulletBlocksEnv(PyBulletBlocksEnv):
         kinematics here.
         """
         joint_state = list(self._pybullet_robot.initial_joint_values)
-        state_with_sim = _PyBulletState(state.data,
-                                        simulator_state=joint_state)
+        state_with_sim = PyBulletState(state.data, simulator_state=joint_state)
         self._current_state = state_with_sim
         self._current_task = None
         self._reset_state(state_with_sim)

--- a/tests/envs/test_pybullet_robots.py
+++ b/tests/envs/test_pybullet_robots.py
@@ -159,8 +159,9 @@ def test_fetch_pybullet_robot():
     open_fingers = 0.04
     closed_fingers = 0.01
     max_vel_norm = 0.05
+    grasp_tol = 0.05
     robot = FetchPyBulletRobot(ee_home_pose, open_fingers, closed_fingers,
-                               max_vel_norm, physics_client_id)
+                               max_vel_norm, grasp_tol, physics_client_id)
     assert np.allclose(robot.action_space.low, robot.joint_lower_limits)
     assert np.allclose(robot.action_space.high, robot.joint_upper_limits)
     # The robot arm is 7 DOF and the left and right fingers are appended last.
@@ -177,7 +178,7 @@ def test_fetch_pybullet_robot():
 
     ee_delta = (-0.01, 0.0, 0.01)
     ee_target = np.add(ee_home_pose, ee_delta)
-    joint_target = robot.run_inverse_kinematics(ee_target, validate=False)
+    joint_target = robot._run_inverse_kinematics(ee_target, validate=False)  # pylint: disable=protected-access
     f_value = 0.03
     joint_target[robot.left_finger_joint_idx] = f_value
     joint_target[robot.right_finger_joint_idx] = f_value
@@ -198,11 +199,14 @@ def test_create_single_arm_pybullet_robot():
     open_fingers = 0.04
     closed_fingers = 0.01
     max_vel_norm = 0.05
+    grasp_tol = 0.05
     robot = create_single_arm_pybullet_robot("fetch", ee_home_pose,
                                              open_fingers, closed_fingers,
-                                             max_vel_norm, physics_client_id)
+                                             max_vel_norm, grasp_tol,
+                                             physics_client_id)
     assert isinstance(robot, FetchPyBulletRobot)
     with pytest.raises(NotImplementedError):
         create_single_arm_pybullet_robot("not a real robot", ee_home_pose,
                                          open_fingers, closed_fingers,
-                                         max_vel_norm, physics_client_id)
+                                         max_vel_norm, grasp_tol,
+                                         physics_client_id)


### PR DESCRIPTION
this is so that the panda can run IK once and motion plan, if it wants to, but the fetch can still run IK at every time step, which appears to be more stable and effective.