### PR TITLE
tri-value harmlessness check to patch rnt painting with few demonstrations

### DIFF
--- a/scripts/supercloud/run_option_learning_experiments.sh
+++ b/scripts/supercloud/run_option_learning_experiments.sh
@@ -26,7 +26,7 @@ for ENV in ${ENVS[@]}; do
 
         COMMON_ARGS="--env $ENV --min_perc_data_for_nsrt 1 \
                 --segmenter contacts --num_train_tasks $NUM_TRAIN_TASKS --timeout 300 \
-                --gnn_num_epochs 1000 --disable_harmlessness_check True \
+                --gnn_num_epochs 1000 --harmlessness_check disable \
                 --neural_gaus_regressor_max_itr 50000"
 
         # Include the motion planning options for the doors environment.

--- a/scripts/supercloud/run_predicators_sidelining_experiments.sh
+++ b/scripts/supercloud/run_predicators_sidelining_experiments.sh
@@ -24,19 +24,19 @@ for ENV in ${ALL_ENVS[@]}; do
         # Oracle.
         python $FILE $COMMON_ARGS --experiment_id ${ENV}_oracle --approach oracle --num_train_tasks 0
         # Main backchaining approach with various numbers of demonstrations.
-        python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_5demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 5
-        python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_10demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 10
-        python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_25demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 25
-        python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_50demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 50
+        python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_5demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 5 --harmlessness_check log
+        python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_10demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 10 --harmlessness_check log
+        python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_25demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 25 --harmlessness_check log
+        python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_50demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 50 --harmlessness_check log
         # Cluster-and-intersect (RLDM) baseline. Although it is guaranteed to
         # preserve harmlessness, we disable the check because it takes a long
         # time (since the operators have high arity).
-        python $FILE $COMMON_ARGS --experiment_id ${ENV}_cluster_and_intersect_50demo --approach nsrt_learning --strips_learner cluster_and_intersect --num_train_tasks 50 --disable_harmlessness_check True
+        python $FILE $COMMON_ARGS --experiment_id ${ENV}_cluster_and_intersect_50demo --approach nsrt_learning --strips_learner cluster_and_intersect --num_train_tasks 50 --harmlessness_check disable
         # LOFT baseline. Same note on harmlessness as for cluster-and-intersect.
-        python $FILE $COMMON_ARGS --experiment_id ${ENV}_cluster_and_search_50demo --approach nsrt_learning --strips_learner cluster_and_search --num_train_tasks 50 --disable_harmlessness_check True
+        python $FILE $COMMON_ARGS --experiment_id ${ENV}_cluster_and_search_50demo --approach nsrt_learning --strips_learner cluster_and_search --num_train_tasks 50 --harmlessness_check disable
         # Prediction error baseline that optimizes via hill climbing. Not
         # guaranteed to preserve harmlessness.
-        python $FILE $COMMON_ARGS --experiment_id ${ENV}_pred_error_50demo --approach nsrt_learning --strips_learner cluster_and_intersect_sideline_prederror --num_train_tasks 50 --disable_harmlessness_check True
+        python $FILE $COMMON_ARGS --experiment_id ${ENV}_pred_error_50demo --approach nsrt_learning --strips_learner cluster_and_intersect_sideline_prederror --num_train_tasks 50 --harmlessness_check disable
         # Model-based GNN option policy baseline.
         python $FILE $COMMON_ARGS --experiment_id ${ENV}_gnn_shooting_50demo --approach gnn_option_policy --num_train_tasks 50
     fi

--- a/src/nsrt_learning/strips_learning/base_strips_learner.py
+++ b/src/nsrt_learning/strips_learning/base_strips_learner.py
@@ -48,7 +48,7 @@ class BaseSTRIPSLearner(abc.ABC):
             logging.info("\nRunning harmlessness check...")
             is_harmless = self._check_harmlessness(learned_pnads)
             if CFG.harmlessness_check == "assert":
-                assert is_harmless
+                assert is_harmless, "Harmlessness check failed!"
             else:
                 logging.info(f"Harmlessness check result: {is_harmless}")
         min_data = max(CFG.min_data_for_nsrt,

--- a/src/nsrt_learning/strips_learning/base_strips_learner.py
+++ b/src/nsrt_learning/strips_learning/base_strips_learner.py
@@ -42,9 +42,15 @@ class BaseSTRIPSLearner(abc.ABC):
         filtering may break it.
         """
         learned_pnads = self._learn()
-        if self._verify_harmlessness and not CFG.disable_harmlessness_check:
+        assert CFG.harmlessness_check in ("assert", "log", "disable")
+        if self._verify_harmlessness and \
+           CFG.harmlessness_check in ("assert", "log"):
             logging.info("\nRunning harmlessness check...")
-            assert self._check_harmlessness(learned_pnads)
+            is_harmless = self._check_harmlessness(learned_pnads)
+            if CFG.harmlessness_check == "assert":
+                assert is_harmless
+            else:
+                logging.info(f"Harmlessness check result: {is_harmless}")
         min_data = max(CFG.min_data_for_nsrt,
                        self._num_segments * CFG.min_perc_data_for_nsrt / 100)
         learned_pnads = [

--- a/src/settings.py
+++ b/src/settings.py
@@ -217,7 +217,9 @@ class GlobalSettings:
     # STRIPS learning algorithm. See get_name() functions in the directory
     # nsrt_learning/strips_learning/ for valid settings.
     strips_learner = "cluster_and_intersect"
-    disable_harmlessness_check = False  # some methods may want this to be True
+    # Whether to run the harmlessness check on STRIPS operators after they
+    # are learned. Choices are "assert", "log", or "disable".
+    harmlessness_check = "assert"
     clustering_learner_true_pos_weight = 10
     clustering_learner_false_pos_weight = 1
     cluster_and_intersect_prederror_max_groundings = 10

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -85,10 +85,25 @@ def test_main():
     shutil.rmtree(results_dir)
     # Run NSRT learning, but without sampler learning.
     sys.argv = [
-        "dummy", "--env", "cover", "--approach", "nsrt_learning", "--seed",
-        "123", "--sampler_learner", "random", "--cover_initial_holding_prob",
-        "0.0", "--num_train_tasks", "1", "--num_test_tasks", "1",
-        "--experiment_id", "foobar", "--harmlessness_check", "log",
+        "dummy",
+        "--env",
+        "cover",
+        "--approach",
+        "nsrt_learning",
+        "--seed",
+        "123",
+        "--sampler_learner",
+        "random",
+        "--cover_initial_holding_prob",
+        "0.0",
+        "--num_train_tasks",
+        "1",
+        "--num_test_tasks",
+        "1",
+        "--experiment_id",
+        "foobar",
+        "--harmlessness_check",
+        "log",
     ]
     main()
     # Try loading approaches and data.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -88,7 +88,7 @@ def test_main():
         "dummy", "--env", "cover", "--approach", "nsrt_learning", "--seed",
         "123", "--sampler_learner", "random", "--cover_initial_holding_prob",
         "0.0", "--num_train_tasks", "1", "--num_test_tasks", "1",
-        "--experiment_id", "foobar"
+        "--experiment_id", "foobar", "--harmlessness_check", "log",
     ]
     main()
     # Try loading approaches and data.


### PR DESCRIPTION
This PR puts a band-aid on the observation that rnt painting + backchaining often fails the harmlessness check with few demonstrations (5 or 10), while never failing this check with the default 50 demonstrations. Upon investigation, we found that the issue is this operator for placing an object onto the table:
```
STRIPS-Place2:
    Parameters: [?x0:robot]
    Preconditions: [NextToTable(?x0:robot)]
    Add Effects: [GripperOpen(?x0:robot)]
    Delete Effects: []
    Side Predicates: [Holding, HoldingSide, HoldingTop, NotOnTable, OnTable]
    Option Spec: Place(?x0:robot)
```

With the default 50 demonstrations, the following operator is learned instead:
```
STRIPS-Place2:
    Parameters: [?x0:robot, ?x1:obj]
    Preconditions: [Holding(?x1:obj), NextTo(?x0:robot, ?x1:obj), NextToTable(?x0:robot), NotOnTable(?x1:obj)]
    Add Effects: [GripperOpen(?x0:robot), OnTable(?x1:obj)]
    Delete Effects: [Holding(?x1:obj), HoldingSide(?x1:obj), HoldingTop(?x1:obj), NotOnTable(?x1:obj)]
    Side Predicates: []
    Option Spec: Place(?x0:robot)
```

So with fewer demonstrations, the `obj` parameter doesn't appear in the operator, and therefore we never learn that `OnTable(?x1:obj)` should be an add effect, and so we end up putting it in the side predicates, which is harmful. In particular, I want to highlight that the harmlessness check DOESN'T fail on the Place itself, it fails on a later step of moving to some object, for which OnTable is a precondition, but we wiped out all OnTable facts from our atoms because OnTable was put into the side predicates of Place.

Why does that parameter not appear in the operator? Imagine a demonstration where you start out holding some unimportant object. You put it down on the table to free your hand. While the _actual_ add effects of this are _both_ `GripperOpen(?x0:robot)` and `OnTable(?x1:obj)`, the *necessary* add effects are only the former, because it doesn't matter for future steps whether this object was placed onto the table or dropped into the toilet.

So what's different with 50 demonstrations? The key is that by random chance, we'll have tasks where we start out holding some _important_ object (i.e., one that has to eventually go into the box or shelf). If we start out holding it with the wrong grasp, then we will have to place it on the table, but then OnTable _is_ a necessary add effect, and we'll specialize the first Place operator above into the second one, making everything golden.

Basically, our core assumption is that the objects we care about appear in either the option objects or the _necessary add effects_ (note: not all the add effects!), but that assumption is violated here, and so harmlessness is no longer guaranteed.

To move forward, this PR just disables the harmlessness check (but still log it) for backchaining, since at the end of the day this is just a routine data issue: with too little data, we didn't see a specific thing that we needed to see, and so we learn operators that are bad at evaluation time.

Supercloud results:
```
Git commit hashes seen in results/:
c0e0a8e8968385fc5fcdface7f4e68c66ce2b743


AGGREGATED DATA OVER SEEDS:
                                             NUM_TRAIN_TASKS     NUM_SOLVED AVG_NUM_PREDS AVG_TEST_TIME  AVG_NODES_CREATED  LEARNING_TIME  NUM_SEEDS
EXPERIMENT_ID
repeated_nextto_painting_backchaining_10demo    10.00 (0.00)  32.00 (11.03)  18.00 (0.00)   0.94 (0.36)   1925.74 (739.94)  85.60 (10.81)         10
repeated_nextto_painting_backchaining_25demo    25.00 (0.00)   43.70 (6.99)  18.00 (0.00)   0.72 (0.04)   1777.32 (428.79)   91.90 (7.13)         10
repeated_nextto_painting_backchaining_50demo    50.00 (0.00)   49.50 (0.67)  18.00 (0.00)   0.74 (0.07)   1837.22 (448.66)  101.42 (7.85)         10
repeated_nextto_painting_backchaining_5demo      5.00 (0.00)   18.80 (8.61)  18.00 (0.00)   1.00 (0.36)  3083.50 (1990.93)   81.86 (7.56)         10
repeated_nextto_painting_oracle                  0.00 (0.00)   49.40 (1.02)  18.00 (0.00)   1.35 (0.14)  6875.19 (2075.98)    0.00 (0.00)         10
```