### PR TITLE
minor change in requirements-dev to specify yapf version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 pytest-cov>=2.12.1
 pytest-pylint>=0.18.0
-yapf
+yapf==0.32.0
 docformatter
 isort
 # Note: if https://github.com/python/mypy/issues/5485 gets resolved, we can install mypy from head again.


### PR DESCRIPTION
Specifies the version of `yapf`, because @wmcclinton's system happened to `pip install` an older version, which caused all sorts of weird formatting changes. We want to avoid this for any new users in the future!