### PR TITLE
fix `has_option` for loading

### DIFF
--- a/src/structs.py
+++ b/src/structs.py
@@ -950,7 +950,7 @@ class Action:
 
     def has_option(self) -> bool:
         """Whether this action has a non-default option attached."""
-        return self._option.name != DummyOption.name
+        return self._option.parent != DummyOption.parent
 
     def get_option(self) -> _Option:
         """Get the option that produced this action."""
@@ -1100,7 +1100,7 @@ class Segment:
 
     def has_option(self) -> bool:
         """Whether this segment has a non-default option attached."""
-        return self._option.name != DummyOption.name
+        return self._option.parent != DummyOption.parent
 
     def get_option(self) -> _Option:
         """Get the option that produced this segment."""

--- a/src/structs.py
+++ b/src/structs.py
@@ -950,7 +950,7 @@ class Action:
 
     def has_option(self) -> bool:
         """Whether this action has a non-default option attached."""
-        return self._option is not DummyOption
+        return self._option.name != DummyOption.name
 
     def get_option(self) -> _Option:
         """Get the option that produced this action."""
@@ -1100,7 +1100,7 @@ class Segment:
 
     def has_option(self) -> bool:
         """Whether this segment has a non-default option attached."""
-        return self._option is not DummyOption
+        return self._option.name != DummyOption.name
 
     def get_option(self) -> _Option:
         """Get the option that produced this segment."""


### PR DESCRIPTION
if we save data that has no options (dummy options) and then load a dataset, `has_option` incorrectly reports True, because the `DummyOption` instance is different now, because it's a different Python process.

I looked for other similar cases in the code and didn't see any. there are a few other instances of `is DummyOption`, but those look correct, because they could only refer to the dummy option for the current process.