### PR TITLE
[sidelining] Fix known issue with intermediate harmlessness in longrun tests

### DIFF
--- a/scripts/supercloud/run_predicators_sidelining_experiments.sh
+++ b/scripts/supercloud/run_predicators_sidelining_experiments.sh
@@ -23,24 +23,24 @@ for ENV in ${ALL_ENVS[@]}; do
         # Model-free GNN option policy baseline.
         python $FILE $COMMON_ARGS --experiment_id ${ENV}_gnn_modelfree_50demo --load_experiment_id ${ENV}_gnn_shooting_50demo --approach gnn_option_policy --num_train_tasks 50 --gnn_option_policy_solve_with_shooting False --load_approach --load_data
     else
-        # # Oracle.
-        # python $FILE $COMMON_ARGS --experiment_id ${ENV}_oracle --approach oracle --num_train_tasks 0
+        # Oracle.
+        python $FILE $COMMON_ARGS --experiment_id ${ENV}_oracle --approach oracle --num_train_tasks 0
         # Main backchaining approach with various numbers of demonstrations.
         python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_5demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 5
         python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_10demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 10
         python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_25demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 25
         python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_50demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 50
-        # # Cluster-and-intersect (RLDM) baseline. Although it is guaranteed to
-        # # preserve harmlessness, we disable the check because it takes a long
-        # # time (since the operators have high arity).
-        # python $FILE $COMMON_ARGS --experiment_id ${ENV}_cluster_and_intersect_50demo --approach nsrt_learning --strips_learner cluster_and_intersect --num_train_tasks 50 --disable_harmlessness_check True
-        # # LOFT baseline. Same note on harmlessness as for cluster-and-intersect.
-        # python $FILE $COMMON_ARGS --experiment_id ${ENV}_cluster_and_search_50demo --approach nsrt_learning --strips_learner cluster_and_search --num_train_tasks 50 --disable_harmlessness_check True
-        # # Prediction error baseline that optimizes via hill climbing. Not
-        # # guaranteed to preserve harmlessness.
-        # python $FILE $COMMON_ARGS --experiment_id ${ENV}_pred_error_50demo --approach nsrt_learning --strips_learner cluster_and_intersect_sideline_prederror --num_train_tasks 50 --disable_harmlessness_check True
-        # # Model-based GNN option policy baseline.
-        # python $FILE $COMMON_ARGS --experiment_id ${ENV}_gnn_shooting_50demo --approach gnn_option_policy --num_train_tasks 50
+        # Cluster-and-intersect (RLDM) baseline. Although it is guaranteed to
+        # preserve harmlessness, we disable the check because it takes a long
+        # time (since the operators have high arity).
+        python $FILE $COMMON_ARGS --experiment_id ${ENV}_cluster_and_intersect_50demo --approach nsrt_learning --strips_learner cluster_and_intersect --num_train_tasks 50 --disable_harmlessness_check True
+        # LOFT baseline. Same note on harmlessness as for cluster-and-intersect.
+        python $FILE $COMMON_ARGS --experiment_id ${ENV}_cluster_and_search_50demo --approach nsrt_learning --strips_learner cluster_and_search --num_train_tasks 50 --disable_harmlessness_check True
+        # Prediction error baseline that optimizes via hill climbing. Not
+        # guaranteed to preserve harmlessness.
+        python $FILE $COMMON_ARGS --experiment_id ${ENV}_pred_error_50demo --approach nsrt_learning --strips_learner cluster_and_intersect_sideline_prederror --num_train_tasks 50 --disable_harmlessness_check True
+        # Model-based GNN option policy baseline.
+        python $FILE $COMMON_ARGS --experiment_id ${ENV}_gnn_shooting_50demo --approach gnn_option_policy --num_train_tasks 50
     fi
 
 done

--- a/scripts/supercloud/run_predicators_sidelining_experiments.sh
+++ b/scripts/supercloud/run_predicators_sidelining_experiments.sh
@@ -23,24 +23,24 @@ for ENV in ${ALL_ENVS[@]}; do
         # Model-free GNN option policy baseline.
         python $FILE $COMMON_ARGS --experiment_id ${ENV}_gnn_modelfree_50demo --load_experiment_id ${ENV}_gnn_shooting_50demo --approach gnn_option_policy --num_train_tasks 50 --gnn_option_policy_solve_with_shooting False --load_approach --load_data
     else
-        # Oracle.
-        python $FILE $COMMON_ARGS --experiment_id ${ENV}_oracle --approach oracle --num_train_tasks 0
+        # # Oracle.
+        # python $FILE $COMMON_ARGS --experiment_id ${ENV}_oracle --approach oracle --num_train_tasks 0
         # Main backchaining approach with various numbers of demonstrations.
         python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_5demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 5
         python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_10demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 10
         python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_25demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 25
         python $FILE $COMMON_ARGS --experiment_id ${ENV}_backchaining_50demo --approach nsrt_learning --strips_learner backchaining --num_train_tasks 50
-        # Cluster-and-intersect (RLDM) baseline. Although it is guaranteed to
-        # preserve harmlessness, we disable the check because it takes a long
-        # time (since the operators have high arity).
-        python $FILE $COMMON_ARGS --experiment_id ${ENV}_cluster_and_intersect_50demo --approach nsrt_learning --strips_learner cluster_and_intersect --num_train_tasks 50 --disable_harmlessness_check True
-        # LOFT baseline. Same note on harmlessness as for cluster-and-intersect.
-        python $FILE $COMMON_ARGS --experiment_id ${ENV}_cluster_and_search_50demo --approach nsrt_learning --strips_learner cluster_and_search --num_train_tasks 50 --disable_harmlessness_check True
-        # Prediction error baseline that optimizes via hill climbing. Not
-        # guaranteed to preserve harmlessness.
-        python $FILE $COMMON_ARGS --experiment_id ${ENV}_pred_error_50demo --approach nsrt_learning --strips_learner cluster_and_intersect_sideline_prederror --num_train_tasks 50 --disable_harmlessness_check True
-        # Model-based GNN option policy baseline.
-        python $FILE $COMMON_ARGS --experiment_id ${ENV}_gnn_shooting_50demo --approach gnn_option_policy --num_train_tasks 50
+        # # Cluster-and-intersect (RLDM) baseline. Although it is guaranteed to
+        # # preserve harmlessness, we disable the check because it takes a long
+        # # time (since the operators have high arity).
+        # python $FILE $COMMON_ARGS --experiment_id ${ENV}_cluster_and_intersect_50demo --approach nsrt_learning --strips_learner cluster_and_intersect --num_train_tasks 50 --disable_harmlessness_check True
+        # # LOFT baseline. Same note on harmlessness as for cluster-and-intersect.
+        # python $FILE $COMMON_ARGS --experiment_id ${ENV}_cluster_and_search_50demo --approach nsrt_learning --strips_learner cluster_and_search --num_train_tasks 50 --disable_harmlessness_check True
+        # # Prediction error baseline that optimizes via hill climbing. Not
+        # # guaranteed to preserve harmlessness.
+        # python $FILE $COMMON_ARGS --experiment_id ${ENV}_pred_error_50demo --approach nsrt_learning --strips_learner cluster_and_intersect_sideline_prederror --num_train_tasks 50 --disable_harmlessness_check True
+        # # Model-based GNN option policy baseline.
+        # python $FILE $COMMON_ARGS --experiment_id ${ENV}_gnn_shooting_50demo --approach gnn_option_policy --num_train_tasks 50
     fi
 
 done

--- a/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
+++ b/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
@@ -228,11 +228,11 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                     if segment not in segs_in_pnad:
                         # Find PNAD that the segment is currently in.
                         for seg_pnad in pnads_for_option:
-                            segs_in_seg_pnad = {
+                            segs_in_seg_pnad = [
                                 datapoint[0]
                                 for datapoint in seg_pnad.datastore
-                            }
-                            if segment in segs_in_seg_pnad:
+                            ]
+                            if segment in set(segs_in_seg_pnad):
                                 seg_idx = segs_in_seg_pnad.index(segment)
                                 seg_pnad.datastore.pop(seg_idx)
                                 break

--- a/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
+++ b/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
@@ -97,12 +97,8 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
             self._induce_delete_side_keep(param_opt_to_nec_pnads)
 
             # Harmlessness should now hold, but it's slow to check.
-            try:
-                assert self._check_harmlessness(
-                    self._get_uniquely_named_nec_pnads(param_opt_to_nec_pnads))
-            except AssertionError:
-                import ipdb; ipdb.set_trace()
-
+            assert self._check_harmlessness(
+                self._get_uniquely_named_nec_pnads(param_opt_to_nec_pnads))
             # Recompute datastores and preconditions for all PNADs.
             # Filter out PNADs that don't have datastores.
             cur_itr_pnads_unfiltered = [

--- a/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
+++ b/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
@@ -288,10 +288,7 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                         segment, objects,
                         param_opt_to_nec_pnads[option.parent])
                     assert var_to_obj is not None
-                    try:
-                        assert best_score_pnad == pnad
-                    except AssertionError:
-                        import ipdb; ipdb.set_trace()
+                    assert best_score_pnad == pnad
                     obj_to_var = {v: k for k, v in var_to_obj.items()}
                     assert len(var_to_obj) == len(obj_to_var)
                     ground_op = pnad.op.ground(

--- a/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
+++ b/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
@@ -216,15 +216,21 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                     segment, objects, pnads_for_option)
 
                 if pnad is not None:
-                    segs_in_pnad = [datapoint[0] for datapoint in pnad.datastore]                        
+                    segs_in_pnad = [
+                        datapoint[0] for datapoint in pnad.datastore
+                    ]
                     # In this case, we potentially want to recompute_datastores
                     # to see if this will just resolve the issue.
                     if segment not in segs_in_pnad:
-                        self._recompute_datastores_from_segments(pnads_for_option)
-                        # Since we're not changing anything aside from the PNADs'
-                        # datastores, we're guaranteed that the result of
-                        # _find_best_matching_pnad_and_sub will stay the same.
-                        segs_in_pnad = [datapoint[0] for datapoint in pnad.datastore]
+                        self._recompute_datastores_from_segments(
+                            pnads_for_option)
+                        # Since we're not changing anything aside from the
+                        # PNADs' datastores, we're guaranteed that the result
+                        # of _find_best_matching_pnad_and_sub will stay the
+                        # same.
+                        segs_in_pnad = [
+                            datapoint[0] for datapoint in pnad.datastore
+                        ]
 
                 if pnad is not None and segment in segs_in_pnad:
                     assert var_to_obj is not None

--- a/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
+++ b/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
@@ -218,7 +218,12 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                         datapoint[0] for datapoint in pnad.datastore
                     ]
                     # In this case, we want to move the segment from
-                    # another PNAD into the current PNAD.
+                    # another PNAD into the current PNAD. Note that
+                    # we don't have to recompute the PNAD's add
+                    # effects or preconditions because of the fact that
+                    # this PNAD was found by the _find_best_matching
+                    # function (which internally checks that the
+                    # preconditions and add effects are all correct).
                     if segment not in segs_in_pnad:
                         # Find PNAD that the segment is currently in.
                         for seg_pnad in pnads_for_option:
@@ -234,12 +239,10 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                         self._remove_empty_datastore_pnads(
                             param_opt_to_nec_pnads, option.parent)
 
-                # If we weren't able to find a substitution such that the given
-                # segment is in the particular PNAD's datastore (i.e, the above
-                # _find_best_matching call didn't yield a PNAD such that this
-                # PNAD's datastore contains the segment), we need to spawn a
-                # new PNAD from the most general PNAD to cover these necessary
-                # add effects.
+                # If we weren't able to find a substitution (i.e, the above
+                # _find_best_matching call didn't yield a PNAD), we need to
+                # spawn a new PNAD from the most general PNAD to cover
+                # these necessary add effects.
                 else:
                     nec_pnad_set_changed = True
                     pnad = self._spawn_new_pnad(segment)

--- a/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
+++ b/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
@@ -214,7 +214,6 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                 objects = set(segment.states[0])
                 pnad, var_to_obj = self._find_best_matching_pnad_and_sub(
                     segment, objects, pnads_for_option)
-
                 if pnad is not None:
                     segs_in_pnad = [
                         datapoint[0] for datapoint in pnad.datastore
@@ -231,7 +230,6 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                         segs_in_pnad = [
                             datapoint[0] for datapoint in pnad.datastore
                         ]
-
                 if pnad is not None and segment in segs_in_pnad:
                     assert var_to_obj is not None
                     obj_to_var = {v: k for k, v in var_to_obj.items()}
@@ -240,12 +238,12 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                         tuple(var_to_obj[var] for var in pnad.op.parameters))
                     if len(param_opt_to_nec_pnads[option.parent]) == 0:
                         param_opt_to_nec_pnads[option.parent].append(pnad)
-
                 # If we weren't able to find a substitution such that the given
                 # segment is in the particular PNAD's datastore (i.e, the above
-                # _find_best_matching call didn't yield a PNAD), we need to
-                # spawn a new PNAD from the most general PNAD to cover
-                # these necessary add effects.
+                # _find_best_matching call didn't yield a PNAD such that this
+                # PNAD's datastore contains the segment), we need to spawn a
+                # new PNAD from the most general PNAD to cover these necessary
+                # add effects.
                 else:
                     nec_pnad_set_changed = True
                     pnad = self._spawn_new_pnad(
@@ -284,6 +282,12 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                         param_opt_to_nec_pnads[option.parent])
                     assert var_to_obj is not None
                     assert best_score_pnad == pnad
+                    # Also, since this segment caused us to induce the new
+                    # PNAD, it should appear in this new PNAD's datastore.
+                    segs_in_pnad = [
+                        datapoint[0] for datapoint in pnad.datastore
+                    ]
+                    assert segment in segs_in_pnad
                     obj_to_var = {v: k for k, v in var_to_obj.items()}
                     assert len(var_to_obj) == len(obj_to_var)
                     ground_op = pnad.op.ground(

--- a/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
+++ b/src/nsrt_learning/strips_learning/gen_to_spec_learner.py
@@ -214,9 +214,10 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                         tuple(var_to_obj[var] for var in pnad.op.parameters))
                     if len(param_opt_to_nec_pnads[option.parent]) == 0:
                         param_opt_to_nec_pnads[option.parent].append(pnad)
-                    segs_in_pnad = [
-                        datapoint[0] for datapoint in pnad.datastore
-                    ]
+                    segs_in_pnad = {
+                        datapoint[0]
+                        for datapoint in pnad.datastore
+                    }
                     # In this case, we want to move the segment from
                     # another PNAD into the current PNAD. Note that
                     # we don't have to recompute the PNAD's add
@@ -227,10 +228,10 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                     if segment not in segs_in_pnad:
                         # Find PNAD that the segment is currently in.
                         for seg_pnad in pnads_for_option:
-                            segs_in_seg_pnad = [
+                            segs_in_seg_pnad = {
                                 datapoint[0]
                                 for datapoint in seg_pnad.datastore
-                            ]
+                            }
                             if segment in segs_in_seg_pnad:
                                 seg_idx = segs_in_seg_pnad.index(segment)
                                 seg_pnad.datastore.pop(seg_idx)
@@ -278,9 +279,10 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                     assert best_score_pnad == pnad
                     # Also, since this segment caused us to induce the new
                     # PNAD, it should appear in this new PNAD's datastore.
-                    segs_in_pnad = [
-                        datapoint[0] for datapoint in pnad.datastore
-                    ]
+                    segs_in_pnad = {
+                        datapoint[0]
+                        for datapoint in pnad.datastore
+                    }
                     assert segment in segs_in_pnad
                     obj_to_var = {v: k for k, v in var_to_obj.items()}
                     assert len(var_to_obj) == len(obj_to_var)
@@ -322,8 +324,8 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
     def _remove_empty_datastore_pnads(param_opt_to_nec_pnads: Dict[
         ParameterizedOption, List[PartialNSRTAndDatastore]],
                                       param_opt: ParameterizedOption) -> None:
-        """Removes all PNADs with empty datastores from the input
-        param_opt_to_nec_pnads dict."""
+        """Removes all PNADs associated with the given param_opt that have
+        empty datastores from the input param_opt_to_nec_pnads dict."""
         pnads_to_rm = []
         for pnad in param_opt_to_nec_pnads[param_opt]:
             if len(pnad.datastore) == 0:

--- a/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
+++ b/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
@@ -997,8 +997,11 @@ def test_multi_pass_backchaining(val):
 def test_backchaining_segment_not_in_datastore():
     """Test the BackchainingSTRIPSLearner on a case where it can cover a
     particular segment using an operator that doesn't have that segment in its
-    datastore. This will lead to the intermediate harmlessness check failing
-    if not handled correctly."""
+    datastore.
+
+    This will lead to the intermediate harmlessness check failing if not
+    handled correctly.
+    """
     utils.reset_config({
         "segmenter": "atom_changes",
         "backchaining_check_intermediate_harmlessness": True

--- a/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
+++ b/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
@@ -996,10 +996,10 @@ def test_multi_pass_backchaining(val):
 
 
 def test_backchaining_segment_not_in_datastore():
-    """Test the BackchainingSTRIPSLearner on a case where it can cover
-    a particular segment using an operator that doesn't have that segment
-    in its datastore and this will lead to the intermediate harmlessnes
-    check failing if not handled correctly."""
+    """Test the BackchainingSTRIPSLearner on a case where it can cover a
+    particular segment using an operator that doesn't have that segment in its
+    datastore and this will lead to the intermediate harmlessnes check failing
+    if not handled correctly."""
     utils.reset_config({
         "segmenter": "atom_changes",
         "backchaining_check_intermediate_harmlessness": True

--- a/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
+++ b/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
@@ -986,6 +986,9 @@ def test_multi_pass_backchaining(val):
 @pytest.mark.parametrize("use_single_option,num_demos,seed_offset",
                          itertools.product([True, False], [1, 2, 3, 4],
                                            range(250)))
+# @pytest.mark.parametrize("use_single_option,num_demos,seed_offset",
+#                          itertools.product([True], [4],
+#                                            [99]))
 def test_backchaining_randomly_generated(use_single_option, num_demos,
                                          seed_offset):
     """Test the BackchainingSTRIPSLearner on randomly generated test cases."""

--- a/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
+++ b/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
@@ -999,12 +999,6 @@ def test_multi_pass_backchaining(val):
 @pytest.mark.parametrize("use_single_option,num_demos,seed_offset",
                          itertools.product([True, False], [1, 2, 3, 4],
                                            range(250)))
-# @pytest.mark.parametrize("use_single_option,num_demos,seed_offset",
-#                          itertools.product([True], [4],
-#                                            [99]))
-# @pytest.mark.parametrize("use_single_option,num_demos,seed_offset",
-#                          itertools.product([True], [4],
-#                                            [227]))
 def test_backchaining_randomly_generated(use_single_option, num_demos,
                                          seed_offset):
     """Test the BackchainingSTRIPSLearner on randomly generated test cases."""

--- a/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
+++ b/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
@@ -989,6 +989,9 @@ def test_multi_pass_backchaining(val):
 # @pytest.mark.parametrize("use_single_option,num_demos,seed_offset",
 #                          itertools.product([True], [4],
 #                                            [99]))
+# @pytest.mark.parametrize("use_single_option,num_demos,seed_offset",
+#                          itertools.product([True], [4],
+#                                            [227]))
 def test_backchaining_randomly_generated(use_single_option, num_demos,
                                          seed_offset):
     """Test the BackchainingSTRIPSLearner on randomly generated test cases."""

--- a/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
+++ b/tests/nsrt_learning/strips_learning/test_gen_to_spec_learner.py
@@ -997,7 +997,7 @@ def test_multi_pass_backchaining(val):
 def test_backchaining_segment_not_in_datastore():
     """Test the BackchainingSTRIPSLearner on a case where it can cover a
     particular segment using an operator that doesn't have that segment in its
-    datastore and this will lead to the intermediate harmlessnes check failing
+    datastore. This will lead to the intermediate harmlessness check failing
     if not handled correctly."""
     utils.reset_config({
         "segmenter": "atom_changes",
@@ -1018,33 +1018,33 @@ def test_backchaining_segment_not_in_datastore():
                                               lambda s, m, o, p: None,
                                               types=[]).ground([], [])
     act = Action([], Pick)
-    #Setup the first trajectory.
+    # Set up the first trajectory.
     goal0 = {GroundAtom(B, [])}
     s00 = State({dummy: [1.0, 1.0, 0.0, 1.0, 0.0]})
     s01 = State({dummy: [0.0, 0.0, 1.0, 0.0, 1.0]})
     s02 = State({dummy: [1.0, 1.0, 1.0, 1.0, 1.0]})
     traj0 = LowLevelTrajectory([s00, s01, s02], [act, act], True, 0)
     task0 = Task(s00, goal0)
-    # Setup the second trajectory.
+    # Set up the second trajectory.
     goal1 = {GroundAtom(B, [])}
     s10 = State({dummy: [1.0, 0.0, 0.0, 1.0, 0.0]})
     s11 = State({dummy: [1.0, 1.0, 0.0, 0.0, 1.0]})
     traj1 = LowLevelTrajectory([s10, s11], [act], True, 1)
     task1 = Task(s10, goal1)
-    # Setup the third trajectory.
+    # Set up the third trajectory.
     goal2 = {GroundAtom(A, []), GroundAtom(C, [])}
     s20 = State({dummy: [0.0, 1.0, 0.0, 1.0, 1.0]})
     s21 = State({dummy: [1.0, 1.0, 1.0, 1.0, 1.0]})
     traj2 = LowLevelTrajectory([s20, s21], [act], True, 2)
     task2 = Task(s20, goal2)
-    # Setup the fourth trajectory.
+    # Set up the fourth trajectory.
     goal3 = {GroundAtom(A, []), GroundAtom(D, [])}
     s30 = State({dummy: [0.0, 1.0, 1.0, 1.0, 1.0]})
     s31 = State({dummy: [1.0, 0.0, 1.0, 1.0, 0.0]})
     s32 = State({dummy: [1.0, 1.0, 0.0, 1.0, 1.0]})
     traj3 = LowLevelTrajectory([s30, s31, s32], [act, act], True, 3)
     task3 = Task(s30, goal3)
-    # Ground and segment these trajectories
+    # Ground and segment these trajectories.
     trajs = [traj0, traj1, traj2, traj3]
     ground_atom_trajs = utils.create_ground_atom_dataset(trajs, predicates)
     segmented_trajs = [segment_trajectory(traj) for traj in ground_atom_trajs]


### PR DESCRIPTION
Gets the intermediate harmlessness check to pass for the longrun tests, resolving the known issue with these tests. 

Conceptually, we want to ensure at the end of our backchaining that:
- The segment.necessary_add_effects should be set correctly.
- We should be able to find a best-matching PNAD (unification) for this segment.
- *This segment should be in the particular PNAD’s datastore.*

We weren't previously explicitly checking this last condition (though it is important only rarely), which leads to intermediate harmlessness violations that get fixed at later iterations of the outer loop.

We now explicitly check this condition, and if it's false, we move the segment into the correct datastore to fix the problem. Here's a diagram of the logic:

![image](https://user-images.githubusercontent.com/12446934/175660400-c022cc09-ff53-4d7f-84af-25eaffda2d33.png)

It's possible we can accomplish the same thing in a nicer, more integrated way that makes the code cleaner/easier to understand.

**Supercloud results**:

```
Git commit hashes seen in results/:
a02d4fff0ca5e9cd9ea342e7b5079e7419b55d8e


AGGREGATED DATA OVER SEEDS:
                                                  NUM_TRAIN_TASKS     NUM_SOLVED AVG_NUM_PREDS AVG_TEST_TIME  AVG_NODES_CREATED  LEARNING_TIME  NUM_SEEDS
EXPERIMENT_ID                                                                                                                                            
painting_backchaining_10demo                         10.00 (0.00)   41.90 (3.91)  14.00 (0.00)   0.47 (0.20)   1995.81 (935.53)   53.19 (3.88)         10
painting_backchaining_25demo                         25.00 (0.00)   49.20 (1.17)  14.00 (0.00)   0.38 (0.08)   2378.04 (829.09)   56.16 (3.38)         10
painting_backchaining_50demo                         50.00 (0.00)   49.40 (0.66)  14.00 (0.00)   0.43 (0.12)  2748.98 (1084.43)   57.99 (2.40)         10
painting_backchaining_5demo                           5.00 (0.00)   12.00 (8.72)  14.00 (0.00)   1.20 (0.90)   1208.96 (882.06)   50.65 (2.30)         10
repeated_nextto_painting_backchaining_10demo         10.00 (0.00)  34.30 (10.00)  18.00 (0.00)   1.31 (0.46)  5763.46 (5495.06)   89.86 (6.76)         10
repeated_nextto_painting_backchaining_25demo         25.00 (0.00)   45.00 (3.71)  18.00 (0.00)   0.80 (0.23)  2544.65 (2748.56)   92.88 (3.36)         10
repeated_nextto_painting_backchaining_50demo         50.00 (0.00)   49.50 (0.67)  18.00 (0.00)   0.76 (0.06)   1829.65 (422.83)   96.13 (4.74)         10
repeated_nextto_painting_backchaining_5demo           5.00 (0.00)   20.40 (9.86)  18.00 (0.00)   1.58 (0.78)  7347.63 (6640.82)   83.10 (2.36)         10
repeated_nextto_single_option_backchaining_10demo    10.00 (0.00)   50.00 (0.00)   3.00 (0.00)   0.04 (0.01)       88.50 (2.35)   20.68 (2.67)         10
repeated_nextto_single_option_backchaining_25demo    25.00 (0.00)   50.00 (0.00)   3.00 (0.00)   0.03 (0.00)       88.50 (2.35)   17.13 (0.90)         10
repeated_nextto_single_option_backchaining_50demo    50.00 (0.00)   50.00 (0.00)   3.00 (0.00)   0.03 (0.00)       88.50 (2.35)   23.07 (1.15)         10
repeated_nextto_single_option_backchaining_5demo      5.00 (0.00)   49.80 (0.60)   3.00 (0.00)   0.04 (0.01)      83.81 (14.95)   22.77 (2.30)         10
satellites_backchaining_10demo                       10.00 (0.00)   23.20 (7.61)  13.00 (0.00)   2.00 (0.85)  5547.99 (3190.52)   10.40 (0.46)         10
satellites_backchaining_25demo                       25.00 (0.00)   38.60 (5.64)  13.00 (0.00)   1.34 (0.30)  5360.62 (2624.37)   14.48 (0.72)         10
satellites_backchaining_50demo                       50.00 (0.00)   47.30 (1.55)  13.00 (0.00)   1.10 (0.21)  6667.70 (2726.76)   66.22 (0.55)         10
satellites_backchaining_5demo                         5.00 (0.00)    6.90 (9.41)  13.00 (0.00)   1.33 (0.84)  6966.44 (9825.95)    9.38 (0.61)         10
satellites_simple_backchaining_10demo                10.00 (0.00)   33.50 (6.04)  13.00 (0.00)   0.85 (0.53)    402.45 (210.77)   10.11 (0.82)         10
satellites_simple_backchaining_25demo                25.00 (0.00)   44.00 (2.41)  13.00 (0.00)   0.37 (0.16)     288.60 (45.14)   11.39 (0.75)         10
satellites_simple_backchaining_50demo                50.00 (0.00)   49.20 (0.60)  13.00 (0.00)   0.16 (0.09)     278.21 (45.27)  33.98 (23.71)         10
satellites_simple_backchaining_5demo                  5.00 (0.00)    7.50 (8.15)  13.00 (0.00)   1.80 (2.47)    533.91 (345.06)    9.44 (0.57)         10
screws_backchaining_10demo                           10.00 (0.00)   50.00 (0.00)   4.00 (0.00)   0.09 (0.00)      117.32 (1.06)    0.12 (0.00)         10
screws_backchaining_25demo                           25.00 (0.00)   50.00 (0.00)   4.00 (0.00)   0.09 (0.00)      117.32 (1.06)    0.35 (0.01)         10
screws_backchaining_50demo                           50.00 (0.00)   50.00 (0.00)   4.00 (0.00)   0.09 (0.00)      117.32 (1.06)    0.61 (0.02)         10
screws_backchaining_5demo                             5.00 (0.00)   50.00 (0.00)   4.00 (0.00)   0.09 (0.00)      117.32 (1.06)    0.07 (0.00)         10
```