### PR TITLE
add per-task solve time and execution time metrics

### DIFF
--- a/scripts/plotting/create_per_task_bar_plots.py
+++ b/scripts/plotting/create_per_task_bar_plots.py
@@ -1,0 +1,66 @@
+"""Create bar plots for per-task metrics that start with NO_PRINT.
+
+Assumes that files in the results/ directory can be grouped by
+experiment ID alone."""
+
+import os
+import re
+import glob
+from collections import defaultdict
+import dill as pkl
+import matplotlib.pyplot as plt
+
+from predicators.src.settings import CFG
+
+DPI = 500
+
+
+def _main() -> None:
+    outdir = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                          "results")
+    os.makedirs(outdir, exist_ok=True)
+
+    experiment_ids = set()
+    solve_data = defaultdict(list)
+    exec_data = defaultdict(list)
+    for filepath in sorted(glob.glob(f"{CFG.results_dir}/*")):
+        with open(filepath, "rb") as f:
+            outdata = pkl.load(f)
+        config = outdata["config"].__dict__.copy()
+        run_data_defaultdict = outdata["results"]
+        assert not set(config.keys()) & set(run_data_defaultdict.keys())
+        run_data_defaultdict.update(config)
+        _, _, _, _, _, experiment_id, _ = filepath[8:-4].split("__")
+        experiment_ids.add(experiment_id)
+        run_data = dict(
+            run_data_defaultdict)  # want to crash if key not found!
+        run_data.update({"experiment_id": experiment_id})
+        for key in run_data:
+            if not key.startswith("NO_PRINT_"):
+                continue
+            match = re.match(r"NO_PRINT_task\d+_(solve|exec)_time", key)
+            assert match is not None
+            solve_or_exec = match.groups()[0]
+            if solve_or_exec == "solve":
+                solve_data[experiment_id].append(run_data[key])
+            else:
+                exec_data[experiment_id].append(run_data[key])
+    if not solve_data and not exec_data:
+        raise ValueError(f"No per-task data found in {CFG.results_dir}/")
+    print("Found the following experiment IDs:")
+    for experiment_id in experiment_ids:
+        print(experiment_id)
+        _, (ax1, ax2) = plt.subplots(1, 2)
+        ax1.hist(solve_data[experiment_id])
+        ax2.hist(exec_data[experiment_id])
+        ax1.set_title("Per-task solve time histogram")
+        ax2.set_title("Per-task execution time histogram")
+        outfile = os.path.join(outdir, f"{experiment_id}_per_task.png")
+        plt.savefig(outfile, dpi=DPI)
+        print(f"\tFound {len(solve_data[experiment_id])} task solve times and "
+              f"{len(exec_data[experiment_id])} task execution times")
+        print(f"\tWrote out to {outfile}")
+
+
+if __name__ == "__main__":
+    _main()

--- a/src/main.py
+++ b/src/main.py
@@ -249,6 +249,7 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
     total_num_execution_failures = 0
 
     video_prefix = utils.get_config_path_str()
+    metrics: Metrics = defaultdict(float)
     for test_task_idx, task in enumerate(test_tasks):
         solve_start = time.time()
         try:
@@ -268,6 +269,7 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
                 utils.save_video(outfile, video)
             continue
         solve_time = time.time() - solve_start
+        metrics[f"NO_PRINT_task{test_task_idx}_solve_time"] = solve_time
         num_found_policy += 1
         make_video = False
         solved = False
@@ -286,7 +288,8 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
                 max_num_steps=CFG.horizon,
                 monitor=monitor)
             solved = task.goal_holds(traj.states[-1])
-            solve_time += execution_metrics["policy_call_time"]
+            exec_time = execution_metrics["policy_call_time"]
+            metrics[f"NO_PRINT_task{test_task_idx}_exec_time"] = exec_time
         except utils.EnvironmentFailure as e:
             log_message = f"Environment failed with error: {e}"
             caught_exception = True
@@ -301,7 +304,7 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
         if solved:
             log_message = "SOLVED"
             num_solved += 1
-            total_suc_time += solve_time
+            total_suc_time += (solve_time + exec_time)
             make_video = CFG.make_test_videos
             video_file = f"{video_prefix}__task{test_task_idx+1}.mp4"
         else:
@@ -315,7 +318,6 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
             assert monitor is not None
             video = monitor.get_video()
             utils.save_video(video_file, video)
-    metrics: Metrics = defaultdict(float)
     metrics["num_solved"] = num_solved
     metrics["num_total"] = len(test_tasks)
     metrics["avg_suc_time"] = (total_suc_time /
@@ -361,6 +363,9 @@ def _save_test_results(results: Metrics,
     }
     with open(outfile, "wb") as f:
         pkl.dump(outdata, f)
+    del_keys = [k for k in outdata["results"] if k.startswith("NO_PRINT_")]
+    for k in del_keys:
+        del outdata["results"][k]
     logging.info(f"Test results: {outdata['results']}")
     logging.info(f"Wrote out test results to {outfile}")
 


### PR DESCRIPTION
also includes a no-frills plotting script for these new metrics

example results of script:
```
Found the following experiment IDs:
pybullet_cover_nsrt_learning
	Found 50 task solve times and 49 task execution times
	Wrote out to /Users/rohan/Documents/predicators/scripts/plotting/results/pybullet_cover_nsrt_learning_per_task.png
cover_nsrt_learning
	Found 50 task solve times and 50 task execution times
	Wrote out to /Users/rohan/Documents/predicators/scripts/plotting/results/cover_nsrt_learning_per_task.png
```

subsumes and closes #948