### PR TITLE
clip parameters inside sample_option() instead of sampler learning

### DIFF
--- a/src/nsrt_learning/sampler_learning.py
+++ b/src/nsrt_learning/sampler_learning.py
@@ -286,11 +286,11 @@ class _LearnedSampler:
         sub = dict(zip(self._variables, objects))
         for var in self._variables:
             x_lst.extend(state[sub[var]])
-        # For sampler learning, we currently make the extremely limiting
-        # assumption that there is one goal atom, with one goal object. This
-        # will not be true in most cases. This is a placeholder for better
-        # methods to come.
         if CFG.sampler_learning_use_goals:
+            # For goal-conditioned sampler learning, we currently make the
+            # extremely limiting assumption that there is one goal atom, with
+            # one goal object. This will not be true in most cases. This is a
+            # placeholder for better methods to come.
             assert len(goal) == 1
             goal_atom = next(iter(goal))
             assert len(goal_atom.objects) == 1
@@ -301,9 +301,6 @@ class _LearnedSampler:
         if CFG.sampler_disable_classifier:
             params = np.array(self._regressor.predict_sample(x, rng),
                               dtype=self._param_option.params_space.dtype)
-            low = self._param_option.params_space.low
-            high = self._param_option.params_space.high
-            params = np.clip(params, low, high)
             return params
         while num_rejections <= CFG.max_rejection_sampling_tries:
             params = np.array(self._regressor.predict_sample(x, rng),
@@ -312,12 +309,6 @@ class _LearnedSampler:
                self._classifier.classify(np.r_[x, params]):
                 break
             num_rejections += 1
-        else:
-            # Edge case: we exceeded the number of sampling tries
-            # and we might be left with a params that is not in
-            # bounds. If so, fall back to sampling from the space.
-            if not self._param_option.params_space.contains(params):
-                params = self._param_option.params_space.sample()
         return params
 
 

--- a/src/structs.py
+++ b/src/structs.py
@@ -913,6 +913,10 @@ class _GroundNSRT:
         # Note that the sampler takes in ALL self.objects, not just the subset
         # self.option_objs of objects that are passed into the option.
         params = self._sampler(state, goal, rng, self.objects)
+        # Clip the params into the params_space of self.option, for safety.
+        low = self.option.params_space.low
+        high = self.option.params_space.high
+        params = np.clip(params, low, high)
         return self.option.ground(self.option_objs, params)
 
     def copy_with(self, **kwargs: Any) -> _GroundNSRT:


### PR DESCRIPTION
note: the only places that call sample_option() are planner.py and gnn_metacontroller_approach.py, both of which use sampler_learning.py, so i think i've cleaned out all the redundant calls to clip().