### PR TITLE
nonparameterized direct bc option learning

### DIFF
--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -148,6 +148,12 @@ def test_neural_option_learning():
                        "implicit_mlp_regressor_num_negative_data_per_input": 1,
                        "implicit_mlp_regressor_num_samples_per_inference": 1,
                    })
+    _test_approach(env_name="touch_point",
+                   approach_name="nsrt_learning",
+                   try_solving=False,
+                   sampler_learner="random",
+                   option_learner="direct_bc_nonparameterized",
+                   check_solution=False)
 
 
 def test_oracle_samplers():


### PR DESCRIPTION
closes #737 

example usage:
```
python src/main.py --approach nsrt_learning --env stick_point --seed 0 --option_learner direct_bc_nonparameterized --num_train_tasks 500 --min_perc_data_for_nsrt 1 --segmenter oracle
```

preliminary tests suggest that this baseline is actually doing very well in stick point, suggesting we may need to rethink some things there...