### PR TITLE
[sidelining] simplify algorithm by removing specialization

### DIFF
--- a/scripts/supercloud/run_predicators_sidelining_experiments.sh
+++ b/scripts/supercloud/run_predicators_sidelining_experiments.sh
@@ -22,23 +22,23 @@ for ENV in ${ALL_ENVS[@]}; do
         python $FILE $COMMON_ARGS --experiment_id ${ENV}_gnn_modelfree_50demo --load_experiment_id ${ENV}_gnn_shooting_50demo --approach gnn_option_policy --num_train_tasks 50 --gnn_option_policy_solve_with_shooting False --load_approach --load_data
     else
         # Oracle.
-        python $FILE $COMMON_ARGS --experiment_id ${ENV}_oracle --approach oracle --num_train_tasks 0
+        # python $FILE $COMMON_ARGS --experiment_id ${ENV}_oracle --approach oracle --num_train_tasks 0
         # Main backchaining approach with various numbers of demonstrations.
         python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_5demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 5
         python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_10demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 10
         python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_25demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 25
         python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_50demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 50
-        # Cluster-and-intersect (RLDM) baseline. Although it is guaranteed to
-        # preserve harmlessness, we disable the check because it takes a long
-        # time (since the operators have high arity).
-        python $FILE $COMMON_ARGS --experiment_id ${ENV}_cluster_and_intersect_50demo --approach nsrt_learning --strips_learner cluster_and_intersect --num_train_tasks 50 --disable_harmlessness_check True
-        # LOFT baseline. Same note on harmlessness as for cluster-and-intersect.
-        python $FILE $COMMON_ARGS --experiment_id ${ENV}_cluster_and_search_50demo --approach nsrt_learning --strips_learner cluster_and_search --num_train_tasks 50 --disable_harmlessness_check True
-        # Prediction error baseline that optimizes via hill climbing. Not
-        # guaranteed to preserve harmlessness.
-        python $FILE $COMMON_ARGS --experiment_id ${ENV}_pred_error_50demo --approach nsrt_learning --strips_learner cluster_and_intersect_sideline_prederror --num_train_tasks 50 --disable_harmlessness_check True
-        # Model-based GNN option policy baseline.
-        python $FILE $COMMON_ARGS --experiment_id ${ENV}_gnn_shooting_50demo --approach gnn_option_policy --num_train_tasks 50
+        # # Cluster-and-intersect (RLDM) baseline. Although it is guaranteed to
+        # # preserve harmlessness, we disable the check because it takes a long
+        # # time (since the operators have high arity).
+        # python $FILE $COMMON_ARGS --experiment_id ${ENV}_cluster_and_intersect_50demo --approach nsrt_learning --strips_learner cluster_and_intersect --num_train_tasks 50 --disable_harmlessness_check True
+        # # LOFT baseline. Same note on harmlessness as for cluster-and-intersect.
+        # python $FILE $COMMON_ARGS --experiment_id ${ENV}_cluster_and_search_50demo --approach nsrt_learning --strips_learner cluster_and_search --num_train_tasks 50 --disable_harmlessness_check True
+        # # Prediction error baseline that optimizes via hill climbing. Not
+        # # guaranteed to preserve harmlessness.
+        # python $FILE $COMMON_ARGS --experiment_id ${ENV}_pred_error_50demo --approach nsrt_learning --strips_learner cluster_and_intersect_sideline_prederror --num_train_tasks 50 --disable_harmlessness_check True
+        # # Model-based GNN option policy baseline.
+        # python $FILE $COMMON_ARGS --experiment_id ${ENV}_gnn_shooting_50demo --approach gnn_option_policy --num_train_tasks 50
     fi
 
 done

--- a/scripts/supercloud/run_predicators_sidelining_experiments.sh
+++ b/scripts/supercloud/run_predicators_sidelining_experiments.sh
@@ -22,23 +22,23 @@ for ENV in ${ALL_ENVS[@]}; do
         python $FILE $COMMON_ARGS --experiment_id ${ENV}_gnn_modelfree_50demo --load_experiment_id ${ENV}_gnn_shooting_50demo --approach gnn_option_policy --num_train_tasks 50 --gnn_option_policy_solve_with_shooting False --load_approach --load_data
     else
         # Oracle.
-        # python $FILE $COMMON_ARGS --experiment_id ${ENV}_oracle --approach oracle --num_train_tasks 0
+        python $FILE $COMMON_ARGS --experiment_id ${ENV}_oracle --approach oracle --num_train_tasks 0
         # Main backchaining approach with various numbers of demonstrations.
         python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_5demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 5
         python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_10demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 10
         python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_25demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 25
         python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_50demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 50
-        # # Cluster-and-intersect (RLDM) baseline. Although it is guaranteed to
-        # # preserve harmlessness, we disable the check because it takes a long
-        # # time (since the operators have high arity).
-        # python $FILE $COMMON_ARGS --experiment_id ${ENV}_cluster_and_intersect_50demo --approach nsrt_learning --strips_learner cluster_and_intersect --num_train_tasks 50 --disable_harmlessness_check True
-        # # LOFT baseline. Same note on harmlessness as for cluster-and-intersect.
-        # python $FILE $COMMON_ARGS --experiment_id ${ENV}_cluster_and_search_50demo --approach nsrt_learning --strips_learner cluster_and_search --num_train_tasks 50 --disable_harmlessness_check True
-        # # Prediction error baseline that optimizes via hill climbing. Not
-        # # guaranteed to preserve harmlessness.
-        # python $FILE $COMMON_ARGS --experiment_id ${ENV}_pred_error_50demo --approach nsrt_learning --strips_learner cluster_and_intersect_sideline_prederror --num_train_tasks 50 --disable_harmlessness_check True
-        # # Model-based GNN option policy baseline.
-        # python $FILE $COMMON_ARGS --experiment_id ${ENV}_gnn_shooting_50demo --approach gnn_option_policy --num_train_tasks 50
+        # Cluster-and-intersect (RLDM) baseline. Although it is guaranteed to
+        # preserve harmlessness, we disable the check because it takes a long
+        # time (since the operators have high arity).
+        python $FILE $COMMON_ARGS --experiment_id ${ENV}_cluster_and_intersect_50demo --approach nsrt_learning --strips_learner cluster_and_intersect --num_train_tasks 50 --disable_harmlessness_check True
+        # LOFT baseline. Same note on harmlessness as for cluster-and-intersect.
+        python $FILE $COMMON_ARGS --experiment_id ${ENV}_cluster_and_search_50demo --approach nsrt_learning --strips_learner cluster_and_search --num_train_tasks 50 --disable_harmlessness_check True
+        # Prediction error baseline that optimizes via hill climbing. Not
+        # guaranteed to preserve harmlessness.
+        python $FILE $COMMON_ARGS --experiment_id ${ENV}_pred_error_50demo --approach nsrt_learning --strips_learner cluster_and_intersect_sideline_prederror --num_train_tasks 50 --disable_harmlessness_check True
+        # Model-based GNN option policy baseline.
+        python $FILE $COMMON_ARGS --experiment_id ${ENV}_gnn_shooting_50demo --approach gnn_option_policy --num_train_tasks 50
     fi
 
 done

--- a/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
+++ b/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
@@ -150,7 +150,8 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                     # recompute all preconditions.
                     param_opt_to_nec_pnads[option.parent] = [
                         pnad for pnad in param_opt_to_nec_pnads[option.parent]
-                        if len(pnad.datastore) > 0]
+                        if len(pnad.datastore) > 0
+                    ]
                     for pnad in param_opt_to_nec_pnads[option.parent]:
                         pre = self._induce_preconditions_via_intersection(pnad)
                         pnad.op = pnad.op.copy_with(preconditions=pre)
@@ -288,7 +289,8 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
         must achieve, create a new PNAD ("spawn" from the most general one) so
         that it has these necessary add effects.
 
-        Returns the newly constructed PNAD, without modifying the original.
+        Returns the newly constructed PNAD, without modifying the
+        original.
         """
         # Assert that this really is a general PNAD.
         assert len(pnad.op.add_effects) == 0, \

--- a/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
+++ b/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
@@ -350,6 +350,9 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                                         preconditions=set(),
                                         add_effects=updated_add_effects)
         new_pnad = PartialNSRTAndDatastore(new_pnad_op, [], pnad.option_spec)
+        # Note: we don't need to copy anything related to keep effects into
+        # new_pnad here, because we only care about keep effects on the final
+        # iteration of backchaining, where this function is never called.
 
         return new_pnad
 

--- a/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
+++ b/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
@@ -72,7 +72,7 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
 
         # Run backchaining to update the PNADs' preconditions and add effects.
         self._backchain(param_opt_to_nec_pnads, param_opt_to_general_pnad)
-        # Induce delete effects, side predicates and keep effects if
+        # Induce delete effects, side predicates, and keep effects if
         # necessary to finish learning.
         final_pnads = self._finish_learning(param_opt_to_nec_pnads)
         self._assert_all_data_in_exactly_one_datastore(final_pnads)
@@ -84,8 +84,8 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
         param_opt_to_general_pnad: Dict[ParameterizedOption,
                                         PartialNSRTAndDatastore]
     ) -> None:
-        """Go through each one demonstration the end back to the start, making
-        the PNADs more specific whenever needed.
+        """Go through each demonstration from the end back to the start (in an
+        arbitrary order), spawning new, more specific PNADs when needed.
 
         Note that this method updates param_opt_to_nec_pnads.
         """
@@ -132,9 +132,8 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                         break
 
                 # If we weren't able to find a substitution (i.e, the above
-                # for loop did not break), we need to spawn from the most
-                # general PNAD and make a new PNAD to cover these necessary
-                # add effects.
+                # for loop did not break), we need to spawn a new PNAD from
+                # the most general PNAD to cover these necessary add effects.
                 else:
                     pnad = self._spawn_new_pnad(
                         necessary_add_effects,

--- a/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
+++ b/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
@@ -162,15 +162,18 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                     # matched to another PNAD.
                     self._recompute_datastores_from_segments(
                         param_opt_to_nec_pnads[option.parent])
-                    # If any PNAD now has an empty datastore, delete it. Then
-                    # recompute all preconditions.
+                    # If any PNAD now has an empty datastore, delete it.
+                    # TODO: see if this is necessary
                     param_opt_to_nec_pnads[option.parent] = [
                         pnad for pnad in param_opt_to_nec_pnads[option.parent]
                         if len(pnad.datastore) > 0
                     ]
-                    for pnad in param_opt_to_nec_pnads[option.parent]:
-                        pre = self._induce_preconditions_via_intersection(pnad)
-                        pnad.op = pnad.op.copy_with(preconditions=pre)
+                    # Recompute all preconditions, now that we have recomputed
+                    # the datastores.
+                    for nec_pnad in param_opt_to_nec_pnads[option.parent]:
+                        pre = self._induce_preconditions_via_intersection(
+                            nec_pnad)
+                        nec_pnad.op = nec_pnad.op.copy_with(preconditions=pre)
 
                     # After all this, the unification call that failed earlier
                     # (leading us into the current else statement) should work.

--- a/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
+++ b/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
@@ -145,33 +145,18 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                             param_opt_to_nec_pnads[option.parent].append(pnad)
                         break
                 # If we weren't able to find a substitution (i.e, the above
-                # for loop did not break), we need to try specializing each
-                # of our PNADs.
+                # for loop did not break), we need to spawn from the most
+                # general PNAD and make a new PNAD to cover these necessary
+                # add effects.
                 else:
                     nec_pnad_set_changed = True
-                    # for pnad in pnads_for_option:
-                    #     new_pnad = self._try_specializing_pnad(
-                    #         necessary_add_effects, pnad, segment)
-                    #     if new_pnad is not None:
-                    #         assert new_pnad.option_spec == pnad.option_spec
-                    #         if len(param_opt_to_nec_pnads[option.parent]) > 0:
-                    #             param_opt_to_nec_pnads[option.parent].remove(
-                    #                 pnad)
-                    #         del pnad
-                    #         break
-                    # If we were unable to specialize any of the PNADs, we need
-                    # to spawn from the most general PNAD and make a new PNAD
-                    # to cover these necessary add effects.
-                    # else:
                     new_pnad = self._try_specializing_pnad(
                         necessary_add_effects,
                         param_opt_to_general_pnad[option.parent], segment)
                     assert new_pnad is not None
-
                     pnad = new_pnad
                     del new_pnad  # unused from here
                     param_opt_to_nec_pnads[option.parent].append(pnad)
-
                     # Recompute datastores for ALL PNADs associated with this
                     # option. We need to do this because the new PNAD may now
                     # be a better match for some transition that we previously
@@ -188,10 +173,11 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                         else:
                             pre = self._induce_preconditions_via_intersection(
                                 nec_pnad)
-                            nec_pnad.op = nec_pnad.op.copy_with(preconditions=pre)
-
+                            nec_pnad.op = nec_pnad.op.copy_with(
+                                preconditions=pre)
                     for pnad_to_remove in pnads_without_datastore:
-                        param_opt_to_nec_pnads[option.parent].remove(pnad_to_remove)
+                        param_opt_to_nec_pnads[option.parent].remove(
+                            pnad_to_remove)
 
                     # After all this, the unification call that failed earlier
                     # (leading us into the current else statement) should work.

--- a/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
+++ b/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
@@ -72,6 +72,7 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
 
         # Pass over the demonstrations multiple times. Each time, backchain
         # to learn PNADs. Repeat until a fixed point is reached.
+        num_backchaining_iters = 0
         nec_pnad_set_changed = True
         while nec_pnad_set_changed:
             # Before each pass, clear the poss_keep_effects and
@@ -85,6 +86,11 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
             # Run one pass of backchaining.
             nec_pnad_set_changed = self._backchain_one_pass(
                 param_opt_to_nec_pnads, param_opt_to_general_pnad)
+            num_backchaining_iters += 1
+        
+        # Test to check that there are only ever two iterations of backchaining
+        # that get run.
+        assert num_backchaining_iters == 2
 
         final_pnads = self._finish_learning(param_opt_to_nec_pnads)
         self._assert_all_data_in_exactly_one_datastore(final_pnads)

--- a/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
+++ b/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
@@ -8,7 +8,7 @@ from predicators.src.nsrt_learning.strips_learning.gen_to_spec_learner import \
     BackchainingSTRIPSLearner
 from predicators.src.structs import Action, LowLevelTrajectory, \
     PartialNSRTAndDatastore, Predicate, Segment, State, STRIPSOperator, Task, \
-    Type
+    Type, GroundAtom, DefaultState
 
 
 class _MockBackchainingSTRIPSLearner(BackchainingSTRIPSLearner):
@@ -868,3 +868,65 @@ def test_keep_effect_adding_new_variables():
             seg, sub = pnad.datastore[0]
             assert seg is segmented_traj[1]
             assert sub == {potato_x0: potato3}
+
+
+@pytest.mark.parametrize("val", [0.0, 1.0])
+def test_multi_pass_backchaining(val):
+    """Test that the BackchainingSTRIPSLearner does multiple passes
+    of backchaining, which is needed to ensure harmlessness.
+    """
+    utils.reset_config({"segmenter": "atom_changes"})
+    # Set up the predicates.
+    A = Predicate("A", [], lambda s, o: s[0] > 0.5)
+    B = Predicate("B", [], lambda s, o: s[1] > 0.5)
+    C = Predicate("C", [], lambda s, o: s[2] > 0.5)
+    D = Predicate("D", [], lambda s, o: s[3] > 0.5)
+    E = Predicate("E", [], lambda s, o: s[4] > 0.5)
+    predicates = {A, B, C, D, E}
+
+    # Create the necessary options and actions.
+    Pick = utils.SingletonParameterizedOption("Pick",
+                                              lambda s, m, o, p: None,
+                                              types=[]).ground([], [])
+    pick_act = Action([], Pick)
+    Place = utils.SingletonParameterizedOption("Place",
+                                               lambda s, m, o, p: None,
+                                               types=[]).ground([], [])
+    place_act = Action([], Place)
+
+    # Create trajectories.
+    traj1 = LowLevelTrajectory(
+        [[1.0, 0.0, 0.0, 0.0, 0.0],
+         [1.0, 1.0, 1.0, 0.0, 0.0],
+         [1.0, 0.0, 1.0, 1.0, 1.0]],
+        [pick_act, place_act], True, 0)
+    goal1 = {GroundAtom(D, [])}
+    task1 = Task(DefaultState, goal1)  # note: initial state is unused
+
+    traj2 = LowLevelTrajectory(
+        [[1.0, 1.0, 0.0, 0.0, val],
+         [1.0, 0.0, 0.0, 1.0, 1.0]],
+        [place_act], True, 1)
+    goal2 = {GroundAtom(D, []), GroundAtom(E, [])}
+    task2 = Task(DefaultState, goal2)  # note: initial state is unused
+
+    traj3 = LowLevelTrajectory(
+        [[1.0, 1.0, val, 0.0, 0.0],
+         [1.0, 0.0, 1.0, 1.0, 1.0]],
+        [place_act], True, 2)
+    goal3 = {GroundAtom(C, []), GroundAtom(D, [])}
+    task3 = Task(DefaultState, goal3)  # note: initial state is unused
+
+    ground_atom_trajs = utils.create_ground_atom_dataset(
+        [traj1, traj2, traj3], predicates)
+    segmented_trajs = [segment_trajectory(traj) for traj in ground_atom_trajs]
+
+    # Now, run the learner on the demo.
+    learner = _MockBackchainingSTRIPSLearner([traj1, traj2, traj3],
+                                             [task1, task2, task3],
+                                             predicates, segmented_trajs,
+                                             verify_harmlessness=True)
+    output_pnads = learner.learn()
+    for pnad in output_pnads:
+        print(pnad)
+    # TODO: assert stuff about output_pnads


### PR DESCRIPTION
Gets rid of specialization in favor of always spawning.

Supercloud results from before this change: https://github.com/Learning-and-Intelligent-Systems/predicators/pull/931

Supercloud results (only oracle and backchaining) from after this change:
TODO

closes #961 