### PR TITLE
skip training tasks where human demonstrator gave a bad input

### DIFF
--- a/src/datasets/demo_only.py
+++ b/src/datasets/demo_only.py
@@ -75,7 +75,10 @@ def create_demo_data(env: BaseEnv, train_tasks: List[Task],
                 idx,
                 termination_function=termination_function,
                 max_num_steps=CFG.horizon,
-                exceptions_to_break_on={utils.OptionExecutionFailure},
+                exceptions_to_break_on={
+                    utils.OptionExecutionFailure,
+                    utils.HumanDemonstrationFailure,
+                },
                 monitor=monitor)
         except (ApproachTimeout, ApproachFailure,
                 utils.EnvironmentFailure) as e:
@@ -138,8 +141,10 @@ def _human_demonstrator_policy(env: BaseEnv, idx: int, num_tasks: int,
     fig.canvas.mpl_disconnect(keyboard_cid)
     fig.canvas.mpl_disconnect(mouse_cid)
     plt.close()
-    assert "action" in container, "Event handler failed. Its " \
-        "error message should be printed above."
+    if "action" not in container:
+        logging.warning("WARNING: Event handler failed. Its error message "
+                        "should be printed above. Terminating task.")
+        raise utils.HumanDemonstrationFailure("Event handler failed!")
     # Revert to the previous backend.
     matplotlib.use(cur_backend)
     return container["action"]

--- a/src/utils.py
+++ b/src/utils.py
@@ -979,6 +979,11 @@ class OptionExecutionFailure(ExceptionWithInfo):
     """An exception raised by an option policy in the course of execution."""
 
 
+class HumanDemonstrationFailure(ExceptionWithInfo):
+    """An exception raised when CFG.demonstrator == "human" and the human gives
+    a bad input."""
+
+
 class EnvironmentFailure(ExceptionWithInfo):
     """Exception raised when any type of failure occurs in an environment.
 


### PR DESCRIPTION
i think this is easier and cleaner than the individual task saving idea in #946, and so we should only do that more complicated thing if we really find it necessary in the future.

closes #946 