### PR TITLE
updates to stick point ground truth operators

### DIFF
--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -1993,10 +1993,9 @@ def _get_stick_point_gt_nsrts() -> Set[NSRT]:
     }
     delete_effects = {LiftedAtom(NoPointInContact, [])}
     side_predicates: Set[Predicate] = {InContactRobotPoint}
-    robot_touch_point_nsrt = NSRT("RobotTouchPoint", parameters,
-                                  preconditions, add_effects, delete_effects,
-                                  side_predicates, option, option_vars,
-                                  null_sampler)
+    robot_touch_point_nsrt = NSRT("RobotTouchPoint", parameters, preconditions,
+                                  add_effects, delete_effects, side_predicates,
+                                  option, option_vars, null_sampler)
     nsrts.add(robot_touch_point_nsrt)
 
     # PickStick
@@ -2024,9 +2023,9 @@ def _get_stick_point_gt_nsrts() -> Set[NSRT]:
         pick_pos = rng.uniform(0, 1)
         return np.array([pick_pos], dtype=np.float32)
 
-    pick_stick_nsrt = NSRT("PickStick", parameters, preconditions,
-                           add_effects, delete_effects, side_predicates,
-                           option, option_vars, pick_stick_sampler)
+    pick_stick_nsrt = NSRT("PickStick", parameters, preconditions, add_effects,
+                           delete_effects, side_predicates, option,
+                           option_vars, pick_stick_sampler)
     nsrts.add(pick_stick_nsrt)
 
     # StickTouchPoint
@@ -2045,9 +2044,9 @@ def _get_stick_point_gt_nsrts() -> Set[NSRT]:
     }
     delete_effects = {LiftedAtom(NoPointInContact, [])}
     side_predicates = {InContactStickPoint}
-    stick_point_nsrt = NSRT("StickTouchPoint", parameters,
-                            preconditions, add_effects, delete_effects,
-                            side_predicates, option, option_vars, null_sampler)
+    stick_point_nsrt = NSRT("StickTouchPoint", parameters, preconditions,
+                            add_effects, delete_effects, side_predicates,
+                            option, option_vars, null_sampler)
     nsrts.add(stick_point_nsrt)
 
     return nsrts

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -1978,7 +1978,7 @@ def _get_stick_point_gt_nsrts() -> Set[NSRT]:
 
     nsrts = set()
 
-    # RobotTouchPointFromNothing
+    # RobotTouchPoint
     robot = Variable("?robot", robot_type)
     point = Variable("?point", point_type)
     parameters = [robot, point]
@@ -1986,44 +1986,20 @@ def _get_stick_point_gt_nsrts() -> Set[NSRT]:
     option = RobotTouchPoint
     preconditions = {
         LiftedAtom(HandEmpty, [robot]),
-        LiftedAtom(NoPointInContact, []),
     }
     add_effects = {
         LiftedAtom(Touched, [point]),
         LiftedAtom(InContactRobotPoint, [robot, point])
     }
     delete_effects = {LiftedAtom(NoPointInContact, [])}
-    side_predicates: Set[Predicate] = set()
-    robot_touch_point_nsrt = NSRT("RobotTouchPointFromNothing", parameters,
+    side_predicates: Set[Predicate] = {InContactRobotPoint}
+    robot_touch_point_nsrt = NSRT("RobotTouchPoint", parameters,
                                   preconditions, add_effects, delete_effects,
                                   side_predicates, option, option_vars,
                                   null_sampler)
     nsrts.add(robot_touch_point_nsrt)
 
-    # RobotTouchPointFromPoint
-    robot = Variable("?robot", robot_type)
-    point = Variable("?point", point_type)
-    from_point = Variable("?from-point", point_type)
-    parameters = [robot, point, from_point]
-    option_vars = [robot, point]
-    option = RobotTouchPoint
-    preconditions = {
-        LiftedAtom(HandEmpty, [robot]),
-        LiftedAtom(InContactRobotPoint, [robot, from_point]),
-    }
-    add_effects = {
-        LiftedAtom(Touched, [point]),
-        LiftedAtom(InContactRobotPoint, [robot, point])
-    }
-    delete_effects = {LiftedAtom(InContactRobotPoint, [robot, from_point])}
-    side_predicates = set()
-    robot_touch_point_nsrt = NSRT("RobotTouchPointFromPoint", parameters,
-                                  preconditions, add_effects, delete_effects,
-                                  side_predicates, option, option_vars,
-                                  null_sampler)
-    nsrts.add(robot_touch_point_nsrt)
-
-    # PickStickFromNothing
+    # PickStick
     robot = Variable("?robot", robot_type)
     stick = Variable("?stick", stick_type)
     parameters = [robot, stick]
@@ -2031,14 +2007,13 @@ def _get_stick_point_gt_nsrts() -> Set[NSRT]:
     option = PickStick
     preconditions = {
         LiftedAtom(HandEmpty, [robot]),
-        LiftedAtom(NoPointInContact, []),
     }
     add_effects = {
         LiftedAtom(Grasped, [robot, stick]),
         LiftedAtom(InContactRobotStick, [robot, stick])
     }
     delete_effects = {LiftedAtom(HandEmpty, [robot])}
-    side_predicates = set()
+    side_predicates = {NoPointInContact, InContactRobotPoint}
 
     def pick_stick_sampler(state: State, goal: Set[GroundAtom],
                            rng: np.random.Generator,
@@ -2049,38 +2024,12 @@ def _get_stick_point_gt_nsrts() -> Set[NSRT]:
         pick_pos = rng.uniform(0, 1)
         return np.array([pick_pos], dtype=np.float32)
 
-    pick_stick_nsrt = NSRT("PickStickFromNothing", parameters, preconditions,
+    pick_stick_nsrt = NSRT("PickStick", parameters, preconditions,
                            add_effects, delete_effects, side_predicates,
                            option, option_vars, pick_stick_sampler)
     nsrts.add(pick_stick_nsrt)
 
-    # PickStickFromPoint
-    robot = Variable("?robot", robot_type)
-    stick = Variable("?stick", stick_type)
-    point = Variable("?from-point", point_type)
-    parameters = [robot, stick, point]
-    option_vars = [robot, stick]
-    option = PickStick
-    preconditions = {
-        LiftedAtom(HandEmpty, [robot]),
-        LiftedAtom(InContactRobotPoint, [robot, point])
-    }
-    add_effects = {
-        LiftedAtom(Grasped, [robot, stick]),
-        LiftedAtom(InContactRobotStick, [robot, stick]),
-        LiftedAtom(NoPointInContact, [])
-    }
-    delete_effects = {
-        LiftedAtom(HandEmpty, [robot]),
-        LiftedAtom(InContactRobotPoint, [robot, point]),
-    }
-    side_predicates = set()
-    pick_stick_nsrt = NSRT("PickStickFromPoint", parameters, preconditions,
-                           add_effects, delete_effects, side_predicates,
-                           option, option_vars, pick_stick_sampler)
-    nsrts.add(pick_stick_nsrt)
-
-    # StickTouchPointFromNothing
+    # StickTouchPoint
     robot = Variable("?robot", robot_type)
     stick = Variable("?stick", stick_type)
     point = Variable("?point", point_type)
@@ -2089,38 +2038,14 @@ def _get_stick_point_gt_nsrts() -> Set[NSRT]:
     option = StickTouchPoint
     preconditions = {
         LiftedAtom(Grasped, [robot, stick]),
-        LiftedAtom(NoPointInContact, []),
     }
     add_effects = {
         LiftedAtom(InContactStickPoint, [stick, point]),
         LiftedAtom(Touched, [point])
     }
     delete_effects = {LiftedAtom(NoPointInContact, [])}
-    side_predicates = set()
-    stick_point_nsrt = NSRT("StickTouchPointFromNothing", parameters,
-                            preconditions, add_effects, delete_effects,
-                            side_predicates, option, option_vars, null_sampler)
-    nsrts.add(stick_point_nsrt)
-
-    # StickTouchPointFromPoint
-    robot = Variable("?robot", robot_type)
-    stick = Variable("?stick", stick_type)
-    point = Variable("?point", point_type)
-    from_point = Variable("?from-point", point_type)
-    parameters = [robot, stick, point, from_point]
-    option_vars = [robot, stick, point]
-    option = StickTouchPoint
-    preconditions = {
-        LiftedAtom(Grasped, [robot, stick]),
-        LiftedAtom(InContactStickPoint, [stick, from_point])
-    }
-    add_effects = {
-        LiftedAtom(InContactStickPoint, [stick, point]),
-        LiftedAtom(Touched, [point])
-    }
-    delete_effects = {LiftedAtom(InContactStickPoint, [stick, from_point])}
-    side_predicates = set()
-    stick_point_nsrt = NSRT("StickTouchPointFromPoint", parameters,
+    side_predicates = {InContactStickPoint}
+    stick_point_nsrt = NSRT("StickTouchPoint", parameters,
                             preconditions, add_effects, delete_effects,
                             side_predicates, option, option_vars, null_sampler)
     nsrts.add(stick_point_nsrt)


### PR DESCRIPTION
it seems that our previous changes to backchaining (#769) magically fixed backchaining in the stick point env. this leads us to be able to run, e.g.:
`python src/main.py --env stick_point --approach nsrt_learning --seed 0 --strips_learner backchaining`
which produces the following learned operators:
```
NSRT-PickStick0:
    Parameters: [?x0:robot, ?x1:stick]
    Preconditions: [HandEmpty(?x0:robot)]
    Add Effects: [Grasped(?x0:robot, ?x1:stick), InContactRobotStick(?x0:robot, ?x1:stick)]
    Delete Effects: [HandEmpty(?x0:robot)]
    Side Predicates: [InContactRobotPoint, NoPointInContact]
    Option Spec: PickStick(?x0:robot, ?x1:stick)
NSRT-RobotTouchPoint0:
    Parameters: [?x0:robot, ?x1:point]
    Preconditions: [HandEmpty(?x0:robot)]
    Add Effects: [Touched(?x1:point)]
    Delete Effects: [NoPointInContact()]
    Side Predicates: [InContactRobotPoint]
    Option Spec: RobotTouchPoint(?x0:robot, ?x1:point)
NSRT-StickTouchPoint0:
    Parameters: [?x0:robot, ?x1:stick, ?x2:point]
    Preconditions: [Grasped(?x0:robot, ?x1:stick), InContactRobotStick(?x0:robot, ?x1:stick)]
    Add Effects: [Touched(?x2:point)]
    Delete Effects: [NoPointInContact()]
    Side Predicates: [InContactStickPoint]
    Option Spec: StickTouchPoint(?x0:robot, ?x1:stick, ?x2:point)
```

Using this as guidance, I changed the oracle operators to the following:
```
NSRT-PickStick:
    Parameters: [?robot:robot, ?stick:stick]
    Preconditions: [HandEmpty(?robot:robot)]
    Add Effects: [Grasped(?robot:robot, ?stick:stick), InContactRobotStick(?robot:robot, ?stick:stick)]
    Delete Effects: [HandEmpty(?robot:robot)]
    Side Predicates: [InContactRobotPoint, NoPointInContact]
    Option Spec: PickStick(?robot:robot, ?stick:stick)
NSRT-RobotTouchPoint:
    Parameters: [?robot:robot, ?point:point]
    Preconditions: [HandEmpty(?robot:robot)]
    Add Effects: [InContactRobotPoint(?robot:robot, ?point:point), Touched(?point:point)]
    Delete Effects: [NoPointInContact()]
    Side Predicates: [InContactRobotPoint]
    Option Spec: RobotTouchPoint(?robot:robot, ?point:point)
NSRT-StickTouchPoint:
    Parameters: [?robot:robot, ?stick:stick, ?point:point]
    Preconditions: [Grasped(?robot:robot, ?stick:stick)]
    Add Effects: [InContactStickPoint(?stick:stick, ?point:point), Touched(?point:point)]
    Delete Effects: [NoPointInContact()]
    Side Predicates: [InContactStickPoint]
    Option Spec: StickTouchPoint(?robot:robot, ?stick:stick, ?point:point)
```

Here are the differences:
* In oracle, `RobotTouchPoint` includes an extra add effect `InContactRobotPoint(?robot:robot, ?point:point)`. This is a reasonable add effect, so I wanted to include it, but backchaining wouldn't learn it because it's never in the necessary image.
* Same as above for the `InContactStickPoint(?stick:stick, ?point:point)` add effect in `StickTouchPoint`.
* In learned, `StickTouchPoint` includes an extra precondition `InContactRobotStick(?x0:robot, ?x1:stick)`. This is not really important because it's subsumed by `Grasped(?robot:robot, ?stick:stick)`, but it makes sense that it's there since it's in the intersection.