### PR TITLE
Add exception counts to metrics

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -260,8 +260,11 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
     num_solved = 0
     approach.reset_metrics()
     total_suc_time = 0.0
-    total_num_execution_failures = 0
+    total_num_solve_timeouts = 0
     total_num_solve_failures = 0
+    total_num_execution_timeouts = 0
+    total_num_execution_failures = 0
+
     video_prefix = utils.get_config_path_str()
     for test_task_idx, task in enumerate(test_tasks):
         solve_start = time.time()
@@ -270,7 +273,10 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
         except (ApproachTimeout, ApproachFailure) as e:
             logging.info(f"Task {test_task_idx+1} / {len(test_tasks)}: "
                          f"Approach failed to solve with error: {e}")
-            total_num_solve_failures += 1
+            if type(e) == ApproachTimeout:
+                total_num_solve_timeouts += 1
+            elif type(e) == ApproachFailure:
+                total_num_solve_failures += 1
             if CFG.make_failure_videos and e.info.get("partial_refinements"):
                 video = utils.create_video_from_partial_refinements(
                     e.info["partial_refinements"], env, "test", test_task_idx,
@@ -304,7 +310,10 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
         except (ApproachTimeout, ApproachFailure) as e:
             log_message = ("Approach failed at policy execution time with "
                            f"error: {e}")
-            total_num_execution_failures += 1
+            if type(e) == ApproachTimeout:
+                total_num_execution_timeouts += 1
+            elif type(e) == ApproachFailure:
+                total_num_execution_failures += 1
             caught_exception = True
         if solved:
             log_message = "SOLVED"
@@ -333,8 +342,10 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
             "min_num_skeletons_optimized"] < float("inf") else 0
     metrics["max_skeletons_optimized"] = approach.metrics[
         "max_num_skeletons_optimized"]
-    metrics["num_execution_failures"] = total_num_execution_failures
+    metrics["num_solve_timeouts"] = total_num_solve_timeouts
     metrics["num_solve_failures"] = total_num_solve_failures
+    metrics["num_execution_timeouts"] = total_num_execution_timeouts
+    metrics["num_execution_failures"] = total_num_execution_failures
     # Handle computing averages of total approach metrics wrt the
     # number of found policies. Note: this is different from computing
     # an average wrt the number of solved tasks, which might be more

--- a/src/main.py
+++ b/src/main.py
@@ -273,9 +273,9 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
         except (ApproachTimeout, ApproachFailure) as e:
             logging.info(f"Task {test_task_idx+1} / {len(test_tasks)}: "
                          f"Approach failed to solve with error: {e}")
-            if type(e) == ApproachTimeout:
+            if isinstance(e, ApproachTimeout):
                 total_num_solve_timeouts += 1
-            elif type(e) == ApproachFailure:
+            elif isinstance(e, ApproachFailure):
                 total_num_solve_failures += 1
             if CFG.make_failure_videos and e.info.get("partial_refinements"):
                 video = utils.create_video_from_partial_refinements(
@@ -310,9 +310,9 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
         except (ApproachTimeout, ApproachFailure) as e:
             log_message = ("Approach failed at policy execution time with "
                            f"error: {e}")
-            if type(e) == ApproachTimeout:
+            if isinstance(e, ApproachTimeout):
                 total_num_execution_timeouts += 1
-            elif type(e) == ApproachFailure:
+            elif isinstance(e, ApproachFailure):
                 total_num_execution_failures += 1
             caught_exception = True
         if solved:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,19 +8,19 @@ from typing import Callable
 import pytest
 
 from predicators.src import utils
-from predicators.src.approaches import ApproachFailure, BaseApproach, \
-    create_approach
+from predicators.src.approaches import ApproachFailure, ApproachTimeout, \
+    BaseApproach, create_approach
 from predicators.src.envs.cover import CoverEnv
 from predicators.src.main import _run_testing, main
 from predicators.src.structs import Action, State, Task
 
 
-class _DummyApproach(BaseApproach):
+class _DummyFailureApproach(BaseApproach):
     """Dummy approach that raises ApproachFailure for testing."""
 
     @classmethod
     def get_name(cls) -> str:
-        return "dummy"
+        return "dummy_failure"
 
     @property
     def is_learning_based(self):
@@ -30,6 +30,42 @@ class _DummyApproach(BaseApproach):
 
         def _policy(s: State) -> Action:
             raise ApproachFailure("Option plan exhausted.")
+
+        return _policy
+
+
+class _DummySolveTimeoutApproach(BaseApproach):
+    """Dummy approach that raises ApproachTimeout during planning
+    for testing."""
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "dummy_solve_timeout"
+
+    @property
+    def is_learning_based(self):
+        return False
+
+    def _solve(self, task: Task, timeout: int) -> Callable[[State], Action]:
+        raise ApproachTimeout("Planning timed out.")
+
+
+class _DummyExecutionTimeoutApproach(BaseApproach):
+    """Dummy approach that raises ApproachTimeout during execution
+    for testing."""
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "dummy_execution_timeout"
+
+    @property
+    def is_learning_based(self):
+        return False
+
+    def _solve(self, task: Task, timeout: int) -> Callable[[State], Action]:
+
+        def _policy(s: State) -> Action:
+            raise ApproachTimeout("Policy timed out.")
 
         return _policy
 
@@ -136,8 +172,8 @@ def test_main():
     main()
 
 
-def test_bilevel_planning_approach_failure():
-    """Test coverage for ApproachFailure in run_testing()."""
+def test_bilevel_planning_approach_failure_and_timeout():
+    """Test coverage for ApproachFailure and ApproachTimeout in run_testing()."""
     utils.reset_config({
         "env": "cover",
         "approach": "nsrt_learning",
@@ -147,11 +183,21 @@ def test_bilevel_planning_approach_failure():
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
-    approach = _DummyApproach(env.predicates, env.options, env.types,
+    task = train_tasks[0]
+
+    approach = _DummyFailureApproach(env.predicates, env.options, env.types,
                               env.action_space, train_tasks)
     assert not approach.is_learning_based
-    task = train_tasks[0]
-    approach.solve(task, timeout=500)
+    _run_testing(env, approach)
+
+    approach = _DummySolveTimeoutApproach(env.predicates, env.options, env.types,
+                              env.action_space, train_tasks)
+    assert not approach.is_learning_based
+    _run_testing(env, approach)
+
+    approach = _DummyExecutionTimeoutApproach(env.predicates, env.options, env.types,
+                              env.action_space, train_tasks)
+    assert not approach.is_learning_based
     _run_testing(env, approach)
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -35,8 +35,8 @@ class _DummyFailureApproach(BaseApproach):
 
 
 class _DummySolveTimeoutApproach(BaseApproach):
-    """Dummy approach that raises ApproachTimeout during planning
-    for testing."""
+    """Dummy approach that raises ApproachTimeout during planning for
+    testing."""
 
     @classmethod
     def get_name(cls) -> str:
@@ -51,8 +51,8 @@ class _DummySolveTimeoutApproach(BaseApproach):
 
 
 class _DummyExecutionTimeoutApproach(BaseApproach):
-    """Dummy approach that raises ApproachTimeout during execution
-    for testing."""
+    """Dummy approach that raises ApproachTimeout during execution for
+    testing."""
 
     @classmethod
     def get_name(cls) -> str:
@@ -173,7 +173,8 @@ def test_main():
 
 
 def test_bilevel_planning_approach_failure_and_timeout():
-    """Test coverage for ApproachFailure and ApproachTimeout in run_testing()."""
+    """Test coverage for ApproachFailure and ApproachTimeout in
+    run_testing()."""
     utils.reset_config({
         "env": "cover",
         "approach": "nsrt_learning",
@@ -183,20 +184,20 @@ def test_bilevel_planning_approach_failure_and_timeout():
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
-    task = train_tasks[0]
-
     approach = _DummyFailureApproach(env.predicates, env.options, env.types,
-                              env.action_space, train_tasks)
+                                     env.action_space, train_tasks)
     assert not approach.is_learning_based
     _run_testing(env, approach)
 
-    approach = _DummySolveTimeoutApproach(env.predicates, env.options, env.types,
-                              env.action_space, train_tasks)
+    approach = _DummySolveTimeoutApproach(env.predicates, env.options,
+                                          env.types, env.action_space,
+                                          train_tasks)
     assert not approach.is_learning_based
     _run_testing(env, approach)
 
-    approach = _DummyExecutionTimeoutApproach(env.predicates, env.options, env.types,
-                              env.action_space, train_tasks)
+    approach = _DummyExecutionTimeoutApproach(env.predicates, env.options,
+                                              env.types, env.action_space,
+                                              train_tasks)
     assert not approach.is_learning_based
     _run_testing(env, approach)
 


### PR DESCRIPTION
Want the metrics dictionary to store how many times each kind of exception occurred so that we get a clearer picture about how and why an approach is failing. 