### PR TITLE
update nightly with option learning expts; add NotSameCup predicate to coffee env

### DIFF
--- a/scripts/supercloud/run_nightly_experiments.sh
+++ b/scripts/supercloud/run_nightly_experiments.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# NOTE: all these experiments should get >45 / 50 in the NUM_SOLVED column of
+# the table printed out by `python scripts/analyze_results_directory.py`,
+# except stick_button_option_learning, which should get ~40-45 / 50.
+
 FILE="scripts/supercloud/submit_supercloud_job.py"
 
 # cover

--- a/scripts/supercloud/run_nightly_experiments.sh
+++ b/scripts/supercloud/run_nightly_experiments.sh
@@ -5,26 +5,22 @@ FILE="scripts/supercloud/submit_supercloud_job.py"
 # cover
 python $FILE --experiment_id cover_oracle --env cover --approach oracle --num_train_tasks 0
 python $FILE --experiment_id cover_nsrt_learning --env cover --approach nsrt_learning --num_train_tasks 50
-python $FILE --experiment_id cover_invent_noexclude --env cover --approach grammar_search_invention --num_train_tasks 50
 python $FILE --experiment_id cover_invent_allexclude --env cover --approach grammar_search_invention --excluded_predicates all --num_train_tasks 50
 
 # pybullet_blocks
 python $FILE --experiment_id pybullet_blocks_oracle --env pybullet_blocks --approach oracle --num_train_tasks 0
 python $FILE --experiment_id pybullet_blocks_nsrt_learning --env pybullet_blocks --approach nsrt_learning --num_train_tasks 50
-python $FILE --experiment_id pybullet_blocks_invent_noexclude --env pybullet_blocks --approach grammar_search_invention --num_train_tasks 50
 python $FILE --experiment_id pybullet_blocks_invent_allexclude --env pybullet_blocks --approach grammar_search_invention --excluded_predicates all --num_train_tasks 50
 
 # painting
 python $FILE --experiment_id painting_oracle --env painting --approach oracle --num_train_tasks 0
 python $FILE --experiment_id painting_nsrt_learning --env painting --approach nsrt_learning --num_train_tasks 50
-python $FILE --experiment_id painting_invent_noexclude --env painting --approach grammar_search_invention --num_train_tasks 50
 python $FILE --experiment_id painting_invent_allexclude --env painting --approach grammar_search_invention --excluded_predicates all --num_train_tasks 50
 
 # tools
 # requires more data: "--num_train_tasks 200"
 python $FILE --experiment_id tools_oracle --env tools --approach oracle --num_train_tasks 0
 python $FILE --experiment_id tools_nsrt_learning --env tools --approach nsrt_learning --num_train_tasks 200
-python $FILE --experiment_id tools_invent_noexclude --env tools --approach grammar_search_invention --num_train_tasks 200
 python $FILE --experiment_id tools_invent_allexclude --env tools --approach grammar_search_invention --excluded_predicates all --num_train_tasks 200
 
 # playroom
@@ -34,7 +30,6 @@ python $FILE --experiment_id playroom_nsrt_learning --env playroom --approach ns
 # pybullet_cover
 python $FILE --experiment_id pybullet_cover_oracle --env pybullet_cover --approach oracle --num_train_tasks 0
 python $FILE --experiment_id pybullet_cover_nsrt_learning --env pybullet_cover --approach nsrt_learning --num_train_tasks 50
-python $FILE --experiment_id pybullet_cover_invent_noexclude --env pybullet_cover --approach grammar_search_invention --num_train_tasks 50
 python $FILE --experiment_id pybullet_cover_invent_allexclude --env pybullet_cover --approach grammar_search_invention --excluded_predicates all --num_train_tasks 50
 
 # stick button
@@ -43,3 +38,9 @@ python $FILE --experiment_id stick_button_oracle --env stick_button --approach o
 # requires more data: "--num_train_tasks 500"
 # requires filtering: "--min_perc_data_for_nsrt 1"
 python $FILE --experiment_id stick_button_nsrt_learning --env stick_button --approach nsrt_learning --timeout 300 --num_train_tasks 500 --min_perc_data_for_nsrt 1
+
+# option learning
+python $FILE --experiment_id cover_option_learning --env cover_multistep_options --approach nsrt_learning --option_learner direct_bc --min_perc_data_for_nsrt 1 --segmenter contacts --num_train_tasks 1000 --timeout 300
+python $FILE --experiment_id doors_option_learning --env doors --included_options MoveToDoor,MoveThroughDoor --approach nsrt_learning --option_learner direct_bc --min_perc_data_for_nsrt 1 --segmenter contacts --num_train_tasks 1000 --timeout 300
+python $FILE --experiment_id stick_button_option_learning --env stick_button --approach nsrt_learning --option_learner direct_bc --min_perc_data_for_nsrt 1 --segmenter contacts --num_train_tasks 1000 --timeout 300
+python $FILE --experiment_id coffee_option_learning --env coffee --approach nsrt_learning --option_learner direct_bc --min_perc_data_for_nsrt 1 --segmenter contacts --num_train_tasks 1000 --timeout 300

--- a/scripts/supercloud/run_nightly_experiments.sh
+++ b/scripts/supercloud/run_nightly_experiments.sh
@@ -40,7 +40,7 @@ python $FILE --experiment_id stick_button_oracle --env stick_button --approach o
 python $FILE --experiment_id stick_button_nsrt_learning --env stick_button --approach nsrt_learning --timeout 300 --num_train_tasks 500 --min_perc_data_for_nsrt 1
 
 # option learning
-python $FILE --experiment_id cover_option_learning --env cover_multistep_options --approach nsrt_learning --option_learner direct_bc --min_perc_data_for_nsrt 1 --segmenter contacts --num_train_tasks 1000 --timeout 300
-python $FILE --experiment_id doors_option_learning --env doors --included_options MoveToDoor,MoveThroughDoor --approach nsrt_learning --option_learner direct_bc --min_perc_data_for_nsrt 1 --segmenter contacts --num_train_tasks 1000 --timeout 300
-python $FILE --experiment_id stick_button_option_learning --env stick_button --approach nsrt_learning --option_learner direct_bc --min_perc_data_for_nsrt 1 --segmenter contacts --num_train_tasks 1000 --timeout 300
-python $FILE --experiment_id coffee_option_learning --env coffee --approach nsrt_learning --option_learner direct_bc --min_perc_data_for_nsrt 1 --segmenter contacts --num_train_tasks 1000 --timeout 300
+python $FILE --experiment_id cover_option_learning --env cover_multistep_options --approach nsrt_learning --option_learner direct_bc --min_perc_data_for_nsrt 1 --segmenter contacts --num_train_tasks 1000 --timeout 300 --neural_gaus_regressor_max_itr 50000
+python $FILE --experiment_id doors_option_learning --env doors --included_options MoveToDoor,MoveThroughDoor --approach nsrt_learning --option_learner direct_bc --min_perc_data_for_nsrt 1 --segmenter contacts --num_train_tasks 1000 --timeout 300 --neural_gaus_regressor_max_itr 50000
+python $FILE --experiment_id stick_button_option_learning --env stick_button --approach nsrt_learning --option_learner direct_bc --min_perc_data_for_nsrt 1 --segmenter contacts --num_train_tasks 1000 --timeout 300 --neural_gaus_regressor_max_itr 50000
+python $FILE --experiment_id coffee_option_learning --env coffee --approach nsrt_learning --option_learner direct_bc --min_perc_data_for_nsrt 1 --segmenter contacts --num_train_tasks 1000 --timeout 300 --neural_gaus_regressor_max_itr 50000

--- a/src/envs/coffee.py
+++ b/src/envs/coffee.py
@@ -686,8 +686,7 @@ class CoffeeEnv(BaseEnv):
         return sq_dist_to_button < self.button_radius
 
     @staticmethod
-    def _NotSameCup_holds(state: State,
-                          objects: Sequence[Object]) -> bool:
+    def _NotSameCup_holds(state: State, objects: Sequence[Object]) -> bool:
         del state  # unused
         cup1, cup2 = objects
         return cup1 != cup2

--- a/src/envs/coffee.py
+++ b/src/envs/coffee.py
@@ -138,6 +138,9 @@ class CoffeeEnv(BaseEnv):
         self._PressingButton = Predicate(
             "PressingButton", [self._robot_type, self._machine_type],
             self._PressingButton_holds)
+        self._NotSameCup = Predicate("NotSameCup",
+                                     [self._cup_type, self._cup_type],
+                                     self._NotSameCup_holds)
 
         # Options
         self._MoveToTwistJug = ParameterizedOption(
@@ -336,7 +339,7 @@ class CoffeeEnv(BaseEnv):
             self._CupFilled, self._JugInMachine, self._Holding,
             self._MachineOn, self._OnTable, self._HandEmpty, self._JugFilled,
             self._RobotAboveCup, self._JugAboveCup, self._NotAboveCup,
-            self._PressingButton, self._Twisting
+            self._PressingButton, self._Twisting, self._NotSameCup
         }
 
     @property
@@ -681,6 +684,13 @@ class CoffeeEnv(BaseEnv):
         z = state.get(robot, "z")
         sq_dist_to_button = np.sum(np.subtract(button_pos, (x, y, z))**2)
         return sq_dist_to_button < self.button_radius
+
+    @staticmethod
+    def _NotSameCup_holds(state: State,
+                          objects: Sequence[Object]) -> bool:
+        del state  # unused
+        cup1, cup2 = objects
+        return cup1 != cup2
 
     def _MoveToTwistJug_policy(self, state: State, memory: Dict,
                                objects: Sequence[Object],

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -2331,11 +2331,11 @@ def _get_coffee_gt_nsrts() -> Set[NSRT]:
         CFG.env, ["robot", "jug", "cup", "machine"])
     CupFilled, Holding, JugInMachine, MachineOn, OnTable, HandEmpty, \
         JugFilled, RobotAboveCup, JugAboveCup, NotAboveCup, PressingButton, \
-        Twisting = \
+        Twisting, NotSameCup = \
         _get_predicates_by_names(CFG.env, ["CupFilled",
             "Holding", "JugInMachine", "MachineOn", "OnTable", "HandEmpty",
             "JugFilled", "RobotAboveCup", "JugAboveCup", "NotAboveCup",
-            "PressingButton", "Twisting"])
+            "PressingButton", "Twisting", "NotSameCup"])
     MoveToTwistJug, TwistJug, PickJug, PlaceJugInMachine, TurnMachineOn, \
         Pour = _get_options_by_names(CFG.env, ["MoveToTwistJug", "TwistJug",
             "PickJug", "PlaceJugInMachine", "TurnMachineOn", "Pour"])
@@ -2530,6 +2530,8 @@ def _get_coffee_gt_nsrts() -> Set[NSRT]:
         LiftedAtom(JugFilled, [jug]),
         LiftedAtom(JugAboveCup, [jug, other_cup]),
         LiftedAtom(RobotAboveCup, [robot, other_cup]),
+        LiftedAtom(NotSameCup, [cup, other_cup]),
+        LiftedAtom(NotSameCup, [other_cup, cup]),
     }
     add_effects = {
         LiftedAtom(JugAboveCup, [jug, cup]),

--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -2531,7 +2531,6 @@ def _get_coffee_gt_nsrts() -> Set[NSRT]:
         LiftedAtom(JugAboveCup, [jug, other_cup]),
         LiftedAtom(RobotAboveCup, [robot, other_cup]),
         LiftedAtom(NotSameCup, [cup, other_cup]),
-        LiftedAtom(NotSameCup, [other_cup, cup]),
     }
     add_effects = {
         LiftedAtom(JugAboveCup, [jug, cup]),

--- a/tests/envs/test_coffee.py
+++ b/tests/envs/test_coffee.py
@@ -21,7 +21,7 @@ def test_coffee():
     for task in env.get_test_tasks():
         for obj in task.init:
             assert len(obj.type.feature_names) == len(task.init[obj])
-    assert len(env.predicates) == 12
+    assert len(env.predicates) == 13
     assert len(env.goal_predicates) == 1
     pred_name_to_pred = {p.name: p for p in env.predicates}
     CupFilled = pred_name_to_pred["CupFilled"]


### PR DESCRIPTION
this is a possible fix to a subtle regression in coffee option learning that was introduced by the change to `apply_operator()` in #984 .

after that change, the number of possible skeletons that appear to solve the task significantly increased, which led to slower overall planning time. by adding this predicate, the hope is to reduce the number of skeletons back to the original and restore option learning results.

also closes #1029 

coffee results:
```
Git commit hashes seen in results/:
471a97d1f80d09d0d9c5f3aee89fe1fce0f2effc


AGGREGATED DATA OVER SEEDS:
                 NUM_TRAIN_TASKS    NUM_SOLVED AVG_NUM_PREDS  AVG_TEST_TIME AVG_NODES_CREATED    LEARNING_TIME  NUM_SEEDS
EXPERIMENT_ID                                                                                                            
coffee_main_100    100.00 (0.00)  39.90 (7.74)  13.00 (0.00)  49.08 (17.93)      40.48 (6.32)   430.42 (26.69)         10
coffee_main_1000  1000.00 (0.00)  49.10 (1.04)  13.00 (0.00)  49.15 (10.74)      41.35 (4.41)  1009.58 (12.67)         10
coffee_main_250    250.00 (0.00)  45.80 (5.74)  13.00 (0.00)  48.76 (12.64)      39.83 (4.72)   531.16 (16.23)         10
coffee_main_50      50.00 (0.00)  21.80 (9.46)  13.00 (0.00)  33.56 (15.15)      30.77 (9.07)   400.10 (12.70)         10
coffee_main_500    500.00 (0.00)  48.90 (1.37)  13.00 (0.00)  43.64 (13.12)      40.43 (4.88)  879.29 (183.01)         10
```

new nightly results:
