### PR TITLE
add `min_perc_data_for_nsrt` flag

### DIFF
--- a/src/nsrt_learning/strips_learning/base_strips_learner.py
+++ b/src/nsrt_learning/strips_learning/base_strips_learner.py
@@ -30,6 +30,7 @@ class BaseSTRIPSLearner(abc.ABC):
         self._segmented_trajs = segmented_trajs
         self._verify_harmlessness = verify_harmlessness
         self._verbose = verbose
+        self._num_segments = sum(len(t) for t in segmented_trajs)
         assert len(self._trajectories) == len(self._segmented_trajs)
 
     def learn(self) -> List[PartialNSRTAndDatastore]:
@@ -43,9 +44,10 @@ class BaseSTRIPSLearner(abc.ABC):
         learned_pnads = self._learn()
         if self._verify_harmlessness and not CFG.disable_harmlessness_check:
             assert self._check_harmlessness(learned_pnads)
+        min_data = max(CFG.min_data_for_nsrt,
+                       self._num_segments * CFG.min_perc_data_for_nsrt / 100)
         learned_pnads = [
-            pnad for pnad in learned_pnads
-            if len(pnad.datastore) >= CFG.min_data_for_nsrt
+            pnad for pnad in learned_pnads if len(pnad.datastore) >= min_data
         ]
         return learned_pnads
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -173,6 +173,7 @@ class GlobalSettings:
 
     # NSRT learning parameters
     min_data_for_nsrt = 0
+    min_perc_data_for_nsrt = 0
     # STRIPS learning algorithm. See nsrt_learning/strips_learning/__init__.py
     # for valid settings.
     strips_learner = "cluster_and_intersect"

--- a/tests/nsrt_learning/test_nsrt_learning_main.py
+++ b/tests/nsrt_learning/test_nsrt_learning_main.py
@@ -14,6 +14,7 @@ def test_nsrt_learning_specific_nsrts():
     """Tests with a specific desired set of NSRTs."""
     utils.reset_config({
         "min_data_for_nsrt": 0,
+        "min_perc_data_for_nsrt": 0,
         "sampler_mlp_classifier_max_itr": 1000,
         "neural_gaus_regressor_max_itr": 1000
     })
@@ -195,14 +196,20 @@ def test_nsrt_learning_specific_nsrts():
     for nsrt in nsrts:
         assert str(nsrt) == expected[nsrt.name]
     # Test minimum number of examples parameter
-    utils.update_config({"min_data_for_nsrt": 3})
+    utils.update_config({
+        "min_data_for_nsrt": 3,
+        "min_perc_data_for_nsrt": 0,
+    })
     nsrts = learn_nsrts_from_data(dataset, [],
                                   preds,
                                   action_space,
                                   sampler_learner="random")
     assert len(nsrts) == 0
     # Test minimum percent of examples parameter
-    utils.update_config({"min_perc_data_for_nsrt": 50})
+    utils.update_config({
+        "min_data_for_nsrt": 0,
+        "min_perc_data_for_nsrt": 90,
+    })
     nsrts = learn_nsrts_from_data(dataset, [],
                                   preds,
                                   action_space,
@@ -211,6 +218,7 @@ def test_nsrt_learning_specific_nsrts():
     # Test max_rejection_sampling_tries = 0
     utils.update_config({
         "min_data_for_nsrt": 0,
+        "min_perc_data_for_nsrt": 0,
         "max_rejection_sampling_tries": 0,
         "sampler_mlp_classifier_max_itr": 1,
         "neural_gaus_regressor_max_itr": 1

--- a/tests/nsrt_learning/test_nsrt_learning_main.py
+++ b/tests/nsrt_learning/test_nsrt_learning_main.py
@@ -201,6 +201,13 @@ def test_nsrt_learning_specific_nsrts():
                                   action_space,
                                   sampler_learner="random")
     assert len(nsrts) == 0
+    # Test minimum percent of examples parameter
+    utils.update_config({"min_perc_data_for_nsrt": 50})
+    nsrts = learn_nsrts_from_data(dataset, [],
+                                  preds,
+                                  action_space,
+                                  sampler_learner="random")
+    assert len(nsrts) == 0
     # Test max_rejection_sampling_tries = 0
     utils.update_config({
         "min_data_for_nsrt": 0,


### PR DESCRIPTION
when running experiments that vary the number of training data, it's easier to specify this new flag instead of `min_data_for_nsrt`. but I think we should still leave the old flag since it's useful for testing and is currently being used in a number of @amburger66 's scripts.