### PR TITLE
add setting to disable expected atoms check

### DIFF
--- a/src/planning.py
+++ b/src/planning.py
@@ -322,7 +322,7 @@ def _run_low_level_search(task: Task, option_model: _OptionModelBase,
                 # Check if we have exceeded the horizon.
                 if np.sum(num_actions_per_option[:cur_idx]) > max_horizon:
                     can_continue_on = False
-                else:
+                elif CFG.sesame_check_expected_atoms:
                     # Check atoms against expected atoms_sequence constraint.
                     assert len(traj) == len(atoms_sequence)
                     # The expected atoms are ones that we definitely expect to
@@ -341,6 +341,14 @@ def _run_low_level_search(task: Task, option_model: _OptionModelBase,
                         if cur_idx == len(skeleton):
                             return plan, True  # success!
                     else:
+                        can_continue_on = False
+                else:
+                    # If we're not checking expected_atoms, we need to
+                    # explicitly check the goal on the final timestep.
+                    can_continue_on = True
+                    if cur_idx == len(skeleton):
+                        if task.goal_holds(traj[cur_idx]):
+                            return plan, True  # success!
                         can_continue_on = False
         else:
             # The option is not initiable.

--- a/src/settings.py
+++ b/src/settings.py
@@ -158,6 +158,7 @@ class GlobalSettings:
     # SeSamE parameters
     sesame_task_planning_heuristic = "lmcut"
     sesame_allow_noops = True  # recommended to keep this False if using replays
+    sesame_check_expected_atoms = True
 
     # evaluation parameters
     log_dir = "logs"

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -18,12 +18,17 @@ from predicators.src.structs import NSRT, Action, ParameterizedOption, \
     Predicate, State, STRIPSOperator, Task, Type, _GroundNSRT, _Option
 
 
-def test_sesame_plan():
+@pytest.mark.parametrize("sesame_check_expected_atoms", [True, False])
+def test_sesame_plan(sesame_check_expected_atoms):
     """Tests for sesame_plan()."""
-    utils.reset_config({"env": "cover"})
+    utils.reset_config({
+        "env": "cover",
+        "sesame_check_expected_atoms": sesame_check_expected_atoms,
+        "num_test_tasks": 1,
+    })
     env = CoverEnv()
     nsrts = get_gt_nsrts(env.predicates, env.options)
-    task = env.get_train_tasks()[0]
+    task = env.get_test_tasks()[0]
     option_model = create_option_model(CFG.option_model_name)
     plan, metrics = sesame_plan(
         task,
@@ -36,9 +41,8 @@ def test_sesame_plan():
         CFG.sesame_max_skeletons_optimized,
         max_horizon=CFG.horizon,
     )
-    assert len(plan) == 2
-    assert isinstance(plan[0], _Option)
-    assert isinstance(plan[1], _Option)
+    assert len(plan) == 3
+    assert all(isinstance(act, _Option) for act in plan)
     assert metrics["num_nodes_created"] >= metrics["num_nodes_expanded"]
 
 


### PR DESCRIPTION
findings on repeated_nextto:
- oracle & our backchaining approach work the same whether it's enabled or disabled, no difference in planning time
- cluster_and_intersect sucks whether it's enabled or disabled, because the skeleton search itself is so difficult with so many high-arity operators. so planning times out in skeleton search itself
- one interesting thing i tried: **if you change the oracle operators to not contain side predicates** (just do side_predicates = set() for both Move and Grasp), **then planning works** (albeit slowly; gets ~40/50) **when the expected atoms check is disabled, but fails unilaterally when it's enabled**. this was interesting to me because i always thought that the expected atoms check is strictly beneficial from a success rate perspective (ignoring timeout), but this is not true. the reason planning fails when expected_atoms is enabled is, simply, that something like NextToNothing would be in the expected_atoms after a Move, but it's not in the actual state.

closes #862