### PR TITLE
allow keep effects to create new variables

### DIFF
--- a/src/nsrt_learning/strips_learning/base_strips_learner.py
+++ b/src/nsrt_learning/strips_learning/base_strips_learner.py
@@ -214,12 +214,12 @@ class BaseSTRIPSLearner(abc.ABC):
                     if param_opt != segment_param_option:
                         continue
                     isub = dict(zip(opt_vars, segment_option_objs))
-                    if segment in pnad.keep_effects_subs:
-                        keep_effects_subs = pnad.keep_effects_subs[segment]
+                    if segment in pnad.seg_to_keep_effects_sub:
+                        keep_eff_sub = pnad.seg_to_keep_effects_sub[segment]
                         for var in pnad.op.parameters:
-                            if var in keep_effects_subs:
+                            if var in keep_eff_sub:
                                 assert var not in isub
-                                isub[var] = keep_effects_subs[var]
+                                isub[var] = keep_eff_sub[var]
                     for ground_op in utils.all_ground_operators_given_partial(
                             pnad.op, objects, isub):
                         if len(ground_op.objects) != len(set(

--- a/src/nsrt_learning/strips_learning/base_strips_learner.py
+++ b/src/nsrt_learning/strips_learning/base_strips_learner.py
@@ -214,6 +214,12 @@ class BaseSTRIPSLearner(abc.ABC):
                     if param_opt != segment_param_option:
                         continue
                     isub = dict(zip(opt_vars, segment_option_objs))
+                    if segment in pnad.keep_effects_subs:
+                        keep_effects_subs = pnad.keep_effects_subs[segment]
+                        for var in pnad.op.parameters:
+                            if var in keep_effects_subs:
+                                assert var not in isub
+                                isub[var] = keep_effects_subs[var]
                     for ground_op in utils.all_ground_operators_given_partial(
                             pnad.op, objects, isub):
                         if len(ground_op.objects) != len(set(

--- a/src/nsrt_learning/strips_learning/base_strips_learner.py
+++ b/src/nsrt_learning/strips_learning/base_strips_learner.py
@@ -215,6 +215,9 @@ class BaseSTRIPSLearner(abc.ABC):
                         continue
                     isub = dict(zip(opt_vars, segment_option_objs))
                     if segment in pnad.seg_to_keep_effects_sub:
+                        # If there are any variables only in the keep effects,
+                        # their mappings should be put into isub, since their
+                        # grounding is underconstrained by the segment itself.
                         keep_eff_sub = pnad.seg_to_keep_effects_sub[segment]
                         for var in pnad.op.parameters:
                             if var in keep_eff_sub:

--- a/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
+++ b/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
@@ -253,8 +253,8 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
         final_pnads = []
         for pnad in nec_pnads:
             if pnad.datastore:
-                pre = self._induce_preconditions_via_intersection(pnad)
-                pnad.op = pnad.op.copy_with(preconditions=pre)
+                # pre = self._induce_preconditions_via_intersection(pnad)
+                # pnad.op = pnad.op.copy_with(preconditions=pre)
                 final_pnads.append(pnad)
 
         return final_pnads

--- a/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
+++ b/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
@@ -253,8 +253,8 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
         final_pnads = []
         for pnad in nec_pnads:
             if pnad.datastore:
-                # pre = self._induce_preconditions_via_intersection(pnad)
-                # pnad.op = pnad.op.copy_with(preconditions=pre)
+                pre = self._induce_preconditions_via_intersection(pnad)
+                pnad.op = pnad.op.copy_with(preconditions=pre)
                 final_pnads.append(pnad)
 
         return final_pnads

--- a/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
+++ b/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
@@ -444,14 +444,19 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
         i = 0
         for r in range(1, len(keep_effects) + 1):
             for keep_effects_subset in itertools.combinations(keep_effects, r):
+                # These keep effects (keep_effects_subset) could involve new
+                # variables, which we need to add to the PNAD parameters.
                 params_set = set(pnad.op.parameters)
                 for eff in keep_effects_subset:
                     for var in eff.variables:
                         params_set.add(var)
                 parameters = sorted(params_set)
+                # The keep effects go into both the PNAD preconditions and the
+                # PNAD add effects.
                 preconditions = pnad.op.preconditions | set(
                     keep_effects_subset)
                 add_effects = pnad.op.add_effects | set(keep_effects_subset)
+                # Create the new PNAD.
                 new_pnad_op = pnad.op.copy_with(name=f"{pnad.op.name}-KEEP{i}",
                                                 parameters=parameters,
                                                 preconditions=preconditions,

--- a/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
+++ b/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
@@ -80,8 +80,8 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
             # the PNADs did not change.
             for pnads in param_opt_to_nec_pnads.values():
                 for pnad in pnads:
-                    pnad.poss_keep_effects = set()
-                    pnad.seg_to_keep_effects_sub = {}
+                    pnad.poss_keep_effects.clear()
+                    pnad.seg_to_keep_effects_sub.clear()
             # Run one pass of backchaining.
             nec_pnad_set_changed = self._backchain_one_pass(
                 param_opt_to_nec_pnads, param_opt_to_general_pnad)

--- a/src/structs.py
+++ b/src/structs.py
@@ -1151,7 +1151,9 @@ class PartialNSRTAndDatastore:
     sampler: Optional[NSRTSampler] = field(init=False, default=None)
     # A container for the possible keep effects for this PNAD.
     poss_keep_effects: Set[LiftedAtom] = field(init=False, default_factory=set)
-    keep_effects_subs: Dict[Segment, VarToObjSub] = field(init=False, default_factory=dict)
+    seg_to_keep_effects_sub: Dict[Segment,
+                                  VarToObjSub] = field(init=False,
+                                                       default_factory=dict)
 
     def add_to_datastore(self,
                          member: Tuple[Segment, VarToObjSub],

--- a/src/structs.py
+++ b/src/structs.py
@@ -1151,6 +1151,7 @@ class PartialNSRTAndDatastore:
     sampler: Optional[NSRTSampler] = field(init=False, default=None)
     # A container for the possible keep effects for this PNAD.
     poss_keep_effects: Set[LiftedAtom] = field(init=False, default_factory=set)
+    keep_effects_subs: Dict[Segment, VarToObjSub] = field(init=False, default_factory=dict)
 
     def add_to_datastore(self,
                          member: Tuple[Segment, VarToObjSub],

--- a/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
+++ b/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
@@ -802,7 +802,7 @@ def test_keep_effect_adding_new_variables():
     ground_atom_traj = utils.create_ground_atom_dataset([traj], predicates)[0]
     segmented_traj = segment_trajectory(ground_atom_traj)
 
-    # Now, run the learner on the four demos.
+    # Now, run the learner on the demo.
     learner = _MockBackchainingSTRIPSLearner([traj], [task],
                                              predicates, [segmented_traj],
                                              verify_harmlessness=True)
@@ -827,6 +827,9 @@ def test_keep_effect_adding_new_variables():
     Option Spec: Pick(?x0:potato_type)"""
     ])
 
+    button_x0 = button_type("?x0")
+    potato_x0 = potato_type("?x0")
+    potato_x1 = potato_type("?x1")
     for pnad in output_pnads:
         assert str(pnad) in correct_pnads
         if pnad.option_spec[0].name == "Press":
@@ -835,12 +838,11 @@ def test_keep_effect_adding_new_variables():
             assert len(pnad.datastore) == 1
             seg, sub = pnad.datastore[0]
             assert seg is segmented_traj[0]
-            assert str(sub) == ("{?x0:button_type: button:button_type, "
-                                "?x1:potato_type: potato3:potato_type}")
+            assert sub == {button_x0: button, potato_x1: potato3}
         else:
             assert pnad.option_spec[0].name == "Pick"
             # The demonstrator Picked potato3.
             assert len(pnad.datastore) == 1
             seg, sub = pnad.datastore[0]
             assert seg is segmented_traj[1]
-            assert str(sub) == "{?x0:potato_type: potato3:potato_type}"
+            assert sub == {potato_x0: potato3}

--- a/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
+++ b/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
@@ -365,8 +365,9 @@ def test_keep_effect_data_partitioning():
                                   lambda s, o: s[o[0]][1] > 0.5)
     MachineRun = Predicate("MachineRun", [machine_type],
                            lambda s, o: s[o[0]][2] > 0.5)
-    predicates = {MachineOn, MachineConfigurableWhileOff, MachineConfigured,
-                  MachineRun}
+    predicates = {
+        MachineOn, MachineConfigurableWhileOff, MachineConfigured, MachineRun
+    }
 
     m1 = machine_type("m1")
     m2 = machine_type("m2")
@@ -651,11 +652,11 @@ def test_combinatorial_keep_effect_data_partitioning():
     segmented_trajs = [segment_trajectory(traj) for traj in ground_atom_trajs]
 
     # Now, run the learner on the four demos.
-    learner = _MockBackchainingSTRIPSLearner(
-        [traj1, traj2, traj3, traj4], [task1, task2, task3, task4],
-        predicates,
-        segmented_trajs,
-        verify_harmlessness=True)
+    learner = _MockBackchainingSTRIPSLearner([traj1, traj2, traj3, traj4],
+                                             [task1, task2, task3, task4],
+                                             predicates,
+                                             segmented_trajs,
+                                             verify_harmlessness=True)
     output_pnads = learner.learn()
     # We need 7 PNADs: 4 for configure, and 1 each for turn on, run, and fix.
     assert len(output_pnads) == 7
@@ -716,11 +717,11 @@ def test_combinatorial_keep_effect_data_partitioning():
 
     # Now, run the learner on 3/4 of the demos and verify that it produces only
     # 3 PNADs for the Configure action.
-    learner = _MockBackchainingSTRIPSLearner(
-        [traj1, traj2, traj3], [task1, task2, task3],
-        predicates,
-        segmented_trajs[:-1],
-        verify_harmlessness=True)
+    learner = _MockBackchainingSTRIPSLearner([traj1, traj2, traj3],
+                                             [task1, task2, task3],
+                                             predicates,
+                                             segmented_trajs[:-1],
+                                             verify_harmlessness=True)
     output_pnads = learner.learn()
     assert len(output_pnads) == 6
 
@@ -743,8 +744,7 @@ def test_combinatorial_keep_effect_data_partitioning():
 def test_keep_effect_adding_new_variables():
     """Test that the BackchainingSTRIPSLearner is able to correctly induce
     operators when the keep effects must create new variables to ensure
-    harmlessness.
-    """
+    harmlessness."""
     utils.reset_config({"segmenter": "atom_changes"})
     # Set up the types and predicates.
     button_type = Type("button_type", ["pressed"])
@@ -783,11 +783,13 @@ def test_keep_effect_adding_new_variables():
     })
 
     # Create the necessary options and actions.
-    press = utils.SingletonParameterizedOption("Press", lambda s, m, o, p: None,
+    press = utils.SingletonParameterizedOption("Press",
+                                               lambda s, m, o, p: None,
                                                types=[button_type])
     Press = press.ground([button], [])
     press_act = Action([], Press)
-    pick = utils.SingletonParameterizedOption("Pick", lambda s, m, o, p: None,
+    pick = utils.SingletonParameterizedOption("Pick",
+                                              lambda s, m, o, p: None,
                                               types=[potato_type])
     Pick = pick.ground([potato3], [])
     pick_act = Action([], Pick)
@@ -801,8 +803,9 @@ def test_keep_effect_adding_new_variables():
     segmented_traj = segment_trajectory(ground_atom_traj)
 
     # Now, run the learner on the four demos.
-    learner = _MockBackchainingSTRIPSLearner(
-        [traj], [task], predicates, [segmented_traj], verify_harmlessness=True)
+    learner = _MockBackchainingSTRIPSLearner([traj], [task],
+                                             predicates, [segmented_traj],
+                                             verify_harmlessness=True)
     output_pnads = learner.learn()
 
     # Verify that all the output PNADs are correct. The PNAD for Press should

--- a/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
+++ b/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
@@ -833,12 +833,14 @@ def test_keep_effect_adding_new_variables():
             # We need that potato3 in particular is left intact during the
             # Press, because it needs to be intact for the subsequent Pick.
             assert len(pnad.datastore) == 1
-            sub = pnad.datastore[0][1]
+            seg, sub = pnad.datastore[0]
+            assert seg is segmented_traj[0]
             assert str(sub) == ("{?x0:button_type: button:button_type, "
                                 "?x1:potato_type: potato3:potato_type}")
         else:
             assert pnad.option_spec[0].name == "Pick"
             # The demonstrator Picked potato3.
             assert len(pnad.datastore) == 1
-            sub = pnad.datastore[0][1]
+            seg, sub = pnad.datastore[0]
+            assert seg is segmented_traj[1]
             assert str(sub) == "{?x0:potato_type: potato3:potato_type}"


### PR DESCRIPTION
A better way of resolving the issue described in detail in #932. We realized that it's okay for keep effects to create new variables, as long as you make sure to reuse those mappings in `recompute_datastores_from_segments()`. This PR implements that functionality and adds a new test for it.

* Verified that the test fails the harmlessness check on master, as we'd expect.
* Verified that the test fails if you don't do the `seg_to_keep_effects_sub` stuff, because the datastore will be wrong, which is checked near the end of the test.

Supercloud (no crashes 🎉 ):
```
Git commit hashes seen in results/:
cc86499968424fe5b0e22c1790842e129ef87095


AGGREGATED DATA OVER SEEDS:
                                                  NUM_TRAIN_TASKS     NUM_SOLVED AVG_NUM_PREDS AVG_TEST_TIME   AVG_NODES_CREATED  LEARNING_TIME  NUM_SEEDS
EXPERIMENT_ID
repeated_nextto_painting_backchaining_10demo         10.00 (0.00)  34.10 (10.38)  18.00 (0.00)   1.29 (0.47)   5328.46 (4654.97)   98.20 (5.99)         10
repeated_nextto_painting_backchaining_25demo         25.00 (0.00)   45.10 (3.56)  18.00 (0.00)   0.80 (0.24)   2606.29 (2788.35)   93.53 (7.79)         10
repeated_nextto_painting_backchaining_50demo         50.00 (0.00)   49.50 (0.67)  18.00 (0.00)   0.77 (0.06)    1832.40 (451.18)  98.63 (10.36)         10
repeated_nextto_painting_backchaining_5demo           5.00 (0.00)  19.60 (10.02)  18.00 (0.00)   1.54 (0.91)  8998.78 (10279.51)   84.52 (7.42)         10
repeated_nextto_painting_oracle                       0.00 (0.00)   49.20 (0.98)  18.00 (0.00)   1.32 (0.15)   6339.68 (1814.10)    0.00 (0.00)         10
repeated_nextto_single_option_backchaining_10demo    10.00 (0.00)   50.00 (0.00)   3.00 (0.00)   0.04 (0.01)        88.50 (2.35)   18.98 (1.91)         10
repeated_nextto_single_option_backchaining_25demo    25.00 (0.00)   50.00 (0.00)   3.00 (0.00)   0.03 (0.00)        88.50 (2.35)   17.43 (1.51)         10
repeated_nextto_single_option_backchaining_50demo    50.00 (0.00)   50.00 (0.00)   3.00 (0.00)   0.03 (0.00)        88.50 (2.35)   23.14 (1.24)         10
repeated_nextto_single_option_backchaining_5demo      5.00 (0.00)   49.90 (0.30)   3.00 (0.00)   0.04 (0.01)       83.78 (15.01)   19.71 (3.06)         10
repeated_nextto_single_option_oracle                  0.00 (0.00)   50.00 (0.00)   3.00 (0.00)   0.01 (0.00)        88.50 (2.35)    0.00 (0.00)         10
                             NUM_TRAIN_TASKS    NUM_SOLVED AVG_NUM_PREDS AVG_TEST_TIME  AVG_NODES_CREATED LEARNING_TIME  NUM_SEEDS
EXPERIMENT_ID
painting_backchaining_10demo    10.00 (0.00)  41.80 (4.09)  14.00 (0.00)   0.46 (0.17)   1986.21 (941.49)  55.30 (5.03)         10
painting_backchaining_25demo    25.00 (0.00)  49.20 (1.17)  14.00 (0.00)   0.38 (0.08)   2378.04 (829.09)  57.18 (5.63)         10
painting_backchaining_50demo    50.00 (0.00)  49.40 (0.66)  14.00 (0.00)   0.43 (0.13)  2748.98 (1084.43)  60.02 (4.74)         10
painting_backchaining_5demo      5.00 (0.00)  11.90 (8.81)  14.00 (0.00)   1.04 (0.56)   1186.03 (879.36)  55.04 (4.67)         10
painting_oracle                  0.00 (0.00)  50.00 (0.00)  14.00 (0.00)   0.38 (0.09)   2301.79 (738.99)   0.00 (0.00)         10
screws_backchaining_10demo      10.00 (0.00)  50.00 (0.00)   4.00 (0.00)   0.09 (0.00)      117.32 (1.06)   0.11 (0.01)         10
screws_backchaining_25demo      25.00 (0.00)  50.00 (0.00)   4.00 (0.00)   0.09 (0.00)      117.32 (1.06)   0.30 (0.01)         10
screws_backchaining_50demo      50.00 (0.00)  50.00 (0.00)   4.00 (0.00)   0.09 (0.00)      117.32 (1.06)   0.54 (0.01)         10
screws_backchaining_5demo        5.00 (0.00)  50.00 (0.00)   4.00 (0.00)   0.09 (0.00)      117.32 (1.06)   0.06 (0.00)         10
screws_oracle                    0.00 (0.00)  50.00 (0.00)   4.00 (0.00)   0.07 (0.00)      116.32 (1.06)   0.00 (0.00)         10
```