### PR TITLE
add a strong timeout to prediction error hill climbing baseline

### DIFF
--- a/src/nsrt_learning/strips_learning/clustering_learner.py
+++ b/src/nsrt_learning/strips_learning/clustering_learner.py
@@ -397,8 +397,10 @@ class ClusterAndIntersectSidelinePredictionErrorSTRIPSLearner(
         segments = [seg for traj in self._segmented_trajs for seg in traj]
         strips_ops = [pnad.op for pnad in s]
         option_specs = [pnad.option_spec for pnad in s]
+        max_groundings = CFG.cluster_and_intersect_prederror_max_groundings
         num_true_positives, num_false_positives, _, _ = \
-            utils.count_positives_for_ops(strips_ops, option_specs, segments)
+            utils.count_positives_for_ops(strips_ops, option_specs, segments,
+                                          max_groundings=max_groundings)
         # Note: lower is better! We want more true positives and fewer
         # false positives.
         tp_w = CFG.clustering_learner_true_pos_weight

--- a/src/settings.py
+++ b/src/settings.py
@@ -220,6 +220,7 @@ class GlobalSettings:
     disable_harmlessness_check = False  # some methods may want this to be True
     clustering_learner_true_pos_weight = 10
     clustering_learner_false_pos_weight = 1
+    cluster_and_intersect_prederror_max_groundings = 10
     cluster_and_search_inner_search_max_expansions = 2500
     cluster_and_search_inner_search_timeout = 30
     cluster_and_search_score_func_max_groundings = 10000

--- a/src/utils.py
+++ b/src/utils.py
@@ -89,8 +89,8 @@ def count_positives_for_ops(
             # that are not in the option vars, and consider all
             # groundings of them.
             for grounding_idx, ground_op in enumerate(
-                    all_ground_operators_given_partial(
-                        op, objects, option_var_to_obj)):
+                    all_ground_operators_given_partial(op, objects,
+                                                       option_var_to_obj)):
                 if max_groundings is not None and \
                    grounding_idx > max_groundings:
                     break

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,7 +23,9 @@ from predicators.src.utils import GoalCountHeuristic, \
     _PyperplanHeuristicWrapper, _TaskPlanningHeuristic
 
 
-def test_count_positives_for_ops():
+@pytest.mark.parametrize("max_groundings,exp_num_true,exp_num_false",
+                         [(-1, 0, 0), (None, 1, 1)])
+def test_count_positives_for_ops(max_groundings, exp_num_true, exp_num_false):
     """Tests for count_positives_for_ops()."""
     utils.reset_config({"segmenter": "atom_changes"})
     cup_type = Type("cup_type", ["feat1"])
@@ -70,9 +72,9 @@ def test_count_positives_for_ops():
     ]
 
     num_true, num_false, _, _ = utils.count_positives_for_ops(
-        strips_ops, option_specs, segments)
-    assert num_true == 1
-    assert num_false == 1
+        strips_ops, option_specs, segments, max_groundings=max_groundings)
+    assert num_true == exp_num_true
+    assert num_false == exp_num_false
 
 
 def test_segment_trajectory_to_state_and_atoms_sequence():


### PR DESCRIPTION
we can try running this as is, but at least based on my local testing, i think we'll still have issues for rnt_painting, because the call to recompute_datastores_from_segments is still very expensive, and i don't know how to get around it.

works well on painting and screws, works decently on rnt_single_option (~40/50)