### PR TITLE
add flag to include specific options

### DIFF
--- a/scripts/grammar_search_analysis.py
+++ b/scripts/grammar_search_analysis.py
@@ -177,7 +177,7 @@ def _run_proxy_analysis_for_env(args: Dict[str, Any], env_name: str,
     })
     env = create_new_env(env_name)
     train_tasks = env.get_train_tasks()
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     start_time = time.time()
 
     for non_goal_predicates in non_goal_predicate_sets:

--- a/scripts/skeleton_score_analysis.py
+++ b/scripts/skeleton_score_analysis.py
@@ -56,7 +56,7 @@ def _setup_data_for_env(env_name: str,
     })
     env = create_new_env(env_name)
     train_tasks = env.get_train_tasks()
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     assert all(traj.is_demo for traj in dataset.trajectories)
     demo_skeleton_lengths = [
         utils.num_options_in_action_sequence(t.actions)

--- a/src/approaches/nsrt_learning_approach.py
+++ b/src/approaches/nsrt_learning_approach.py
@@ -55,6 +55,7 @@ class NSRTLearningApproach(BilevelPlanningApproach):
             learn_nsrts_from_data(trajectories,
                                   self._train_tasks,
                                   self._get_current_predicates(),
+                                  self._initial_options,
                                   self._action_space,
                                   sampler_learner=CFG.sampler_learner)
         save_path = utils.get_approach_save_path_str()

--- a/src/args.py
+++ b/src/args.py
@@ -15,6 +15,7 @@ def create_arg_parser(env_required: bool = True,
     parser.add_argument("--env", required=env_required, type=str)
     parser.add_argument("--approach", required=approach_required, type=str)
     parser.add_argument("--excluded_predicates", default="", type=str)
+    parser.add_argument("--included_options", default="", type=str)
     parser.add_argument("--seed", required=seed_required, type=int)
     parser.add_argument("--option_learner", type=str, default="no_learning")
     parser.add_argument("--timeout", default=10, type=float)

--- a/src/datasets/__init__.py
+++ b/src/datasets/__init__.py
@@ -1,7 +1,7 @@
 """Create offline datasets for training, given a set of training tasks for an
 environment."""
 
-from typing import List
+from typing import List, Set
 
 from predicators.src import utils
 from predicators.src.datasets.demo_only import create_demo_data
@@ -9,18 +9,19 @@ from predicators.src.datasets.demo_replay import create_demo_replay_data
 from predicators.src.datasets.ground_atom_data import create_ground_atom_data
 from predicators.src.envs import BaseEnv
 from predicators.src.settings import CFG
-from predicators.src.structs import Dataset, Task
+from predicators.src.structs import Dataset, ParameterizedOption, Task
 
 
-def create_dataset(env: BaseEnv, train_tasks: List[Task]) -> Dataset:
+def create_dataset(env: BaseEnv, train_tasks: List[Task],
+                   known_options: Set[ParameterizedOption]) -> Dataset:
     """Create offline datasets for training, given a set of training tasks for
     an environment."""
     if CFG.offline_data_method == "demo":
-        return create_demo_data(env, train_tasks)
+        return create_demo_data(env, train_tasks, known_options)
     if CFG.offline_data_method == "demo+replay":
-        return create_demo_replay_data(env, train_tasks)
+        return create_demo_replay_data(env, train_tasks, known_options)
     if CFG.offline_data_method == "demo+ground_atoms":
-        base_dataset = create_demo_data(env, train_tasks)
+        base_dataset = create_demo_data(env, train_tasks, known_options)
         _, excluded_preds = utils.parse_config_excluded_predicates(env)
         n = int(CFG.teacher_dataset_num_examples)
         assert n >= 1, "Must have at least 1 example of each predicate"

--- a/src/datasets/demo_only.py
+++ b/src/datasets/demo_only.py
@@ -1,17 +1,19 @@
 """Create offline datasets by collecting demonstrations."""
 
 import logging
-from typing import List
+from typing import List, Set
 
 from predicators.src import utils
 from predicators.src.approaches import ApproachFailure, ApproachTimeout
 from predicators.src.approaches.oracle_approach import OracleApproach
 from predicators.src.envs import BaseEnv
 from predicators.src.settings import CFG
-from predicators.src.structs import Dataset, LowLevelTrajectory, Task
+from predicators.src.structs import Dataset, LowLevelTrajectory, \
+    ParameterizedOption, Task
 
 
-def create_demo_data(env: BaseEnv, train_tasks: List[Task]) -> Dataset:
+def create_demo_data(env: BaseEnv, train_tasks: List[Task],
+                     known_options: Set[ParameterizedOption]) -> Dataset:
     """Create offline datasets by collecting demos."""
     oracle_approach = OracleApproach(
         env.predicates,
@@ -66,8 +68,9 @@ def create_demo_data(env: BaseEnv, train_tasks: List[Task]) -> Dataset:
                                   traj.actions,
                                   _is_demo=True,
                                   _train_task_idx=idx)
-        if CFG.option_learner != "no_learning":
-            for act in traj.actions:
+        for act in traj.actions:
+            if act.get_option().parent not in known_options:
+                assert CFG.option_learner != "no_learning"
                 act.unset_option()
         trajectories.append(traj)
         if CFG.make_demo_videos:

--- a/src/nsrt_learning/nsrt_learning_main.py
+++ b/src/nsrt_learning/nsrt_learning_main.py
@@ -110,7 +110,8 @@ def _learn_pnad_options(pnads: List[PartialNSRTAndDatastore],
     # have the same parameterized option as their parent.
     known_option_pnads, unknown_option_pnads = [], []
     for pnad in pnads:
-        assert pnad.datastore
+        if not pnad.datastore:
+            raise Exception("No data found for learning an option.")
         example_segment, _ = pnad.datastore[0]
         example_action = example_segment.actions[0]
         pnad_options_known = example_action.has_option()

--- a/src/nsrt_learning/nsrt_learning_main.py
+++ b/src/nsrt_learning/nsrt_learning_main.py
@@ -118,7 +118,18 @@ def _learn_pnad_options(pnads: List[PartialNSRTAndDatastore],
     # Update the segments to include which option is being executed.
     for datastore, spec in zip(datastores, option_specs):
         for (segment, _) in datastore:
-            # Modifies segment in-place.
+            # Sanity check: if an action in the segment has a known option,
+            # then its parent should be the parameterized option in the spec.
+            # Furthermore, either all of the actions in the segment should have
+            # a known option, or none of them should.
+            expecting_known_option = segment.actions[0].has_option()
+            for action in segment.actions:
+                if expecting_known_option:
+                    assert action.has_option()
+                    assert action.get_option().parent == spec[0]
+                else:
+                    assert not action.has_option()
+            # Modify the segment in-place.
             option_learner.update_segment_from_option_spec(segment, spec)
     logging.info("\nLearned operators with option specs:")
     for pnad in pnads:

--- a/src/nsrt_learning/option_learning.py
+++ b/src/nsrt_learning/option_learning.py
@@ -23,7 +23,7 @@ from predicators.src.utils import OptionExecutionFailure
 def create_option_learner(action_space: Box) -> _OptionLearnerBase:
     """Create an option learner given its name."""
     if CFG.option_learner == "no_learning":
-        return _KnownOptionsOptionLearner()
+        return KnownOptionsOptionLearner()
     if CFG.option_learner == "oracle":
         return _OracleOptionLearner()
     if CFG.option_learner == "direct_bc":
@@ -69,7 +69,7 @@ class _OptionLearnerBase(abc.ABC):
         raise NotImplementedError("Override me!")
 
 
-class _KnownOptionsOptionLearner(_OptionLearnerBase):
+class KnownOptionsOptionLearner(_OptionLearnerBase):
     """The "option learner" that's used when we're in the code path where
     CFG.option_learner is "no_learning"."""
 

--- a/src/nsrt_learning/option_learning.py
+++ b/src/nsrt_learning/option_learning.py
@@ -473,9 +473,6 @@ class _BehaviorCloningOptionLearner(_OptionLearnerBase):
                     X_regressor.append(x)
                     Y_regressor.append(action.arr)
 
-            if not X_regressor:
-                raise Exception("No data found for learning an option.")
-
             X_arr_regressor = np.array(X_regressor, dtype=np.float32)
             Y_arr_regressor = np.array(Y_regressor, dtype=np.float32)
             regressor = self._create_regressor()

--- a/src/nsrt_learning/segmentation.py
+++ b/src/nsrt_learning/segmentation.py
@@ -94,7 +94,7 @@ def _segment_with_oracle(trajectory: GroundAtomTrajectory) -> List[Segment]:
     effects achieved, that marks the switch point between segments.
     """
     traj, all_atoms = trajectory
-    if traj.actions[0].has_option():
+    if CFG.option_learner == "no_learning":
         return _segment_with_option_changes(trajectory)
     env = get_or_create_env(CFG.env)
     gt_nsrts = get_gt_nsrts(env.predicates, env.options)

--- a/src/utils.py
+++ b/src/utils.py
@@ -2286,6 +2286,23 @@ def parse_config_excluded_predicates(
     return included, excluded
 
 
+def parse_config_included_options(env: BaseEnv) -> Set[ParameterizedOption]:
+    """Parse the CFG.included_options string, given an environment.
+
+    Return the set of included oracle options.
+
+    Note that "all" is not implemented because setting the option_learner flag
+    to "no_learning" is the preferred way to include all options.
+    """
+    if not CFG.included_options:
+        return set()
+    included_names = set(CFG.included_options.split(","))
+    assert included_names.issubset({option.name for option in env.options}), \
+        "Unrecognized option in included_options!"
+    included_options = {o for o in env.options if o.name in included_names}
+    return included_options
+
+
 def null_sampler(state: State, goal: Set[GroundAtom], rng: np.random.Generator,
                  objs: Sequence[Object]) -> Array:
     """A sampler for an NSRT with no continuous parameters."""

--- a/src/utils.py
+++ b/src/utils.py
@@ -2172,7 +2172,7 @@ def get_config_path_str(experiment_id: Optional[str] = None) -> str:
     if experiment_id is None:
         experiment_id = CFG.experiment_id
     return (f"{CFG.env}__{CFG.approach}__{CFG.seed}__{CFG.excluded_predicates}"
-            f"__{experiment_id}")
+            f"__{CFG.included_options}__{experiment_id}")
 
 
 def get_approach_save_path_str() -> str:

--- a/tests/approaches/test_gnn_action_policy_approach.py
+++ b/tests/approaches/test_gnn_action_policy_approach.py
@@ -26,7 +26,7 @@ def test_gnn_action_policy_approach():
     approach = create_approach("gnn_action_policy", env.predicates,
                                env.options, env.types, env.action_space,
                                train_tasks)
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     assert approach.is_learning_based
     task = env.get_test_tasks()[0]
     with pytest.raises(AssertionError):  # haven't learned yet!

--- a/tests/approaches/test_gnn_metacontroller_approach.py
+++ b/tests/approaches/test_gnn_metacontroller_approach.py
@@ -51,7 +51,7 @@ def test_gnn_metacontroller_approach_with_envs(env_name, num_epochs):
     approach = create_approach("gnn_metacontroller", env.predicates,
                                env.options, env.types, env.action_space,
                                train_tasks)
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     assert approach.is_learning_based
     task = env.get_test_tasks()[0]
     with pytest.raises(AssertionError):  # haven't learned yet!

--- a/tests/approaches/test_gnn_option_policy_approach.py
+++ b/tests/approaches/test_gnn_option_policy_approach.py
@@ -60,7 +60,7 @@ def test_gnn_option_policy_approach_with_envs(env_name):
     approach = create_approach("gnn_option_policy", env.predicates,
                                env.options, env.types, env.action_space,
                                train_tasks)
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     assert approach.is_learning_based
     task = env.get_test_tasks()[0]
     with pytest.raises(AssertionError):  # haven't learned yet!

--- a/tests/approaches/test_interactive_approach.py
+++ b/tests/approaches/test_interactive_approach.py
@@ -49,7 +49,7 @@ def test_interactive_learning_approach():
                                            env.types, env.action_space,
                                            train_tasks)
     teacher = Teacher(train_tasks)
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     assert approach.is_learning_based
     # Learning with an empty dataset should not crash.
     approach.learn_from_offline_dataset(Dataset([]))
@@ -215,4 +215,4 @@ def test_interactive_learning_approach():
         "teacher_dataset_num_examples": 0,
     })
     with pytest.raises(AssertionError):
-        create_dataset(env, train_tasks)
+        create_dataset(env, train_tasks, env.options)

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -62,11 +62,7 @@ def _test_approach(env_name,
         options = utils.parse_config_included_options(env)
     approach = create_approach(approach_name, preds, options, env.types,
                                env.action_space, train_tasks)
-    try:
-        dataset = create_dataset(env, train_tasks, options)
-    except:
-        import ipdb
-        ipdb.set_trace()
+    dataset = create_dataset(env, train_tasks, options)
     assert approach.is_learning_based
     approach.learn_from_offline_dataset(dataset)
     task = env.get_test_tasks()[0]

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -58,7 +58,7 @@ def _test_approach(env_name,
     train_tasks = env.get_train_tasks()
     approach = create_approach(approach_name, preds, env.options, env.types,
                                env.action_space, train_tasks)
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     assert approach.is_learning_based
     approach.learn_from_offline_dataset(dataset)
     task = env.get_test_tasks()[0]

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -156,6 +156,18 @@ def test_neural_option_learning():
                        "cover_multistep_thr_percent": 0.99,
                        "cover_multistep_bhr_percent": 0.99,
                    })
+    # Test with some, but not all, options given.
+    _test_approach(env_name="cover_multistep_options",
+                   approach_name="nsrt_learning",
+                   try_solving=False,
+                   sampler_learner="random",
+                   option_learner="direct_bc",
+                   check_solution=False,
+                   additional_settings={
+                       "cover_multistep_thr_percent": 0.99,
+                       "cover_multistep_bhr_percent": 0.99,
+                       "included_options": "Pick"
+                   })
     # Test with oracle samplers.
     _test_approach(env_name="cover_multistep_options",
                    approach_name="nsrt_learning",

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -56,9 +56,17 @@ def _test_approach(env_name,
     else:
         preds = env.predicates
     train_tasks = env.get_train_tasks()
-    approach = create_approach(approach_name, preds, env.options, env.types,
+    if option_learner == "no_learning":
+        options = env.options
+    else:
+        options = utils.parse_config_included_options(env)
+    approach = create_approach(approach_name, preds, options, env.types,
                                env.action_space, train_tasks)
-    dataset = create_dataset(env, train_tasks, env.options)
+    try:
+        dataset = create_dataset(env, train_tasks, options)
+    except:
+        import ipdb
+        ipdb.set_trace()
     assert approach.is_learning_based
     approach.learn_from_offline_dataset(dataset)
     task = env.get_test_tasks()[0]

--- a/tests/approaches/test_nsrt_rl_approach.py
+++ b/tests/approaches/test_nsrt_rl_approach.py
@@ -34,7 +34,7 @@ def test_nsrt_reinforcement_learning_approach():
                                                  env.types, env.action_space,
                                                  train_tasks)
     teacher = Teacher(train_tasks)
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     assert approach.is_learning_based
     approach.learn_from_offline_dataset(dataset)
     approach.load(online_learning_cycle=None)

--- a/tests/approaches/test_nsrt_rl_approach.py
+++ b/tests/approaches/test_nsrt_rl_approach.py
@@ -30,11 +30,12 @@ def test_nsrt_reinforcement_learning_approach():
     })
     env = CoverMultistepOptions()
     train_tasks = env.get_train_tasks()
-    approach = NSRTReinforcementLearningApproach(env.predicates, env.options,
+    options = utils.parse_config_included_options(env)
+    approach = NSRTReinforcementLearningApproach(env.predicates, options,
                                                  env.types, env.action_space,
                                                  train_tasks)
     teacher = Teacher(train_tasks)
-    dataset = create_dataset(env, train_tasks, env.options)
+    dataset = create_dataset(env, train_tasks, options)
     assert approach.is_learning_based
     approach.learn_from_offline_dataset(dataset)
     approach.load(online_learning_cycle=None)

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -8,7 +8,7 @@ import pytest
 from predicators.src import utils
 from predicators.src.datasets import create_dataset
 from predicators.src.envs.cluttered_table import ClutteredTableEnv
-from predicators.src.envs.cover import CoverEnv
+from predicators.src.envs.cover import CoverEnv, CoverMultistepOptions
 from predicators.src.ground_truth_nsrts import _get_predicates_by_names
 from predicators.src.settings import CFG
 from predicators.src.structs import Dataset, GroundAtom, Task
@@ -28,7 +28,8 @@ def test_demo_dataset():
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
-    dataset = create_dataset(env, train_tasks)
+    options = utils.parse_config_included_options(env)
+    dataset = create_dataset(env, train_tasks, options)
     assert len(dataset.trajectories) == 7
     assert len(dataset.trajectories[0].states) == 3
     assert len(dataset.trajectories[0].actions) == 2
@@ -47,7 +48,7 @@ def test_demo_dataset():
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     assert len(dataset.trajectories) == 7
     assert len(dataset.trajectories[0].states) == 3
     assert len(dataset.trajectories[0].actions) == 2
@@ -57,6 +58,38 @@ def test_demo_dataset():
             assert action.has_option()
     with pytest.raises(AssertionError):
         _ = dataset.annotations
+    # Test that only options in the included_options flag are included
+    utils.reset_config({
+        "env": "cover_multistep_options",
+        "cover_multistep_bhr_percent": 0.99,
+        "cover_multistep_thr_percent": 0.99,
+        "approach": "random_actions",
+        "offline_data_method": "demo",
+        "option_learner": "arbitrary_dummy",
+        "num_train_tasks": 3,
+        "included_options": "Pick"
+    })
+    env = CoverMultistepOptions()
+    Pick, Place = sorted(env.options)
+    assert Pick.name == "Pick"
+    assert Place.name == "Place"
+    train_tasks = env.get_train_tasks()
+    options = utils.parse_config_included_options(env)
+    assert options == {Pick}
+    dataset = create_dataset(env, train_tasks, options)
+    assert len(dataset.trajectories) == 3
+    at_least_one_pick_found = False
+    at_least_one_place_found = False
+    for traj in dataset.trajectories:
+        assert traj.is_demo
+        for action in traj.actions:
+            if action.has_option():
+                assert action.get_option().parent == Pick
+                at_least_one_pick_found = True
+            else:
+                at_least_one_place_found = True
+    assert at_least_one_pick_found
+    assert at_least_one_place_found
     # Test what happens if the goal is unachievable.
     utils.reset_config({
         "env": "cover",
@@ -66,13 +99,15 @@ def test_demo_dataset():
         "option_learner": "no_learning",
         "num_train_tasks": 7,
     })
+    env = CoverEnv()
+    train_tasks = env.get_train_tasks()
     init = train_tasks[0].init
     HandEmpty = [pred for pred in env.predicates
                  if pred.name == "HandEmpty"][0]
     Holding = [pred for pred in env.predicates if pred.name == "Holding"][0]
     imposs_goal = {GroundAtom(HandEmpty, []), Holding([list(init)[0]])}
     train_tasks[0] = Task(init, imposs_goal)
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     assert len(dataset.trajectories) == 6
     # Test max_initial_demos.
     utils.reset_config({
@@ -84,13 +119,13 @@ def test_demo_dataset():
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
     assert len(train_tasks) == 7
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     assert len(dataset.trajectories) == 3
     utils.update_config({
         "offline_data_method": "not a real method",
     })
     with pytest.raises(NotImplementedError):
-        create_dataset(env, train_tasks)
+        create_dataset(env, train_tasks, env.options)
     utils.update_config({
         "offline_data_method":
         "demo",
@@ -98,7 +133,7 @@ def test_demo_dataset():
         "not a real heuristic",
     })
     with pytest.raises(ValueError):
-        create_dataset(env, train_tasks)
+        create_dataset(env, train_tasks, env.options)
     # Test demo video generation.
     video_dir = os.path.join(os.path.dirname(__file__), "_fake_videos")
     utils.reset_config({
@@ -117,7 +152,7 @@ def test_demo_dataset():
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
     assert len(train_tasks) == 1
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     assert len(dataset.trajectories) == 1
     assert os.path.exists(video_file)
     shutil.rmtree(video_dir)
@@ -138,7 +173,7 @@ def test_demo_replay_dataset():
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     assert len(dataset.trajectories) == 5 + 3
     assert len(dataset.trajectories[-1].states) == 2
     assert len(dataset.trajectories[-1].actions) == 1
@@ -161,7 +196,8 @@ def test_demo_replay_dataset():
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
-    dataset = create_dataset(env, train_tasks)
+    options = utils.parse_config_included_options(env)
+    dataset = create_dataset(env, train_tasks, options)
     assert len(dataset.trajectories) == 5 + 3
     assert len(dataset.trajectories[-1].states) == 2
     assert len(dataset.trajectories[-1].actions) == 1
@@ -171,6 +207,39 @@ def test_demo_replay_dataset():
         for action in traj.actions:
             assert not action.has_option()
     assert num_demos == 5
+    # Test that only options in the included_options flag are included
+    utils.reset_config({
+        "env": "cover_multistep_options",
+        "cover_multistep_bhr_percent": 0.99,
+        "cover_multistep_thr_percent": 0.99,
+        "approach": "random_actions",
+        "offline_data_method": "demo+replay",
+        "offline_data_planning_timeout": 500,
+        "offline_data_num_replays": 3,
+        "option_learner": "arbitrary_dummy",
+        "num_train_tasks": 3,
+        "included_options": "Pick"
+    })
+    env = CoverMultistepOptions()
+    Pick, Place = sorted(env.options)
+    assert Pick.name == "Pick"
+    assert Place.name == "Place"
+    train_tasks = env.get_train_tasks()
+    options = utils.parse_config_included_options(env)
+    assert options == {Pick}
+    dataset = create_dataset(env, train_tasks, options)
+    assert len(dataset.trajectories) == 3 + 3
+    at_least_one_pick_found = False
+    at_least_one_place_found = False
+    for traj in dataset.trajectories:
+        for action in traj.actions:
+            if action.has_option():
+                assert action.get_option().parent == Pick
+                at_least_one_pick_found = True
+            else:
+                at_least_one_place_found = True
+    assert at_least_one_pick_found
+    assert at_least_one_place_found
     # Test cluttered table data collection
     utils.reset_config({
         "env": "cluttered_table",
@@ -182,7 +251,7 @@ def test_demo_replay_dataset():
     })
     env = ClutteredTableEnv()
     train_tasks = env.get_train_tasks()
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     assert len(dataset.trajectories[-1].states) == 2
     assert len(dataset.trajectories[-1].actions) == 1
 
@@ -200,7 +269,7 @@ def test_dataset_with_annotations():
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
-    trajectories = create_dataset(env, train_tasks).trajectories
+    trajectories = create_dataset(env, train_tasks, env.options).trajectories
     # The annotations and trajectories need to be the same length.
     with pytest.raises(AssertionError):
         dataset = Dataset(trajectories, [])
@@ -227,7 +296,7 @@ def test_ground_atom_dataset():
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     assert len(dataset.trajectories) == 15
     assert len(dataset.annotations) == 15
     Covers, HandEmpty, Holding = _get_predicates_by_names(
@@ -277,7 +346,7 @@ def test_ground_atom_dataset():
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
     with pytest.raises(ValueError):
-        create_dataset(env, train_tasks)
+        create_dataset(env, train_tasks, env.options)
 
 
 def test_empty_dataset():
@@ -288,7 +357,7 @@ def test_empty_dataset():
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     assert len(dataset.trajectories) == 0
     with pytest.raises(AssertionError):
         _ = dataset.annotations

--- a/tests/nsrt_learning/test_nsrt_learning_main.py
+++ b/tests/nsrt_learning/test_nsrt_learning_main.py
@@ -34,6 +34,7 @@ def test_nsrt_learning_specific_nsrts():
     action_space = Box(0, 1, (1, ))
     param_option1 = utils.SingletonParameterizedOption(
         "Dummy", lambda s, m, o, p: Action(p), params_space=Box(0.1, 1, (1, )))
+    options = {param_option1}
     option1 = param_option1.ground([], np.array([0.2]))
     assert option1.initiable(state1)
     action1 = option1.policy(state1)
@@ -42,6 +43,7 @@ def test_nsrt_learning_specific_nsrts():
     dataset = [LowLevelTrajectory([state1, next_state1], [action1])]
     nsrts, _, _ = learn_nsrts_from_data(dataset, [],
                                         preds,
+                                        options,
                                         action_space,
                                         sampler_learner="neural")
     assert len(nsrts) == 1
@@ -66,6 +68,7 @@ def test_nsrt_learning_specific_nsrts():
     preds = {pred0, pred1, pred2}
     state1 = State({cup0: [0.4], cup1: [0.7], cup2: [0.1]})
     option1 = param_option1.ground([], np.array([0.2]))
+    options = {param_option1}
     assert option1.initiable(state1)
     action1 = option1.policy(state1)
     action1.set_option(option1)
@@ -82,6 +85,7 @@ def test_nsrt_learning_specific_nsrts():
     ]
     nsrts, _, _ = learn_nsrts_from_data(dataset, [],
                                         preds,
+                                        options,
                                         action_space,
                                         sampler_learner="random")
     assert len(nsrts) == 1
@@ -116,6 +120,7 @@ def test_nsrt_learning_specific_nsrts():
         "Dummy",
         lambda s, m, o, p: Action(p),
         params_space=Box(0.1, 0.5, (1, )))
+    options = {param_option1, param_option2}
     option2 = param_option2.ground([], np.array([0.5]))
     assert option2.initiable(state2)
     action2 = option2.policy(state2)
@@ -127,6 +132,7 @@ def test_nsrt_learning_specific_nsrts():
     ]
     nsrts, _, _ = learn_nsrts_from_data(dataset, [],
                                         preds,
+                                        options,
                                         action_space,
                                         sampler_learner="random")
     assert len(nsrts) == 2
@@ -172,6 +178,7 @@ def test_nsrt_learning_specific_nsrts():
     ]
     nsrts, _, _ = learn_nsrts_from_data(dataset, [],
                                         preds,
+                                        options,
                                         action_space,
                                         sampler_learner="random")
     assert len(nsrts) == 2
@@ -202,6 +209,7 @@ def test_nsrt_learning_specific_nsrts():
     })
     nsrts, _, _ = learn_nsrts_from_data(dataset, [],
                                         preds,
+                                        options,
                                         action_space,
                                         sampler_learner="random")
     assert len(nsrts) == 0
@@ -212,6 +220,7 @@ def test_nsrt_learning_specific_nsrts():
     })
     nsrts, _, _ = learn_nsrts_from_data(dataset, [],
                                         preds,
+                                        options,
                                         action_space,
                                         sampler_learner="random")
     assert len(nsrts) == 0
@@ -225,6 +234,7 @@ def test_nsrt_learning_specific_nsrts():
     })
     nsrts, _, _ = learn_nsrts_from_data(dataset, [],
                                         preds,
+                                        options,
                                         action_space,
                                         sampler_learner="neural")
     assert len(nsrts) == 2

--- a/tests/nsrt_learning/test_option_learning.py
+++ b/tests/nsrt_learning/test_option_learning.py
@@ -31,7 +31,7 @@ def test_known_options_option_learner():
     })
     env = create_new_env("cover")
     train_tasks = env.get_train_tasks()
-    dataset = create_demo_replay_data(env, train_tasks)
+    dataset = create_demo_replay_data(env, train_tasks, env.options)
     ground_atom_dataset = utils.create_ground_atom_dataset(
         dataset.trajectories, env.predicates)
     for traj, _ in ground_atom_dataset:
@@ -74,7 +74,7 @@ def test_oracle_option_learner_cover():
     })
     env = create_new_env("cover")
     train_tasks = env.get_train_tasks()
-    dataset = create_demo_replay_data(env, train_tasks)
+    dataset = create_demo_replay_data(env, train_tasks, known_options=set())
     ground_atom_dataset = utils.create_ground_atom_dataset(
         dataset.trajectories, env.predicates)
     for traj, _ in ground_atom_dataset:
@@ -122,7 +122,7 @@ def test_oracle_option_learner_blocks():
     })
     env = create_new_env("blocks")
     train_tasks = env.get_train_tasks()
-    dataset = create_demo_replay_data(env, train_tasks)
+    dataset = create_demo_replay_data(env, train_tasks, known_options=set())
     ground_atom_dataset = utils.create_ground_atom_dataset(
         dataset.trajectories, env.predicates)
     for traj, _ in ground_atom_dataset:
@@ -272,7 +272,7 @@ def test_option_learning_approach_multistep_cover():
     train_tasks = env.get_train_tasks()
     approach = create_approach("nsrt_learning", env.predicates, env.options,
                                env.types, env.action_space, train_tasks)
-    dataset = create_dataset(env, train_tasks, env.options)
+    dataset = create_dataset(env, train_tasks, known_options=set())
     assert approach.is_learning_based
     approach.learn_from_offline_dataset(dataset)
     num_test_successes = 0
@@ -307,7 +307,7 @@ def test_implicit_bc_option_learning_touch_point():
     train_tasks = env.get_train_tasks()
     approach = create_approach("nsrt_learning", env.predicates, env.options,
                                env.types, env.action_space, train_tasks)
-    dataset = create_dataset(env, train_tasks, env.options)
+    dataset = create_dataset(env, train_tasks, known_options=set())
     assert approach.is_learning_based
     approach.learn_from_offline_dataset(dataset)
     num_test_successes = 0

--- a/tests/nsrt_learning/test_option_learning.py
+++ b/tests/nsrt_learning/test_option_learning.py
@@ -272,7 +272,7 @@ def test_option_learning_approach_multistep_cover():
     train_tasks = env.get_train_tasks()
     approach = create_approach("nsrt_learning", env.predicates, env.options,
                                env.types, env.action_space, train_tasks)
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     assert approach.is_learning_based
     approach.learn_from_offline_dataset(dataset)
     num_test_successes = 0
@@ -307,7 +307,7 @@ def test_implicit_bc_option_learning_touch_point():
     train_tasks = env.get_train_tasks()
     approach = create_approach("nsrt_learning", env.predicates, env.options,
                                env.types, env.action_space, train_tasks)
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     assert approach.is_learning_based
     approach.learn_from_offline_dataset(dataset)
     num_test_successes = 0

--- a/tests/nsrt_learning/test_segmentation.py
+++ b/tests/nsrt_learning/test_segmentation.py
@@ -176,7 +176,7 @@ def test_segment_trajectory():
     env = create_new_env("cover_multistep_options", do_cache=False)
     train_tasks = env.get_train_tasks()
     assert len(train_tasks) == 1
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     ground_atom_dataset = utils.create_ground_atom_dataset(
         dataset.trajectories, env.predicates)
     assert len(ground_atom_dataset) == 1
@@ -210,7 +210,7 @@ def test_contact_based_segmentation(env):
     env = create_new_env(env, do_cache=False)
     train_tasks = env.get_train_tasks()
     assert len(train_tasks) == 1
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     ground_atom_dataset = utils.create_ground_atom_dataset(
         dataset.trajectories, env.predicates)
     assert len(ground_atom_dataset) == 1

--- a/tests/nsrt_learning/test_segmentation.py
+++ b/tests/nsrt_learning/test_segmentation.py
@@ -176,7 +176,7 @@ def test_segment_trajectory():
     env = create_new_env("cover_multistep_options", do_cache=False)
     train_tasks = env.get_train_tasks()
     assert len(train_tasks) == 1
-    dataset = create_dataset(env, train_tasks, env.options)
+    dataset = create_dataset(env, train_tasks, known_options=set())
     ground_atom_dataset = utils.create_ground_atom_dataset(
         dataset.trajectories, env.predicates)
     assert len(ground_atom_dataset) == 1

--- a/tests/test_online_learning.py
+++ b/tests/test_online_learning.py
@@ -93,7 +93,7 @@ def test_interaction():
     train_tasks = env.get_train_tasks()
     approach = _MockApproach(env.predicates, env.options, env.types,
                              env.action_space, train_tasks)
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     _run_pipeline(env, approach, train_tasks, dataset)
     utils.update_config({
         "approach": "nsrt_learning",

--- a/tests/test_predicate_search_score_functions.py
+++ b/tests/test_predicate_search_score_functions.py
@@ -154,7 +154,7 @@ def test_prediction_error_score_function():
             initial_predicates.add(p)
     candidates = {p: 1.0 for p in name_to_pred.values()}
     train_tasks = env.get_train_tasks()
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     atom_dataset = utils.create_ground_atom_dataset(dataset.trajectories,
                                                     env.predicates)
     score_function = _PredictionErrorScoreFunction(initial_predicates,
@@ -187,7 +187,7 @@ def test_prediction_error_score_function():
             initial_predicates.add(p)
     candidates = {p: 1.0 for p in name_to_pred.values()}
     train_tasks = env.get_train_tasks()
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     atom_dataset = utils.create_ground_atom_dataset(dataset.trajectories,
                                                     env.predicates)
     score_function = _PredictionErrorScoreFunction(initial_predicates,
@@ -224,7 +224,7 @@ def test_hadd_match_score_function():
             initial_predicates.add(p)
     candidates = {p: 1.0 for p in name_to_pred.values()}
     train_tasks = env.get_train_tasks()
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     atom_dataset = utils.create_ground_atom_dataset(dataset.trajectories,
                                                     env.predicates)
     score_function = _RelaxationHeuristicMatchBasedScoreFunction(
@@ -254,7 +254,7 @@ def test_relaxation_energy_score_function():
             initial_predicates.add(p)
     candidates = {p: 1.0 for p in name_to_pred.values()}
     train_tasks = env.get_train_tasks()
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     atom_dataset = utils.create_ground_atom_dataset(dataset.trajectories,
                                                     env.predicates)
     score_function = _RelaxationHeuristicEnergyBasedScoreFunction(
@@ -315,7 +315,7 @@ def test_relaxation_energy_score_function():
             initial_predicates.add(p)
     candidates = {p: 1.0 for p in name_to_pred.values()}
     train_tasks = env.get_train_tasks()
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     atom_dataset = utils.create_ground_atom_dataset(dataset.trajectories,
                                                     env.predicates)
     score_function = _RelaxationHeuristicEnergyBasedScoreFunction(
@@ -370,7 +370,7 @@ def test_relaxation_energy_score_function():
     #         initial_predicates.add(p)
     # candidates = {p: 1.0 for p in name_to_pred.values()}
     # train_tasks = env.get_train_tasks()
-    # dataset = create_dataset(env, train_tasks)
+    # dataset = create_dataset(env, train_tasks, env.options)
     # atom_dataset = utils.create_ground_atom_dataset(dataset.trajectories,
     #                                                 env.predicates)
     # score_function = _RelaxationHeuristicEnergyBasedScoreFunction(
@@ -446,7 +446,7 @@ def test_exact_energy_score_function():
             initial_predicates.add(p)
     candidates = {p: 1.0 for p in name_to_pred.values()}
     train_tasks = env.get_train_tasks()
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     atom_dataset = utils.create_ground_atom_dataset(dataset.trajectories,
                                                     env.predicates)
     score_function = _ExactHeuristicEnergyBasedScoreFunction(
@@ -511,7 +511,7 @@ def test_count_score_functions():
     NotHandEmpty = name_to_pred["HandEmpty"].get_negation()
     candidates[NotHandEmpty] = 1.0
     train_tasks = env.get_train_tasks()
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     atom_dataset = utils.create_ground_atom_dataset(dataset.trajectories,
                                                     env.predicates)
     for name in ["exact_count", "lmcut_count_lookaheaddepth0"]:
@@ -561,7 +561,7 @@ def test_branching_factor_score_function():
         Holding: 1.0,
     }
     train_tasks = env.get_train_tasks()
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     atom_dataset = utils.create_ground_atom_dataset(
         dataset.trajectories, env.goal_predicates | set(candidates))
     score_function = _BranchingFactorScoreFunction(env.goal_predicates,
@@ -595,7 +595,7 @@ def test_task_planning_score_function():
         HandEmpty: 1.0,
     }
     train_tasks = env.get_train_tasks()
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     atom_dataset = utils.create_ground_atom_dataset(
         dataset.trajectories, env.goal_predicates | set(candidates))
     score_function = _TaskPlanningScoreFunction(env.goal_predicates,
@@ -640,7 +640,7 @@ def test_expected_nodes_score_function():
             HandEmpty: 1.0,
         }
         train_tasks = env.get_train_tasks()
-        dataset = create_dataset(env, train_tasks)
+        dataset = create_dataset(env, train_tasks, env.options)
         atom_dataset = utils.create_ground_atom_dataset(
             dataset.trajectories, env.goal_predicates | set(candidates))
         score_function = _ExpectedNodesScoreFunction(
@@ -671,7 +671,7 @@ def test_expected_nodes_score_function():
         "min_data_for_nsrt": 0,
     })
     train_tasks = env.get_train_tasks()
-    dataset = create_dataset(env, train_tasks)
+    dataset = create_dataset(env, train_tasks, env.options)
     atom_dataset = utils.create_ground_atom_dataset(
         dataset.trajectories, env.goal_predicates | set(candidates))
     score_function = _ExpectedNodesScoreFunction(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2206,12 +2206,13 @@ def test_get_config_path_str():
         "approach": "dummyapproach",
         "seed": 321,
         "excluded_predicates": "all",
+        "included_options": "Dummy1,Dummy2",
         "experiment_id": "foobar",
     })
     s = utils.get_config_path_str()
-    assert s == "dummyenv__dummyapproach__321__all__foobar"
+    assert s == "dummyenv__dummyapproach__321__all__Dummy1,Dummy2__foobar"
     s = utils.get_config_path_str("override_id")
-    assert s == "dummyenv__dummyapproach__321__all__override_id"
+    assert s == "dummyenv__dummyapproach__321__all__Dummy1,Dummy2__override_id"
 
 
 def test_get_approach_save_path_str():
@@ -2224,21 +2225,23 @@ def test_get_approach_save_path_str():
         "seed": 123,
         "approach_dir": dirname,
         "excluded_predicates": "test_pred1,test_pred2",
+        "included_options": "Dummy1",
         "experiment_id": "baz",
     })
     save_path = utils.get_approach_save_path_str()
     assert save_path == dirname + ("/test_env__test_approach__123__"
-                                   "test_pred1,test_pred2__baz.saved")
+                                   "test_pred1,test_pred2__Dummy1__baz.saved")
     utils.reset_config({
         "env": "test_env",
         "approach": "test_approach",
         "seed": 123,
         "approach_dir": dirname,
         "excluded_predicates": "",
+        "included_options": "",
         "experiment_id": "",
     })
     save_path = utils.get_approach_save_path_str()
-    assert save_path == dirname + "/test_env__test_approach__123____.saved"
+    assert save_path == dirname + "/test_env__test_approach__123______.saved"
     os.rmdir(dirname)
     utils.reset_config({"approach_dir": old_approach_dir})
 
@@ -2253,29 +2256,31 @@ def test_get_approach_load_path_str():
         "seed": 123,
         "approach_dir": dirname,
         "excluded_predicates": "test_pred1,test_pred2",
+        "included_options": "Dummy1",
         "experiment_id": "baz",
         "load_experiment_id": "foo",
     })
     save_path = utils.get_approach_save_path_str()
     assert save_path == dirname + ("/test_env__test_approach__123__"
-                                   "test_pred1,test_pred2__baz.saved")
+                                   "test_pred1,test_pred2__Dummy1__baz.saved")
     load_path = utils.get_approach_load_path_str()
     assert load_path == dirname + ("/test_env__test_approach__123__"
-                                   "test_pred1,test_pred2__foo.saved")
+                                   "test_pred1,test_pred2__Dummy1__foo.saved")
     utils.reset_config({
         "env": "test_env",
         "approach": "test_approach",
         "seed": 123,
         "approach_dir": dirname,
         "excluded_predicates": "test_pred1,test_pred2",
+        "included_options": "Dummy1",
         "experiment_id": "baz",
     })
     save_path = utils.get_approach_save_path_str()
     assert save_path == dirname + ("/test_env__test_approach__123__"
-                                   "test_pred1,test_pred2__baz.saved")
+                                   "test_pred1,test_pred2__Dummy1__baz.saved")
     load_path = utils.get_approach_load_path_str()
     assert load_path == dirname + ("/test_env__test_approach__123__"
-                                   "test_pred1,test_pred2__baz.saved")
+                                   "test_pred1,test_pred2__Dummy1__baz.saved")
     os.rmdir(dirname)
     utils.reset_config({"approach_dir": old_approach_dir})
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2682,6 +2682,44 @@ def test_parse_config_excluded_predicates():
         utils.parse_config_excluded_predicates(env)
 
 
+def test_parse_config_included_options():
+    """Tests for parse_config_included_options()."""
+    # Test including nothing.
+    utils.reset_config({
+        "env": "cover_multistep_options",
+        "included_options": "",
+    })
+    env = CoverMultistepOptions()
+    included = utils.parse_config_included_options(env)
+    assert not included
+    # Test including specific options.
+    utils.reset_config({
+        "included_options": "Pick",
+    })
+    Pick, Place = sorted(env.options)
+    assert Pick.name == "Pick"
+    assert Place.name == "Place"
+    included = utils.parse_config_included_options(env)
+    assert included == {Pick}
+    utils.reset_config({
+        "included_options": "Place",
+    })
+    included = utils.parse_config_included_options(env)
+    assert included == {Place}
+    utils.reset_config({
+        "included_options": "Pick,Place",
+    })
+    included = utils.parse_config_included_options(env)
+    assert included == {Pick, Place}
+    # Test including an unknown option.
+    utils.reset_config({
+        "included_options": "Pick,NotReal",
+    })
+    with pytest.raises(AssertionError) as e:
+        utils.parse_config_included_options(env)
+    assert "Unrecognized option in included_options!" in str(e)
+
+
 def test_null_sampler():
     """Tests for null_sampler()."""
     assert utils.null_sampler(None, None, None, None).shape == (0, )


### PR DESCRIPTION
closes #873 

* the main updates are in dataset creation and option learning
* tested with including various options in stick_button and multistep cover 
* looked through the baselines and they all seem relatively unaffected because by the time we start using them, we just have segments with options, some of which happen to be learned, and others which happen to be oracle
* grepped for occurrences of "has_option" and "no_learning", and made sure that the remaining ones make sense
* I'm not updating the segmenters because I foresee contact-based segmentation being enough for now