### PR TITLE
[BEHAVIOR] Cuts down the number of 'reachable' predicates to only what's necessary

### DIFF
--- a/src/envs/behavior.py
+++ b/src/envs/behavior.py
@@ -252,10 +252,10 @@ class BehaviorEnv(BaseEnv):
 
         for name, classifier, arity in custom_predicate_specs:
             for type_combo in itertools.product(types_lst, repeat=arity):
-                pred_name = self._create_type_combo_name(name, type_combo)
-                pred = Predicate(pred_name, list(type_combo), classifier)
                 # We only care about reachable when the agent is one of the
                 # types.
+                pred_name = self._create_type_combo_name(name, type_combo)
+                pred = Predicate(pred_name, list(type_combo), classifier)
                 if name == "reachable" and not any(type_i.name == "agent"
                                                    for type_i in type_combo):
                     continue
@@ -461,8 +461,6 @@ class BehaviorEnv(BaseEnv):
         # If the two objects are the same (i.e reachable(agent, agent)),
         # we always want to return False so that when we learn
         # operators, such predicates don't needlessly appear in preconditions.
-        # In the future, we probably want to prevent such atoms from
-        # ever being created.
         if ig_obj == ig_other_obj:
             return False
         return (np.linalg.norm(  # type: ignore

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -2763,16 +2763,16 @@ def _get_behavior_gt_nsrts() -> Set[NSRT]:  # pragma: no cover
         pred_name = f"{base_pred_name}-{type_names}"
         return pred_name_to_pred[pred_name]
 
-    # We start by creating reachable predicates for all possible type
-    # combinations. These predicates will be used as side predicates
-    # for navigateTo operators
-    reachable_predicates = set()
-    for reachable_pred_types in itertools.product(env.types, env.types):
-        reachable_predicates.add(
-            _get_predicate("reachable", reachable_pred_types))
-
     agent_type = type_name_to_type["agent"]
     agent_obj = Variable("?agent", agent_type)
+
+    # We start by creating reachable predicates for the agent and
+    # all possible other type combinations. These predicates will
+    # be used as side predicates for navigateTo operators
+    reachable_predicates = set()
+    for reachable_pred_types in itertools.product([agent_type], env.types):
+        reachable_predicates.add(
+            _get_predicate("reachable", reachable_pred_types))
 
     nsrts = set()
     op_name_count_nav = itertools.count()

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -2767,8 +2767,8 @@ def _get_behavior_gt_nsrts() -> Set[NSRT]:  # pragma: no cover
     agent_obj = Variable("?agent", agent_type)
 
     # We start by creating reachable predicates for the agent and
-    # all possible other type combinations. These predicates will
-    # be used as side predicates for navigateTo operators
+    # all possible other types. These predicates will
+    # be used as side predicates for navigateTo operators.
     reachable_predicates = set()
     for reachable_pred_types in itertools.product([agent_type], env.types):
         reachable_predicates.add(


### PR DESCRIPTION
Prevents the creation of ground atoms like `reachable-hardback-hardback(book1, book1)`, which were previously making NSRT learning return complicated and hyper-specific operators.