### PR TITLE
RL approach with Dummy RLOptionLearner. 

### DIFF
--- a/src/approaches/nsrt_rl_approach.py
+++ b/src/approaches/nsrt_rl_approach.py
@@ -13,7 +13,8 @@ from predicators.src.approaches.nsrt_learning_approach import \
 from predicators.src.settings import CFG
 from predicators.src.structs import NSRT, Dataset, InteractionRequest, \
     InteractionResult, LowLevelTrajectory, ParameterizedOption, Predicate, \
-    Task, Type, Object, Array
+    Task, Type, Object, Array, State
+import numpy as np
 
 
 class NSRTReinforcementLearningApproach(NSRTLearningApproach):
@@ -69,7 +70,8 @@ class NSRTReinforcementLearningApproach(NSRTLearningApproach):
             requests.append(request)
         return requests
 
-    def infer_subgoal(object: Object, states: List[State], features: List[str]) -> List[float]:
+    @classmethod
+    def infer_subgoal(cls, object: Object, states: List[State], features: List[str]) -> List[float]:
         return [states[-1].get(object, feat) - states[0].get(object, feat) for feat in features]
 
     def learn_from_interaction_results(
@@ -85,10 +87,11 @@ class NSRTReinforcementLearningApproach(NSRTLearningApproach):
                                       _train_task_idx=i)
             self._train_task_to_online_traj[i] = traj
 
+
+        option_to_data = {i: [] for i in range(len(plan))} # idx -> list (s, a, s', r)
         # for each task:
         #    for each _Option involved in the trajectory:
-        #       1) get the trajectory that it took
-        #       2) get the sample subgoal, and determine if it was reached
+        #       compute (s, a, s', r) tuples
         for i in range(len(self._train_tasks)):
             plan = self._train_task_to_option_plan[i]
             traj = self._train_task_to_online_traj[i]
@@ -100,6 +103,7 @@ class NSRTReinforcementLearningApproach(NSRTLearningApproach):
             curr_option = plan[curr_option_idx]
             curr_states = []
             curr_actions = []
+            curr_rewards = []
             actions = (a for a in traj.actions)
 
             for i, s in enumerate(traj.states):
@@ -110,16 +114,23 @@ class NSRTReinforcementLearningApproach(NSRTLearningApproach):
                     # TODO: inferring reward requires environment specific code?
                     block = [b for b in curr_option.objects if b.type.name=='block'][0]
                     robot = [r for r in curr_option.objects if r.type.name=='robot'][0]
-                    dblock = self.infer_subgoal(block, curr_states, ['x', 'grasp'])
-                    drobot = self.infer_subogoal(robot, curr_states, ['x', 'grip', 'holding'])
+                    if curr_option.params[-1] > 0: # if holding becomes true
+                        dblock = self.infer_subgoal(block, curr_states, ['grasp'])
+                        drobot = self.infer_subgoal(robot, curr_states, ['x', 'y', 'grip', 'holding'])
+                    else:
+                        dblock = self.infer_subgoal(block, curr_states, ['x', 'grasp'])
+                        drobot = self.infer_subgoal(robot, curr_states, ['x', 'grip', 'holding'])
                     subgoal = np.array(dblock + drobot)
+                    print("option params: ", curr_option.params)
+                    print("subgoal: ", subgoal)
                     if np.allclose(curr_option.params, subgoal, atol=self._reward_epsilon):
                         reward = self._pos_reward
                     else:
                         reward = self._neg_reward
-                    option_to_reward[curr_option_idx] = reward
+                    curr_rewards.append(reward)
 
-                    # Store trajectory.
+                    # Store trajectory and reward
+                    option_to_reward[curr_option_idx] = list(curr_rewards)
                     option_to_traj[curr_option_idx] = (list(curr_states), list(curr_actions))
 
                     # Advance to next option.
@@ -137,16 +148,19 @@ class NSRTReinforcementLearningApproach(NSRTLearningApproach):
                     # Initialize trajectory for next option.
                     curr_states = [s]
                     curr_actions = []
+                    curr_rewards = [-1]
 
                 else:
                     curr_states.append(s)
                     a = next(actions)
                     curr_actions.append(a)
                     # If this is the last state, then we haven't gotten the reward
-                    # TODO: set reward to zero in this case
                     if i == len(traj.states) - 1:
                         option_to_traj[curr_option_idx] = (list(curr_states), list(curr_actions))
+                    curr_rewards.append(self._neg_reward)
 
-            import pdb; pdb.set_trace()
-
-            # TODO: review how the params are used by the _Option's policy for nsrt_learning
+            # TODO: make a list of (s, a, s', r) for each option
+            
+            # TODO: associate each _Option we see with an nsrt's parameterized option
+            # TODO: call RL option learner's update method, passing in (s, a, s', r)
+            # TODO: replace the corresponding parameterized option

--- a/src/approaches/nsrt_rl_approach.py
+++ b/src/approaches/nsrt_rl_approach.py
@@ -175,17 +175,7 @@ class NSRTReinforcementLearningApproach(NSRTLearningApproach):
                         # Store transition data.
                         option_to_data[curr_option.name].append(list(curr_states, curr_actions, curr_rewards, curr_relative_params))
 
-        import pdb; pdb.set_trace()
-
-        # Associate each unique option we see in the data (that we
-        # identify by the option's name) with an nsrt's parameterized option. We
-        # need to do this because the RLOptionLearner updates the parameterized
-        # options. The RLOptionLearner will receive a parameterized option to
-        # update, and all the data associated with it from the online learning
-        # cycle that just happened.
-        option_to_parent_and_nsrt = {}
-        parameterized_options = [(nsrt.option, nsrt) for nsrt in self._nsrts]
-
+        # Call the RL option learner on each option. 
         for option_name, experience in option_to_data.items():
             corresponding_nsrt = [nsrt for nsrt in self._nsrts if nsrt.option.name == option_name][0]
             corresponding_parent_option = corresponding_nsrt.option

--- a/src/approaches/nsrt_rl_approach.py
+++ b/src/approaches/nsrt_rl_approach.py
@@ -95,7 +95,9 @@ class NSRTReinforcementLearningApproach(NSRTLearningApproach):
             curr_option = plan[curr_option_idx]
             curr_traj = [] # List of (state, action) tuples
 
-            for s, a in zip(traj.states, traj.actions):
+            for i in range(len(traj.states)):
+                s = traj.states[i]
+                a = traj.actions[i]
                 if curr_option.terminal(s):
                     curr_option_idx += 1
                     if curr_option_idx < len(plan):
@@ -111,6 +113,10 @@ class NSRTReinforcementLearningApproach(NSRTLearningApproach):
                     curr_traj = [(s, a)]
                 else:
                     curr_traj.append((s, a))
+                    # If this is the last state, then we haven't gotten the reward
+                    # TODO: set reward to zero in this case
+                    if i == len(traj.states) - 1:
+                        option_to_traj[curr_option_idx] = list(curr_traj)
 
             import pdb; pdb.set_trace()
 

--- a/src/nsrt_learning/option_learning.py
+++ b/src/nsrt_learning/option_learning.py
@@ -594,13 +594,15 @@ class _DummyRLOptionLearner(_RLOptionLearnerBase):
     """Does not update the policy associated with a
     _LearnedNeuralParameterizedOption."""
 
-    def __init__() -> None:
+    def __init__(self) -> None:
         super().__init__()
 
-    def update(option: _LearnedNeuralParameterizedOption, experience: List[List[State], List[Action], List[int], List[Array]]) -> _LearnedNeuralParameterizedOption:
+    def update(self, option: _LearnedNeuralParameterizedOption, experience: List[List[State], List[Action], List[int], List[Array]]) -> _LearnedNeuralParameterizedOption:
         # Don't actually update the option at all.
-        # Update would be made to option._regressor.
-        return option
+        # Update would be made to option._regressor, which might require changing
+        # the code in ml_models.py so that you can train without re-initializing
+        # the network.
+        return option.copy()
 
 
 def _create_absolute_option_param(state: State,

--- a/src/nsrt_learning/option_learning.py
+++ b/src/nsrt_learning/option_learning.py
@@ -33,6 +33,8 @@ def create_option_learner(action_space: Box) -> _OptionLearnerBase:
     if CFG.option_learner == "direct_bc_nonparameterized":
         return _DirectBehaviorCloningOptionLearner(action_space,
                                                    is_parameterized=False)
+    if CFG.option_learner == "dummy_rl":
+        return _DummyRLOptionLearner()
     raise NotImplementedError(f"Unknown option_learner: {CFG.option_learner}")
 
 
@@ -576,6 +578,29 @@ class _ImplicitBehaviorCloningOptionLearner(_BehaviorCloningOptionLearner):
             derivative_free_sigma_init=sigma,
             derivative_free_shrink_scale=shrink_scale,
             grid_num_ticks_per_dim=num_ticks)
+
+
+class _RLOptionLearnerBase(abc.ABC):
+    """Struct defining an option learner that learns via reinforcement learning,
+    which has an abstract method for updating the policy associated with an
+    option."""
+
+    @abc.abstractmethod
+    def update(option: _LearnedNeuralParameterizedOption, experience: List[List[State], List[Action], List[int], List[Array]]) -> _LearnedNeuralParameterizedOption:
+        raise NotImplementedError("Override me!")
+
+
+class _DummyRLOptionLearner(_RLOptionLearnerBase):
+    """Does not update the policy associated with a
+    _LearnedNeuralParameterizedOption."""
+
+    def __init__() -> None:
+        super().__init__()
+
+    def update(option: _LearnedNeuralParameterizedOption, experience: List[List[State], List[Action], List[int], List[Array]]) -> _LearnedNeuralParameterizedOption:
+        # Don't actually update the option at all.
+        # Update would be made to option._regressor.
+        return option
 
 
 def _create_absolute_option_param(state: State,

--- a/src/settings.py
+++ b/src/settings.py
@@ -155,6 +155,9 @@ class GlobalSettings:
     # parameters for GNN metacontroller approach
     gnn_metacontroller_max_samples = 100
 
+    # parameters for NSRT reinforcement learning approach
+    reward_epsilon = 1e-2 # reward if within epsilon-ball from sampled subgoal
+
     # SeSamE parameters
     sesame_task_planning_heuristic = "lmcut"
     sesame_allow_noops = True  # recommended to keep this False if using replays

--- a/src/settings.py
+++ b/src/settings.py
@@ -159,6 +159,7 @@ class GlobalSettings:
     reward_epsilon = 1e-2 # reward if within epsilon-ball from sampled subgoal
     pos_reward = 0
     neg_reward = -1
+    rl_option_learner = "dummy_rl"
 
     # SeSamE parameters
     sesame_task_planning_heuristic = "lmcut"

--- a/src/settings.py
+++ b/src/settings.py
@@ -157,6 +157,8 @@ class GlobalSettings:
 
     # parameters for NSRT reinforcement learning approach
     reward_epsilon = 1e-2 # reward if within epsilon-ball from sampled subgoal
+    pos_reward = 0
+    neg_reward = -1
 
     # SeSamE parameters
     sesame_task_planning_heuristic = "lmcut"


### PR DESCRIPTION
Loops through online learning trajectories and creates online experience data for each option. The online experience data consists of the lists of states, actions, rewards, and relative_parameters experienced. This data is passed to an RLOptionLearner, which is instantiated for each option (because the RLOptionLearner will need to maintain state unique to the learning process for its option). The RLOptionLearner returns an updated parameterized_option, which replaces the old one in the corresponding NSRT. 

Reviewers: the main thing to look at is the overall logic before I spend much time integrating non-dummy RLOptionLearners, in case big things need changing, and whether certain computations (especially for the option's relative parameters) can be achieved more concisely. I will continue to update some comments and add tests today, but I think an initial review can be done now. 