### PR TITLE
allow max training iterations in `ml_models.py` to depend on the dataset size

### DIFF
--- a/src/structs.py
+++ b/src/structs.py
@@ -6,7 +6,7 @@ import abc
 from dataclasses import dataclass, field
 from functools import cached_property, lru_cache
 from typing import Any, Callable, Collection, DefaultDict, Dict, Iterator, \
-    List, Optional, Sequence, Set, Tuple, TypeVar, cast
+    List, Optional, Sequence, Set, Tuple, TypeVar, Union, cast
 
 import numpy as np
 from gym.spaces import Box
@@ -1516,3 +1516,6 @@ SamplerDatapoint = Tuple[State, VarToObjSub, _Option,
 # For PDDLEnv environments, given a desired number of problems and an rng,
 # returns a list of that many PDDL problem strings.
 PDDLProblemGenerator = Callable[[int, np.random.Generator], List[str]]
+# Used in ml_models.py. Either the maximum number of training iterations for
+# a model, or a function that produces this number given the amount of data.
+MaxTrainIters = Union[int, Callable[[int], int]]

--- a/src/utils.py
+++ b/src/utils.py
@@ -2402,7 +2402,7 @@ def string_to_python_object(value: str) -> Any:
         return True
     if value == "False":
         return False
-    if value.isdigit():
+    if value.isdigit() or value.startswith("lambda"):
         return eval(value)
     try:
         return float(value)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -168,7 +168,7 @@ def test_main():
         "--online_learning_max_transitions", "0", "--excluded_predicates",
         "Covers", "--interactive_num_ensemble_members", "1",
         "--num_train_tasks", "3", "--num_test_tasks", "3",
-        "--predicate_mlp_classifier_max_itr", "100"
+        "--predicate_mlp_classifier_max_itr", "lambda n: n * 50"
     ]
     main()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2844,6 +2844,10 @@ def test_string_to_python_object():
     assert utils.string_to_python_object("[3.2, 4.3]") == [3.2, 4.3]
     assert utils.string_to_python_object("(3.2,4.3)") == (3.2, 4.3)
     assert utils.string_to_python_object("(3.2, 4.3)") == (3.2, 4.3)
+    assert utils.string_to_python_object("lambda x: x + 3")(12) == 15
+    with pytest.raises(TypeError):  # invalid number of arguments
+        utils.string_to_python_object("lambda: x + 3")(12)
+    assert utils.string_to_python_object("lambda: 13")() == 13
 
 
 def test_get_env_asset_path():


### PR DESCRIPTION
Example usage:
`python src/main.py --env cover --approach nsrt_learning --seed 0 --sampler_mlp_classifier_max_itr "lambda n: n * 100"`
```
Tasks solved: 50 / 50
Average time for successes: 0.04212 seconds
Test results: defaultdict(<class 'float'>, {'num_solved': 50, 'num_total': 50, 'avg_suc_time': 0.04211793422698975, 'min_skeletons_optimized': 1.0, 'max_skeletons_optimized': 2.0, 'num_solve_timeouts': 0, 'num_solve_failures': 0, 'num_execution_timeouts': 0, 'num_execution_failures': 0, 'avg_num_skeletons_optimized': 1.1, 'avg_num_nodes_expanded': 2.8, 'avg_num_nodes_created': 6.6, 'avg_num_nsrts': 2.0, 'avg_num_preds': 5.0, 'avg_plan_length': 2.46, 'avg_num_failures_discovered': 0.0, 'num_offline_transitions': 123, 'num_online_transitions': 0, 'query_cost': 0.0, 'learning_time': 22.879285097122192})
```

closes #659