### PR TITLE
separate online and offline transitions in metrics

### DIFF
--- a/scripts/analyze_results_directory.py
+++ b/scripts/analyze_results_directory.py
@@ -39,7 +39,8 @@ COLUMN_NAMES_AND_KEYS = [
     # ("AVG_DISCOVERED_FAILURES", "avg_num_failures_discovered"),
     # ("AVG_PLAN_LEN", "avg_plan_length"),
     # ("NUM_EXECUTION_FAILURES", "num_execution_failures"),
-    # ("NUM_TRANSITIONS", "num_transitions"),
+    # ("NUM_OFFLINE_TRANSITIONS", "num_offline_transitions"),
+    # ("NUM_ONLINE_TRANSITIONS", "num_online_transitions"),
     # ("QUERY_COST", "query_cost"),
 ]
 

--- a/scripts/plotting/create_interactive_predicate_learning_plots.py
+++ b/scripts/plotting/create_interactive_predicate_learning_plots.py
@@ -26,7 +26,8 @@ COLUMN_NAMES_AND_KEYS = [
     ("SEED", "seed"),
     ("NUM_SOLVED", "num_solved"),
     ("PERC_SOLVED", "perc_solved"),
-    ("NUM_TRANSITIONS", "num_transitions"),
+    ("NUM_OFFLINE_TRANSITIONS", "num_offline_transitions"),
+    ("NUM_ONLINE_TRANSITIONS", "num_online_transitions"),
     ("QUERY_COST", "query_cost"),
     ("PERC_EXEC_FAIL", "perc_exec_fail"),
     ("PERC_PLAN_FAIL", "perc_plan_fail"),
@@ -44,7 +45,7 @@ DERIVED_KEYS = [
 # x axis. See COLUMN_NAMES_AND_KEYS for all available metrics. The second
 # element is used to label the x axis.
 X_KEY_AND_LABEL = [
-    ("NUM_TRANSITIONS", "Number of Transitions"),
+    ("NUM_ONLINE_TRANSITIONS", "Number of Online Transitions"),
 ]
 
 # Same as above, but for the y axis.

--- a/scripts/plotting/create_num_demos_plots.py
+++ b/scripts/plotting/create_num_demos_plots.py
@@ -133,11 +133,7 @@ def _main() -> None:
                                 yerr=y_stds,
                                 label=label,
                                 marker=marker)
-                # Automatically make x ticks integers for certain X KEYS.
-                if x_key == "CYCLE":
-                    ax.xaxis.set_major_locator(MaxNLocator(integer=True))
-                elif x_key == "NUM_TRAIN_TASKS":
-                    ax.set_xticks(xs)
+                ax.set_xticks(xs)
                 ax.set_title(plot_title)
                 ax.set_xlabel(x_label)
                 ax.set_ylabel(y_label)

--- a/scripts/plotting/create_num_demos_plots.py
+++ b/scripts/plotting/create_num_demos_plots.py
@@ -40,6 +40,7 @@ COLUMN_NAMES_AND_KEYS = [
     ("AVG_NODES_CREATED", "avg_num_nodes_created"),
     ("LEARNING_TIME", "learning_time"),
     ("PERC_SOLVED", "perc_solved"),
+    ("NUM_OFFLINE_TRANSITIONS", "num_offline_transitions"),
 ]
 
 DERIVED_KEYS = [("perc_solved",

--- a/scripts/plotting/create_num_demos_plots.py
+++ b/scripts/plotting/create_num_demos_plots.py
@@ -5,7 +5,6 @@ import os
 import matplotlib
 import matplotlib.pyplot as plt
 import pandas as pd
-from matplotlib.ticker import MaxNLocator
 
 from predicators.scripts.analyze_results_directory import create_dataframes, \
     get_df_for_entry

--- a/scripts/plotting/create_num_demos_plots.py
+++ b/scripts/plotting/create_num_demos_plots.py
@@ -50,7 +50,6 @@ DERIVED_KEYS = [("perc_solved",
 # element is used to label the x axis.
 X_KEY_AND_LABEL = [
     ("NUM_TRAIN_TASKS", "Number of Training Tasks"),
-    # ("NUM_TRANSITIONS", "Num transitions"),
     # ("LEARNING_TIME", "Learning time in seconds"),
 ]
 
@@ -135,7 +134,7 @@ def _main() -> None:
                                 label=label,
                                 marker=marker)
                 # Automatically make x ticks integers for certain X KEYS.
-                if x_key in ("CYCLE", "NUM_TRANSITIONS"):
+                if x_key in ("CYCLE", "NUM_OFFLINE_TRANSITIONS"):
                     ax.xaxis.set_major_locator(MaxNLocator(integer=True))
                 elif x_key == "NUM_TRAIN_TASKS":
                     ax.set_xticks(xs)

--- a/scripts/plotting/create_num_demos_plots.py
+++ b/scripts/plotting/create_num_demos_plots.py
@@ -40,7 +40,6 @@ COLUMN_NAMES_AND_KEYS = [
     ("AVG_NODES_CREATED", "avg_num_nodes_created"),
     ("LEARNING_TIME", "learning_time"),
     ("PERC_SOLVED", "perc_solved"),
-    ("NUM_OFFLINE_TRANSITIONS", "num_offline_transitions"),
 ]
 
 DERIVED_KEYS = [("perc_solved",
@@ -135,7 +134,7 @@ def _main() -> None:
                                 label=label,
                                 marker=marker)
                 # Automatically make x ticks integers for certain X KEYS.
-                if x_key in ("CYCLE", "NUM_OFFLINE_TRANSITIONS"):
+                if x_key == "CYCLE":
                     ax.xaxis.set_major_locator(MaxNLocator(integer=True))
                 elif x_key == "NUM_TRAIN_TASKS":
                     ax.set_xticks(xs)

--- a/src/main.py
+++ b/src/main.py
@@ -149,7 +149,7 @@ def _run_pipeline(env: BaseEnv,
                 continue
             logging.info(f"\n\nONLINE LEARNING CYCLE {i}\n")
             logging.info("Getting interaction requests...")
-            if num_online_transitions > CFG.online_learning_max_transitions:
+            if num_online_transitions >= CFG.online_learning_max_transitions:
                 logging.info("Reached online_learning_max_transitions, "
                              "terminating")
                 break

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -128,7 +128,7 @@ def test_main():
     sys.argv = [
         "dummy", "--env", "cover", "--approach", "interactive_learning",
         "--seed", "123", "--num_online_learning_cycles", "1",
-        "--online_learning_max_transitions", "3", "--excluded_predicates",
+        "--online_learning_max_transitions", "0", "--excluded_predicates",
         "Covers", "--interactive_num_ensemble_members", "1",
         "--num_train_tasks", "3", "--num_test_tasks", "3",
         "--predicate_mlp_classifier_max_itr", "100"


### PR DESCRIPTION
closes #893 

@amburger66 this change is going to break the plotting script for any results that were previously generated. to plot old results, we could modify the script locally as needed. or, we can make this change backward compatible, but i'm worried then that we're going to get confused about what "num transitions" means... let me know what you think