### PR TITLE
make `offline_data_planning_timeout` default to `timeout`

### DIFF
--- a/src/args.py
+++ b/src/args.py
@@ -18,8 +18,9 @@ def create_arg_parser(env_required: bool = True,
     parser.add_argument("--included_options", default="", type=str)
     parser.add_argument("--seed", required=seed_required, type=int)
     parser.add_argument("--option_learner", type=str, default="no_learning")
-    # NOTE: this timeout is NOT used for planning when generating offline data.
-    # If you want to change that, modify offline_data_planning_timeout.
+    # NOTE: this timeout affects both data generation and evaluation.
+    # If you want to change only the data generation timeout,
+    # modify offline_data_planning_timeout.
     parser.add_argument("--timeout", default=10, type=float)
     parser.add_argument("--make_test_videos", action="store_true")
     parser.add_argument("--make_failure_videos", action="store_true")

--- a/src/datasets/demo_only.py
+++ b/src/datasets/demo_only.py
@@ -154,8 +154,10 @@ def _generate_demonstrations(
             break
         try:
             if CFG.demonstrator == "oracle":
-                oracle_approach.solve(
-                    task, timeout=CFG.offline_data_planning_timeout)
+                timeout = CFG.offline_data_planning_timeout
+                if timeout == -1:
+                    timeout = CFG.timeout
+                oracle_approach.solve(task, timeout=timeout)
                 # Since we're running the oracle approach, we know that the
                 # policy is actually a plan under the hood, and we can
                 # retrieve it with get_last_plan(). We do this because we want

--- a/src/settings.py
+++ b/src/settings.py
@@ -244,7 +244,8 @@ class GlobalSettings:
 
     # dataset parameters
     # For learning-based approaches, the data collection timeout for planning.
-    offline_data_planning_timeout = 10
+    # If -1, defaults to CFG.timeout.
+    offline_data_planning_timeout = -1
     # If "default", defaults to CFG.task_planning_heuristic.
     offline_data_task_planning_heuristic = "default"
     # If -1, defaults to CFG.sesame_max_skeletons_optimized.


### PR DESCRIPTION
note: this will affect a couple of scripts slightly. in particular:
* stick_button experiments in the nightly require `--timeout 300`, and
so any training examples that fail due to the timeout will take 30x
longer to do so
* similar for ALL experiments in `run_option_learning_experiments.sh`

closes #949