### PR TITLE
minor type fix + rename inverse_kinematics()

### DIFF
--- a/src/envs/pybullet_robots.py
+++ b/src/envs/pybullet_robots.py
@@ -149,7 +149,7 @@ class _SingleArmPyBulletRobot(abc.ABC):
 
     @abc.abstractmethod
     def forward_kinematics(self, joints_state: JointsState) -> Pose3D:
-        """Compute the end effector pose that would result if the robot arm
+        """Compute the end effector position that would result if the robot arm
         joints state was equal to the input joints_state.
 
         WARNING: This method will make use of resetJointState(), and so it
@@ -160,7 +160,9 @@ class _SingleArmPyBulletRobot(abc.ABC):
     @abc.abstractmethod
     def inverse_kinematics(self, end_effector_pose: Pose3D,
                            validate: bool) -> JointsState:
-        """Compute a joints state from a target end effector pose.
+        """Compute a joints state from a target end effector position.
+
+        The target orientation is always self._ee_orientation.
 
         If validate is True, guarantee that the returned joints state
         would result in end_effector_pose if run through
@@ -389,13 +391,14 @@ class FetchPyBulletRobot(_SingleArmPyBulletRobot):
 
     def inverse_kinematics(self, end_effector_pose: Pose3D,
                            validate: bool) -> JointsState:
-        return inverse_kinematics(self._fetch_id,
-                                  self._ee_id,
-                                  end_effector_pose,
-                                  self._ee_orientation,
-                                  self._arm_joints,
-                                  physics_client_id=self._physics_client_id,
-                                  validate=validate)
+        return pybullet_inverse_kinematics(
+            self._fetch_id,
+            self._ee_id,
+            end_effector_pose,
+            self._ee_orientation,
+            self._arm_joints,
+            physics_client_id=self._physics_client_id,
+            validate=validate)
 
     def create_move_end_effector_to_pose_option(
         self,
@@ -534,10 +537,10 @@ def get_kinematic_chain(robot: int, end_effector: int,
     return kinematic_chain
 
 
-def inverse_kinematics(
+def pybullet_inverse_kinematics(
     robot: int,
     end_effector: int,
-    target_position: Sequence[float],
+    target_position: Pose3D,
     target_orientation: Sequence[float],
     joints: Sequence[int],
     physics_client_id: int,

--- a/tests/envs/test_pybullet_robots.py
+++ b/tests/envs/test_pybullet_robots.py
@@ -7,7 +7,7 @@ import pytest
 from predicators.src import utils
 from predicators.src.envs.pybullet_robots import FetchPyBulletRobot, \
     create_single_arm_pybullet_robot, get_kinematic_chain, \
-    inverse_kinematics
+    pybullet_inverse_kinematics
 from predicators.src.settings import CFG
 
 
@@ -67,8 +67,8 @@ def test_get_kinematic_chain(scene_attributes):
     assert len(arm_joints) == 7
 
 
-def test_inverse_kinematics(scene_attributes):
-    """Tests for inverse_kinematics()."""
+def test_pybullet_inverse_kinematics(scene_attributes):
+    """Tests for pybullet_inverse_kinematics()."""
     arm_joints = get_kinematic_chain(
         scene_attributes["fetch_id"],
         scene_attributes["ee_id"],
@@ -89,7 +89,7 @@ def test_inverse_kinematics(scene_attributes):
     target_position = scene_attributes["robot_home"]
     # With validate = False, one call to IK is not good enough.
     _reset_joints()
-    joints_state = inverse_kinematics(
+    joints_state = pybullet_inverse_kinematics(
         scene_attributes["fetch_id"],
         scene_attributes["ee_id"],
         target_position,
@@ -112,7 +112,7 @@ def test_inverse_kinematics(scene_attributes):
         ee_link_state[4], target_position, atol=CFG.pybullet_ik_tol)
     # With validate = True, IK does work.
     _reset_joints()
-    joints_state = inverse_kinematics(
+    joints_state = pybullet_inverse_kinematics(
         scene_attributes["fetch_id"],
         scene_attributes["ee_id"],
         target_position,
@@ -140,7 +140,7 @@ def test_inverse_kinematics(scene_attributes):
         target_position[0], target_position[1], target_position[2] + 100.0
     ]
     with pytest.raises(Exception) as e:
-        inverse_kinematics(
+        pybullet_inverse_kinematics(
             scene_attributes["fetch_id"],
             scene_attributes["ee_id"],
             target_position,


### PR DESCRIPTION
* avoid confusion with `robot.inverse_kinematics` by renaming the global method `inverse_kinematics()` to `pybullet_inverse_kinematics()`
* clarify that the `target_position` argument is a Pose3D