### PR TITLE
DDPG (Deep Deterministic Policy Gradient) RL Option Learner

### DIFF
--- a/src/approaches/nsrt_rl_approach.py
+++ b/src/approaches/nsrt_rl_approach.py
@@ -51,7 +51,7 @@ class NSRTReinforcementLearningApproach(NSRTLearningApproach):
         # each one will maintain its own unique state associated with the
         # learning process.
         self._option_learners = {
-            n: create_rl_option_learner(self._action_space)
+            n: create_rl_option_learner()
             for n in self._nsrts
         }
 
@@ -87,7 +87,7 @@ class NSRTReinforcementLearningApproach(NSRTLearningApproach):
                                                    State, Array, bool]]]]:
         option_to_data: Dict[ParameterizedOption,
                              List[List[Tuple[State, Array, Action, int,
-                                             State]]]] = {}
+                                             State, Array, bool]]]] = {}
         assert self._requests_info is not None
         train_task_idx, plan = self._requests_info[idx]
         traj = LowLevelTrajectory(result.states,

--- a/src/approaches/nsrt_rl_approach.py
+++ b/src/approaches/nsrt_rl_approach.py
@@ -123,7 +123,8 @@ class NSRTReinforcementLearningApproach(NSRTLearningApproach):
                 cur_option.objects,
             )
             input_vec = np.hstack(([1.0], state_features, rel_param))
-            next_input_vec = np.hstack(([1.0], next_state_features, next_rel_param))
+            next_input_vec = np.hstack(
+                ([1.0], next_state_features, next_rel_param))
 
             # Add pos_reward if we got within epsilon of the option's
             # subgoal, otherwise we add neg_reward. To do this, we can check
@@ -146,7 +147,8 @@ class NSRTReinforcementLearningApproach(NSRTLearningApproach):
             # it a reward.
             terminate = parent_option.effect_based_terminal(
                 next_state, cur_option.objects)
-            experience.append((state, input_vec, action, reward, next_state, next_input_vec, terminate))
+            experience.append((state, input_vec, action, reward, next_state,
+                               next_input_vec, terminate))
             had_sufficient_steps = (
                 next_state.allclose(traj.states[-1])
                 and (CFG.max_num_steps_interaction_request - j >
@@ -188,7 +190,8 @@ class NSRTReinforcementLearningApproach(NSRTLearningApproach):
         # relative parameter that the sampler provided. This input vector is
         # necessary during learning to update the option's regressor.
         option_to_data: DefaultDict[ParameterizedOption, List[List[Tuple[
-            State, Array, Action, int, State, Array, bool]]]] = defaultdict(list)
+            State, Array, Action, int, State, Array,
+            bool]]]] = defaultdict(list)
 
         # For each InteractionResult, compute the experience data for each
         # _Option we see used in that interaction.

--- a/src/approaches/nsrt_rl_approach.py
+++ b/src/approaches/nsrt_rl_approach.py
@@ -86,8 +86,8 @@ class NSRTReinforcementLearningApproach(NSRTLearningApproach):
     ) -> Dict[ParameterizedOption, List[List[Tuple[State, Array, Action, int,
                                                    State, Array, bool]]]]:
         option_to_data: Dict[ParameterizedOption,
-                             List[List[Tuple[State, Array, Action, int,
-                                             State, Array, bool]]]] = {}
+                             List[List[Tuple[State, Array, Action, int, State,
+                                             Array, bool]]]] = {}
         assert self._requests_info is not None
         train_task_idx, plan = self._requests_info[idx]
         traj = LowLevelTrajectory(result.states,
@@ -200,6 +200,13 @@ class NSRTReinforcementLearningApproach(NSRTLearningApproach):
                 i, result)
             for option, experience in option_to_data_from_result.items():
                 option_to_data[option].extend(experience)
+
+        # Compute total rewards as debugging tool, for each option.
+        for option, experience in option_to_data.items():
+            total_rewards = sum(t[3] for run in experience for t in run)
+            print(
+                f"{option.name} reward in cycle {self._online_learning_cycle-1}: {total_rewards}"
+            )
 
         # Call the RL option learner on each option.
         for option, experiences in option_to_data.items():

--- a/src/ml_models.py
+++ b/src/ml_models.py
@@ -422,6 +422,17 @@ class MLPRegressor(PyTorchRegressor):
         return nn.MSELoss()
 
 
+class Critic(MLPRegressor):
+    """A critic network to be used in actor-critic RL methods."""
+
+    def forward(self, state: Tensor, action: Tensor) -> Tensor:
+        tensor_X = torch.cat([state, action], dim=1)
+        for _, linear in enumerate(self._linears[:-1]):
+            tensor_X = F.relu(linear(tensor_X))
+        tensor_X = self._linears[-1](tensor_X)
+        return tensor_X
+
+
 class ImplicitMLPRegressor(PyTorchRegressor):
     """A regressor implemented via an energy function.
 

--- a/src/ml_models.py
+++ b/src/ml_models.py
@@ -425,6 +425,13 @@ class MLPRegressor(PyTorchRegressor):
 class Critic(MLPRegressor):
     """A critic network to be used in actor-critic RL methods."""
 
+    def initialize_net(self, input_dim, output_dim) -> None:
+        self._linears.append(nn.Linear(input_dim, self._hid_sizes[0]))
+        for i in range(len(self._hid_sizes) - 1):
+            self._linears.append(
+                nn.Linear(self._hid_sizes[i], self._hid_sizes[i + 1]))
+        self._linears.append(nn.Linear(self._hid_sizes[-1], output_dim))
+
     def forward(self, state: Tensor, action: Tensor) -> Tensor:
         tensor_X = torch.cat([state, action], dim=1)
         for _, linear in enumerate(self._linears[:-1]):

--- a/src/ml_models.py
+++ b/src/ml_models.py
@@ -425,8 +425,7 @@ class MLPRegressor(PyTorchRegressor):
 class Critic(nn.Module):
     """A critic network to be used in actor-critic RL methods."""
 
-    def __init__(self, hid_sizes: List[int], input_dim: int,
-                 output_dim: int) -> None:
+    def __init__(self, hid_sizes: List[int], input_dim: int) -> None:
         super().__init__()  # type: ignore
         self._hid_sizes = hid_sizes
         self._linears = nn.ModuleList()
@@ -434,7 +433,7 @@ class Critic(nn.Module):
         for i in range(len(self._hid_sizes) - 1):
             self._linears.append(
                 nn.Linear(self._hid_sizes[i], self._hid_sizes[i + 1]))
-        self._linears.append(nn.Linear(self._hid_sizes[-1], output_dim))
+        self._linears.append(nn.Linear(self._hid_sizes[-1], 1))
 
     def forward(self, state: Tensor, action: Tensor) -> Tensor:
         """Computes forward pass."""

--- a/src/ml_models.py
+++ b/src/ml_models.py
@@ -426,6 +426,7 @@ class Critic(nn.Module):
     """A critic network to be used in actor-critic RL methods."""
 
     def __init__(self, hid_sizes: List[int], input_dim: int) -> None:
+        # TODO(ashay): make the architecture fancier.
         super().__init__()  # type: ignore
         self._hid_sizes = hid_sizes
         self._linears = nn.ModuleList()

--- a/src/ml_models.py
+++ b/src/ml_models.py
@@ -425,8 +425,9 @@ class MLPRegressor(PyTorchRegressor):
 class Critic(nn.Module):
     """A critic network to be used in actor-critic RL methods."""
 
-    def __init__(self, hid_sizes: List[int], input_dim: int, output_dim: int) -> None:
-        super(Critic, self).__init__()  # type: ignore
+    def __init__(self, hid_sizes: List[int], input_dim: int,
+                 output_dim: int) -> None:
+        super().__init__()  # type: ignore
         self._hid_sizes = hid_sizes
         self._linears = nn.ModuleList()
         self._linears.append(nn.Linear(input_dim, self._hid_sizes[0]))
@@ -436,6 +437,7 @@ class Critic(nn.Module):
         self._linears.append(nn.Linear(self._hid_sizes[-1], output_dim))
 
     def forward(self, state: Tensor, action: Tensor) -> Tensor:
+        """Computes forward pass."""
         tensor_X = torch.cat([state, action], dim=1)
         for _, linear in enumerate(self._linears[:-1]):
             tensor_X = F.relu(linear(tensor_X))

--- a/src/ml_models.py
+++ b/src/ml_models.py
@@ -422,10 +422,13 @@ class MLPRegressor(PyTorchRegressor):
         return nn.MSELoss()
 
 
-class Critic(MLPRegressor):
+class Critic(nn.Module):
     """A critic network to be used in actor-critic RL methods."""
 
-    def initialize_net(self, input_dim, output_dim) -> None:
+    def __init__(self, hid_sizes: List[int], input_dim: int, output_dim: int) -> None:
+        super(Critic, self).__init__()  # type: ignore
+        self._hid_sizes = hid_sizes
+        self._linears = nn.ModuleList()
         self._linears.append(nn.Linear(input_dim, self._hid_sizes[0]))
         for i in range(len(self._hid_sizes) - 1):
             self._linears.append(

--- a/src/settings.py
+++ b/src/settings.py
@@ -231,6 +231,7 @@ class GlobalSettings:
     nsrt_rl_critic_regressor_hid_sizes = [64, 64]
     nsrt_rl_actor_learning_rate = 1e-4
     nsrt_rl_critic_learning_rate = 1e-3
+    nsrt_rl_ddpg_iters = 10000
 
     # SeSamE parameters
     sesame_task_planning_heuristic = "lmcut"

--- a/src/settings.py
+++ b/src/settings.py
@@ -222,7 +222,7 @@ class GlobalSettings:
     nsrt_rl_reward_epsilon = 1e-2  # reward if in epsilon-ball from subgoal
     nsrt_rl_pos_reward = 0
     nsrt_rl_neg_reward = -1
-    nsrt_rl_option_learner = "dummy_rl"
+    nsrt_rl_option_learner = "ddpg"
     nsrt_rl_valid_reward_steps_threshold = 10
     nsrt_rl_batch_size = 200
     nsrt_rl_tau = 1e-2

--- a/src/settings.py
+++ b/src/settings.py
@@ -224,6 +224,13 @@ class GlobalSettings:
     nsrt_rl_neg_reward = -1
     nsrt_rl_option_learner = "dummy_rl"
     nsrt_rl_valid_reward_steps_threshold = 10
+    nsrt_rl_batch_size = 50
+    nsrt_rl_tau = 1e-2
+    nsrt_rl_discount_factor = 0.99
+    nsrt_rl_replay_buffer_size = 50000
+    nsrt_rl_critic_regressor_hid_sizes = [64, 64]
+    nsrt_rl_actor_learning_rate = 1e-4
+    nsrt_rl_critic_learning_rate = 1e-3
 
     # SeSamE parameters
     sesame_task_planning_heuristic = "lmcut"

--- a/src/settings.py
+++ b/src/settings.py
@@ -224,7 +224,7 @@ class GlobalSettings:
     nsrt_rl_neg_reward = -1
     nsrt_rl_option_learner = "dummy_rl"
     nsrt_rl_valid_reward_steps_threshold = 10
-    nsrt_rl_batch_size = 50
+    nsrt_rl_batch_size = 200
     nsrt_rl_tau = 1e-2
     nsrt_rl_discount_factor = 0.99
     nsrt_rl_replay_buffer_size = 50000


### PR DESCRIPTION
RL option learner that updates each option's regressor via (essentially) DDPG. To review DDPG, see the algorithm definition in https://arxiv.org/abs/1509.02971. Currently, it runs. I need to do more testing to see if there are run-time bugs (e.g. by making sure rewards go up as we go through more online learning cycles.) 

There are a number of ways in which what we do is different than DDPG. The main thing is that DDPG updates the actor and critic after each single interaction with the environment. Meanwhile, we update the actor and critic only after a large number of interactions (after each online learning cycle). 

The main things this PR will add is: 
* Replay buffer class in (currently in `option_learner.py`)
* Noise class (Ornstein-Uhlenbeck Process) to be used for exploration by adding noise to the policy output via a `_NoisyNeuralParameterizedOption` class that subclasses `_LearnedNeuralParameterizedOption` (both currently in `option_learner.py`)
* A basic critic network (currently in `ml_models.py`)
* DDPG agent (in `option_learner.py`) that provides an update method that is used to update each option.

Example command: `python3 src/main.py --env cover_multistep_options --approach nsrt_rl --seed 32 --option_learner direct_bc --sampler_learner neural --skip_until_cycle 1 --segmenter contacts --num_train_tasks 30 --nsrt_rl_batch_size 200 --num_online_learning_cycles 100`. 