### PR TITLE
disallow groundings with repeated objects in `recompute_datastores_from_segments()`

### DIFF
--- a/src/nsrt_learning/option_learning.py
+++ b/src/nsrt_learning/option_learning.py
@@ -93,6 +93,7 @@ class KnownOptionsOptionLearner(_OptionLearnerBase):
                 option = segment.actions[0].get_option()
                 if i == 0:
                     obj_to_var = {o: v for v, o in var_to_obj.items()}
+                    assert len(var_to_obj) == len(obj_to_var)
                     param_option = option.parent
                     option_vars = [obj_to_var[o] for o in option.objects]
                 else:

--- a/src/nsrt_learning/strips_learning/base_strips_learner.py
+++ b/src/nsrt_learning/strips_learning/base_strips_learner.py
@@ -216,6 +216,8 @@ class BaseSTRIPSLearner(abc.ABC):
                     isub = dict(zip(opt_vars, segment_option_objs))
                     for ground_op in utils.all_ground_operators_given_partial(
                             pnad.op, objects, isub):
+                        if len(ground_op.objects) != len(set(ground_op.objects)):
+                            continue
                         # If the preconditions don't hold in the segment's
                         # initial atoms, skip.
                         if not ground_op.preconditions.issubset(

--- a/src/nsrt_learning/strips_learning/base_strips_learner.py
+++ b/src/nsrt_learning/strips_learning/base_strips_learner.py
@@ -216,7 +216,8 @@ class BaseSTRIPSLearner(abc.ABC):
                     isub = dict(zip(opt_vars, segment_option_objs))
                     for ground_op in utils.all_ground_operators_given_partial(
                             pnad.op, objects, isub):
-                        if len(ground_op.objects) != len(set(ground_op.objects)):
+                        if len(ground_op.objects) != len(set(
+                                ground_op.objects)):
                             continue
                         # If the preconditions don't hold in the segment's
                         # initial atoms, skip.


### PR DESCRIPTION
this fixes some crashes that were arising in prediction error for rnt painting, where if two different option variables map to the same object in a segment’s sub dict, then KnownOptionsOptionLearner will crash, bc it has to invert that mapping to figure out what the option variables are from the objects in each segment’s option (furthermore, this inverted mapping has to be consistent across all segments in the datastore)

supercloud results look good for both nightly and sidelining:
```
Git commit hashes seen in results/:
3cba5be02b36d0084e9ea13e17ea215f0a62c025


AGGREGATED DATA OVER SEEDS:
                                  NUM_TRAIN_TASKS    NUM_SOLVED AVG_NUM_PREDS AVG_TEST_TIME  AVG_NODES_CREATED       LEARNING_TIME  NUM_SEEDS
EXPERIMENT_ID                                                                                                                                
cover_invent_allexclude              50.00 (0.00)  49.30 (0.90)   5.90 (0.54)   0.01 (0.00)        5.00 (0.23)      142.01 (15.71)         10
cover_invent_noexclude               50.00 (0.00)  49.30 (0.90)   7.00 (0.45)   0.01 (0.00)        5.00 (0.23)       88.38 (11.71)         10
cover_nsrt_learning                  50.00 (0.00)  49.50 (0.50)   5.00 (0.00)   0.06 (0.02)        6.66 (0.36)        20.63 (1.68)         10
cover_oracle                          0.00 (0.00)  50.00 (0.00)   5.00 (0.00)   0.04 (0.01)        6.66 (0.32)         0.00 (0.00)         10
painting_invent_allexclude           50.00 (0.00)  47.30 (2.33)  21.70 (2.49)   0.17 (0.05)    299.41 (118.62)  16687.80 (3930.24)         10
painting_invent_noexclude            50.00 (0.00)  47.00 (2.65)  22.50 (2.11)   0.17 (0.04)    311.43 (115.51)   6581.80 (1816.96)         10
painting_nsrt_learning               50.00 (0.00)  49.50 (0.50)  14.00 (0.00)   0.41 (0.11)   1726.65 (694.62)        73.97 (5.88)         10
painting_oracle                       0.00 (0.00)  50.00 (0.00)  14.00 (0.00)   0.38 (0.09)   2301.79 (738.99)         0.00 (0.00)         10
playroom_nsrt_learning               50.00 (0.00)  50.00 (0.00)  19.00 (0.00)   0.15 (0.00)       44.28 (1.11)       211.36 (6.02)         10
playroom_oracle                       0.00 (0.00)  50.00 (0.00)  19.00 (0.00)   0.15 (0.00)       82.54 (3.67)         0.00 (0.00)         10
pybullet_blocks_invent_allexclude    50.00 (0.00)  49.00 (0.77)   6.20 (0.75)   0.41 (0.11)  3689.97 (2079.22)    2310.10 (146.90)         10
pybullet_blocks_invent_noexclude     50.00 (0.00)  49.30 (0.64)   6.20 (1.78)   0.47 (0.20)  4137.28 (2075.15)   1483.10 (1627.89)         10
pybullet_blocks_nsrt_learning        50.00 (0.00)  49.60 (0.49)   5.00 (0.00)   0.40 (0.11)  4201.33 (2124.80)        18.77 (1.91)         10
pybullet_blocks_oracle                0.00 (0.00)  49.80 (0.40)   5.00 (0.00)   0.39 (0.11)  4259.69 (2224.80)         0.00 (0.00)         10
pybullet_cover_invent_allexclude     50.00 (0.00)  47.70 (1.95)   6.00 (0.45)   0.05 (0.01)        4.94 (0.22)      245.00 (23.37)         10
pybullet_cover_invent_noexclude      50.00 (0.00)  47.70 (1.95)   7.10 (0.30)   0.05 (0.01)        4.94 (0.22)      157.25 (16.88)         10
pybullet_cover_nsrt_learning         50.00 (0.00)  47.80 (1.99)   5.00 (0.00)   0.10 (0.02)        6.64 (0.33)        21.25 (1.62)         10
pybullet_cover_oracle                 0.00 (0.00)  47.20 (1.40)   5.00 (0.00)   0.08 (0.01)        6.66 (0.32)         0.00 (0.00)         10
stick_button_nsrt_learning          500.00 (0.00)  47.60 (1.11)   6.00 (0.00)   0.23 (0.04)     317.70 (31.79)        18.07 (3.35)         10
stick_button_oracle                   0.00 (0.00)  45.20 (1.99)   6.00 (0.00)   0.19 (0.03)     320.32 (46.92)         0.00 (0.00)         10
tools_invent_allexclude             200.00 (0.00)  45.40 (5.82)  28.10 (5.96)   0.37 (0.16)  1964.57 (1592.47)  18224.20 (3471.68)         10
tools_invent_noexclude              200.00 (0.00)  47.10 (3.88)  25.40 (3.61)   0.28 (0.11)  1466.91 (1150.78)   5807.07 (1696.16)         10
tools_nsrt_learning                 200.00 (0.00)  49.40 (0.66)  15.00 (0.00)   0.51 (0.09)  4779.29 (1006.97)       169.36 (2.76)         10
tools_oracle                          0.00 (0.00)  50.00 (0.00)  15.00 (0.00)   0.42 (0.09)  4733.39 (1155.01)         0.00 (0.00)         10
```

```
Git commit hashes seen in results/:
3cba5be02b36d0084e9ea13e17ea215f0a62c025


AGGREGATED DATA OVER SEEDS:
                                      NUM_TRAIN_TASKS     NUM_SOLVED AVG_NUM_PREDS AVG_TEST_TIME  AVG_NODES_CREATED     LEARNING_TIME  NUM_SEEDS
EXPERIMENT_ID                                                                                                                                   
painting_backchaining_10demo             10.00 (0.00)   41.80 (4.09)  14.00 (0.00)   0.46 (0.20)   1986.21 (941.49)      54.45 (4.99)         10
painting_backchaining_25demo             25.00 (0.00)   49.20 (1.17)  14.00 (0.00)   0.39 (0.07)   2378.04 (829.09)      62.21 (5.81)         10
painting_backchaining_50demo             50.00 (0.00)   49.40 (0.66)  14.00 (0.00)   0.44 (0.14)  2748.98 (1084.43)      60.58 (5.75)         10
painting_backchaining_5demo               5.00 (0.00)   11.90 (8.89)  14.00 (0.00)   1.00 (0.62)   1206.26 (862.15)      56.74 (4.26)         10
painting_cluster_and_intersect_50demo    50.00 (0.00)   49.50 (0.50)  14.00 (0.00)   0.41 (0.11)   1726.65 (694.62)      76.29 (7.18)         10
painting_cluster_and_search_50demo       50.00 (0.00)    0.00 (0.00)     nan (nan)     nan (nan)          nan (nan)      93.70 (8.18)         10
painting_gnn_modelfree_50demo            50.00 (0.00)    0.50 (0.92)   0.00 (0.00)   0.06 (0.01)        0.00 (0.00)       0.00 (0.00)         10
painting_gnn_shooting_50demo             50.00 (0.00)   17.30 (7.51)   0.00 (0.00)  10.29 (0.05)        0.00 (0.00)   2390.24 (49.89)         10
painting_oracle                           0.00 (0.00)   50.00 (0.00)  14.00 (0.00)   0.38 (0.10)   2301.79 (738.99)       0.00 (0.00)         10
painting_pred_error_50demo               50.00 (0.00)   46.70 (2.33)  14.00 (0.00)   0.35 (0.11)   1480.39 (593.38)      68.39 (7.01)         10
screws_backchaining_10demo               10.00 (0.00)   50.00 (0.00)   4.00 (0.00)   0.09 (0.00)      117.32 (1.06)       0.11 (0.00)         10
screws_backchaining_25demo               25.00 (0.00)   50.00 (0.00)   4.00 (0.00)   0.09 (0.00)      117.32 (1.06)       0.30 (0.01)         10
screws_backchaining_50demo               50.00 (0.00)   50.00 (0.00)   4.00 (0.00)   0.09 (0.00)      117.32 (1.06)       0.54 (0.01)         10
screws_backchaining_5demo                 5.00 (0.00)   50.00 (0.00)   4.00 (0.00)   0.09 (0.00)      117.32 (1.06)       0.06 (0.00)         10
screws_cluster_and_intersect_50demo      50.00 (0.00)    0.00 (0.00)     nan (nan)     nan (nan)          nan (nan)       0.19 (0.01)         10
screws_cluster_and_search_50demo         50.00 (0.00)    0.00 (0.00)     nan (nan)     nan (nan)          nan (nan)    143.55 (49.71)         10
screws_gnn_modelfree_50demo              50.00 (0.00)   49.90 (0.30)   0.00 (0.00)   0.08 (0.01)        0.00 (0.00)       0.00 (0.00)         10
screws_gnn_shooting_50demo               50.00 (0.00)   49.90 (0.30)   0.00 (0.00)  10.02 (0.00)        0.00 (0.00)   1205.58 (57.05)         10
screws_oracle                             0.00 (0.00)   50.00 (0.00)   4.00 (0.00)   0.07 (0.00)      116.32 (1.06)       0.00 (0.00)         10
screws_pred_error_50demo                 50.00 (0.00)  25.00 (25.00)   4.00 (0.00)   0.63 (1.06)     136.49 (37.39)  731.13 (1057.91)         10                                                                                                    
repeated_nextto_painting_backchaining_10demo          10.00 (0.00)   39.67 (5.82)  18.00 (0.00)   1.05 (0.41)   1947.05 (521.47)      110.21 (7.03)          6
repeated_nextto_painting_backchaining_25demo          25.00 (0.00)   45.78 (3.33)  18.00 (0.00)   0.71 (0.05)   1690.78 (363.54)     118.85 (10.84)          9
repeated_nextto_painting_backchaining_50demo          50.00 (0.00)   49.50 (0.67)  18.00 (0.00)   0.72 (0.07)   1829.64 (454.06)      116.33 (5.72)         10
repeated_nextto_painting_backchaining_5demo            5.00 (0.00)  20.00 (10.02)  18.00 (0.00)   1.25 (0.19)  4459.59 (2315.24)     103.82 (13.67)          4
repeated_nextto_painting_cluster_and_intersect_...    50.00 (0.00)    0.00 (0.00)     nan (nan)     nan (nan)          nan (nan)     539.27 (66.80)         10
repeated_nextto_painting_cluster_and_search_50demo    50.00 (0.00)    0.00 (0.00)     nan (nan)     nan (nan)          nan (nan)   1791.10 (225.12)         10
repeated_nextto_painting_gnn_modelfree_50demo         50.00 (0.00)    0.10 (0.30)   0.00 (0.00)   0.11 (0.00)        0.00 (0.00)        0.00 (0.00)         10
repeated_nextto_painting_gnn_shooting_50demo          50.00 (0.00)    5.30 (5.10)   0.00 (0.00)  10.38 (0.08)        0.00 (0.00)   4203.64 (204.39)         10
repeated_nextto_painting_oracle                        0.00 (0.00)   49.30 (0.90)  18.00 (0.00)   1.32 (0.19)  6744.66 (2234.46)        0.00 (0.00)         10
repeated_nextto_painting_pred_error_50demo            50.00 (0.00)    0.00 (0.00)     nan (nan)     nan (nan)          nan (nan)  2903.11 (1443.75)         10
repeated_nextto_single_option_backchaining_10demo     10.00 (0.00)   50.00 (0.00)   3.00 (0.00)   0.04 (0.01)       88.50 (2.35)       22.57 (2.16)         10
repeated_nextto_single_option_backchaining_25demo     25.00 (0.00)   50.00 (0.00)   3.00 (0.00)   0.03 (0.00)       88.50 (2.35)       20.95 (1.07)         10
repeated_nextto_single_option_backchaining_50demo     50.00 (0.00)   50.00 (0.00)   3.00 (0.00)   0.03 (0.00)       88.50 (2.35)       25.77 (1.53)         10
repeated_nextto_single_option_backchaining_5demo       5.00 (0.00)   49.90 (0.30)   3.00 (0.00)   0.04 (0.01)      83.78 (15.01)       26.87 (3.83)         10
repeated_nextto_single_option_cluster_and_inter...    50.00 (0.00)    4.50 (4.61)   3.00 (0.00)   3.25 (3.43)  1457.09 (1336.64)      75.60 (17.31)         10
repeated_nextto_single_option_cluster_and_searc...    50.00 (0.00)    4.50 (4.61)   3.00 (0.00)   3.27 (3.44)  1457.09 (1336.64)      79.37 (22.53)         10
repeated_nextto_single_option_gnn_modelfree_50demo    50.00 (0.00)   49.50 (0.67)   0.00 (0.00)   0.05 (0.02)        0.00 (0.00)        0.00 (0.00)         10
repeated_nextto_single_option_gnn_shooting_50demo     50.00 (0.00)   49.60 (0.66)   0.00 (0.00)  10.02 (0.00)        0.00 (0.00)    1136.05 (23.85)         10
repeated_nextto_single_option_oracle                   0.00 (0.00)   50.00 (0.00)   3.00 (0.00)   0.01 (0.00)       88.50 (2.35)        0.00 (0.00)         10
repeated_nextto_single_option_pred_error_50demo       50.00 (0.00)   42.90 (3.81)   3.00 (0.00)   0.07 (0.03)      44.72 (15.00)       32.78 (4.80)         10
```