### PR TITLE
fix to doors action space

### DIFF
--- a/src/envs/doors.py
+++ b/src/envs/doors.py
@@ -186,9 +186,10 @@ class DoorsEnv(BaseEnv):
     @property
     def action_space(self) -> Box:
         # dx, dy, drot
-        lb = np.array([-self.action_magnitude, -self.action_magnitude, -np.pi],
-                      dtype=np.float32)
-        ub = np.array([self.action_magnitude, self.action_magnitude, np.pi],
+        lb = np.array(
+            [-self.action_magnitude, -self.action_magnitude, -np.inf],
+            dtype=np.float32)
+        ub = np.array([self.action_magnitude, self.action_magnitude, np.inf],
                       dtype=np.float32)
         return Box(lb, ub)
 


### PR DESCRIPTION
fixes a crash with oracle options. the old action bounds didn't make sense, they were left over from a time where I was thinking about door handle rotations literally...