### PR TITLE
standardize spelling of "noop"

### DIFF
--- a/src/envs/coffee.py
+++ b/src/envs/coffee.py
@@ -272,13 +272,13 @@ class CoffeeEnv(BaseEnv):
                 if abs(tilt - self.tilt_ub) < self.pour_angle_tol:
                     # Find the cup to pour into, if any.
                     cup = self._get_cup_to_pour(next_state)
-                    # If pouring into nothing, no-op.
+                    # If pouring into nothing, noop.
                     if cup is None:
                         return state.copy()
                     # Increase the liquid in the cup.
                     current_liquid = state.get(cup, "current_liquid")
                     new_liquid = current_liquid + self.pour_velocity
-                    # If we have exceeded the capacity of the cup, no-op.
+                    # If we have exceeded the capacity of the cup, noop.
                     if new_liquid > state.get(cup, "capacity_liquid"):
                         return state.copy()
                     next_state.set(cup, "current_liquid", new_liquid)

--- a/src/envs/cover.py
+++ b/src/envs/cover.py
@@ -63,7 +63,7 @@ class CoverEnv(BaseEnv):
         pose = action.arr.item()
         next_state = state.copy()
         hand_regions = self._get_hand_regions(state)
-        # If we're not in any hand region, no-op.
+        # If we're not in any hand region, noop.
         if not any(hand_lb <= pose <= hand_rb
                    for hand_lb, hand_rb in hand_regions):
             return next_state

--- a/src/envs/pybullet_cover.py
+++ b/src/envs/pybullet_cover.py
@@ -242,7 +242,7 @@ class PyBulletCoverEnv(PyBulletEnv, CoverEnv):
         z_thresh = (self._pickplace_z + self._workspace_z) / 2
         if rz < z_thresh and not any(hand_lb <= hand <= hand_rb
                                      for hand_lb, hand_rb in hand_regions):
-            # The constraint is violated, so no-op.
+            # The constraint is violated, so noop.
             return self._current_state.copy()
         return super().step(action)
 

--- a/src/envs/stick_button.py
+++ b/src/envs/stick_button.py
@@ -132,7 +132,7 @@ class StickButtonEnv(BaseEnv):
         new_rx = rx + dx
         new_ry = ry + dy
         new_rtheta = rtheta + dtheta
-        # The robot cannot leave the reachable zone. If it tries to, no-op.
+        # The robot cannot leave the reachable zone. If it tries to, noop.
         rad = self.robot_radius
         if not self.rz_x_lb + rad <= new_rx <= self.rz_x_ub - rad or \
            not self.rz_y_lb + rad <= new_ry <= self.rz_y_ub - rad:

--- a/src/envs/tools.py
+++ b/src/envs/tools.py
@@ -535,7 +535,7 @@ class ToolsEnv(BaseEnv):
         contraption_is_correct = self._is_pose_on_contraption(
             state, pose_x, pose_y, contraption)
         if not tool_is_correct or not contraption_is_correct:
-            # Simulate a no-op by fastening at poses where there is guaranteed
+            # Simulate a noop by fastening at poses where there is guaranteed
             # to be no contraption. We don't use an initiable() function here
             # because we want replay data to be able to try this, in order
             # to discover good operator preconditions.

--- a/src/nsrt_learning/strips_learning/clustering_learner.py
+++ b/src/nsrt_learning/strips_learning/clustering_learner.py
@@ -368,7 +368,7 @@ class ClusterAndIntersectSidelineSTRIPSLearner(ClusterAndIntersectSTRIPSLearner
             # ...consider changing each of its add effects to a side predicate.
             for effect in pnad.op.add_effects:
                 if len(pnad.op.add_effects) > 1:
-                    # We don't want sidelining to result in a no-op.
+                    # We don't want sidelining to result in a noop.
                     new_pnad = PartialNSRTAndDatastore(
                         pnad.op.effect_to_side_predicate(
                             effect, option_vars, "add"), pnad.datastore,

--- a/src/planning.py
+++ b/src/planning.py
@@ -346,7 +346,7 @@ def _run_low_level_search(task: Task, option_model: _OptionModelBase,
                 # Check if we have exceeded the horizon.
                 if np.sum(num_actions_per_option[:cur_idx]) > max_horizon:
                     can_continue_on = False
-                # Check if the option was effectively a no-op.
+                # Check if the option was effectively a noop.
                 elif num_actions == 0:
                     can_continue_on = False
                 elif CFG.sesame_check_expected_atoms:

--- a/tests/envs/test_blocks.py
+++ b/tests/envs/test_blocks.py
@@ -50,7 +50,7 @@ def test_blocks():
 
 
 def test_blocks_failure_cases():
-    """Tests for the cases where simulate() is a no-op."""
+    """Tests for the cases where simulate() is a noop."""
     utils.reset_config({"env": "blocks"})
     env = BlocksEnv()
     Pick = [o for o in env.options if o.name == "Pick"][0]

--- a/tests/envs/test_coffee.py
+++ b/tests/envs/test_coffee.py
@@ -224,7 +224,7 @@ def test_coffee():
     assert GroundAtom(NotAboveCup, [robot, jug]).holds(traj.states[-1])
     s = traj.states[-1]
 
-    # Check for no-op when pouring into nothing.
+    # Check for noop when pouring into nothing.
     pour_act_lst = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0]
     pour_act_arr = np.array(pour_act_lst, dtype=np.float32)
     next_s = env.simulate(s, Action(pour_act_arr))
@@ -263,7 +263,7 @@ def test_coffee():
         # Render a state where we are in the process of pouring.
         env.render_state(traj.states[-2], task)
 
-    # Check for no-op when overfilling a cup.
+    # Check for noop when overfilling a cup.
     next_s = env.simulate(s, Action(pour_act_arr))
     assert s.allclose(next_s)
 

--- a/tests/envs/test_cover.py
+++ b/tests/envs/test_cover.py
@@ -87,7 +87,7 @@ def test_cover():
     assert len(atoms) == expected_lengths.pop(0)
     assert not expected_lengths
     assert task.goal.issubset(atoms)  # goal achieved
-    # Test being outside of a hand region. Should be a no-op.
+    # Test being outside of a hand region. Should be a noop.
     option = next(iter(env.options)).ground([], [0])
     assert option.initiable(task.init)
     traj = utils.run_policy_with_simulator(option.policy,
@@ -182,7 +182,7 @@ def test_cover_typed_options():
     assert len(atoms) == expected_lengths.pop(0)
     assert not expected_lengths
     assert task.goal.issubset(atoms)  # goal achieved
-    # Test being outside of a hand region. Should be a no-op.
+    # Test being outside of a hand region. Should be a noop.
     option = place_option.ground([target0], [0])
     assert option.initiable(task.init)
     traj = utils.run_policy_with_simulator(option.policy,

--- a/tests/envs/test_painting.py
+++ b/tests/envs/test_painting.py
@@ -87,7 +87,7 @@ def test_painting_goals():
 
 
 def test_painting_failure_cases():
-    """Tests for the cases where simulate() is a no-op or
+    """Tests for the cases where simulate() is a noop or
     EnvironmentFailure."""
     utils.reset_config({
         "env": "painting",

--- a/tests/envs/test_pddl_env.py
+++ b/tests/envs/test_pddl_env.py
@@ -10,6 +10,7 @@ from predicators.src import utils
 from predicators.src.envs.pddl_env import FixedTasksBlocksPDDLEnv, \
     ProceduralTasksBlocksPDDLEnv, ProceduralTasksDeliveryPDDLEnv, \
     _FixedTasksPDDLEnv, _PDDLEnv
+from predicators.src.structs import Action
 
 
 @pytest.fixture(scope="module", name="domain_str")
@@ -187,6 +188,12 @@ def test_pddlenv(domain_str, problem_strs):
     assert next_state.simulator_state == {
         isMonkfish([fish1]), ate([fish1, ban2])
     }
+    # Test that when the object types don't match the operator
+    # parameters, a noop occurs.
+    action = Action(
+        np.zeros(env.action_space.shape, dtype=env.action_space.dtype))
+    next_state = env.simulate(state, action)
+    assert state.allclose(next_state)
 
 
 def test_fixed_tasks_pddlenv(domain_str, problem_strs):

--- a/tests/envs/test_playroom.py
+++ b/tests/envs/test_playroom.py
@@ -35,7 +35,7 @@ def test_playroom():
 
 
 def test_playroom_failure_cases():
-    """Tests for the cases where simulate() is a no-op."""
+    """Tests for the cases where simulate() is a noop."""
     utils.reset_config({"env": "playroom"})
     env = PlayroomEnv()
     On = [o for o in env.predicates if o.name == "On"][0]

--- a/tests/envs/test_repeated_nextto_painting.py
+++ b/tests/envs/test_repeated_nextto_painting.py
@@ -41,7 +41,7 @@ def test_repeated_nextto_painting():
 
 
 def test_repeated_nextto_painting_failure_cases():
-    """Tests for the cases where simulate() is a no-op or
+    """Tests for the cases where simulate() is a noop or
     EnvironmentFailure."""
     utils.reset_config({
         "env": "repeated_nextto_painting",

--- a/tests/envs/test_stick_button.py
+++ b/tests/envs/test_stick_button.py
@@ -68,7 +68,7 @@ def test_stick_button():
 
     ## Test simulate ##
 
-    # Test for no-ops if the robot tries to leave the reachable zone.
+    # Test for noops if the robot tries to leave the reachable zone.
     up_action = Action(np.array([0.0, -1.0, 0.0, 0.0], dtype=np.float32))
     s = state
     states = [s]
@@ -258,7 +258,7 @@ def test_stick_button():
     # Press to pick up the stick.
     action = Action(np.array([0., 0., 0., 1.], dtype=np.float32))
     next_state = env.simulate(state, action)
-    assert state.allclose(next_state)  # should no-op
+    assert state.allclose(next_state)  # should noop
 
     # Test interface for collecting human demonstrations.
     event_to_action = env.get_event_to_action_fn()

--- a/tests/envs/test_tools.py
+++ b/tests/envs/test_tools.py
@@ -69,7 +69,7 @@ def test_tools_fasten_option():
 
 
 def test_tools_failure_cases():
-    """Tests for the cases where simulate() is a no-op."""
+    """Tests for the cases where simulate() is a noop."""
     utils.reset_config({"env": "tools", "tools_num_items_train": [25]})
     env = DummyToolsEnv()
     HandEmpty = [o for o in env.predicates if o.name == "HandEmpty"][0]

--- a/tests/nsrt_learning/test_option_learning.py
+++ b/tests/nsrt_learning/test_option_learning.py
@@ -59,7 +59,7 @@ def test_known_options_option_learner():
         for (segment, _) in datastore:
             assert segment.has_option()
             option = segment.get_option()
-            # This call should be a no-op when options are known.
+            # This call should be a noop when options are known.
             option_learner.update_segment_from_option_spec(segment, spec)
             assert segment.has_option()
             assert segment.get_option() == option

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -200,7 +200,7 @@ def test_sesame_plan_failures():
     # immediately, under the option model.
 
     class _MockOptionModel(_OptionModelBase):
-        """A mock option model that always predicts a no-op."""
+        """A mock option model that always predicts a noop."""
 
         def __init__(self, simulator):
             self._simulator = simulator

--- a/third_party/fast_downward_translator/translate.py
+++ b/third_party/fast_downward_translator/translate.py
@@ -337,7 +337,7 @@ def prune_stupid_effect_conditions(var, val, conditions, effects_on_var):
     ## 1. Conditions of the form "var = dualval" where var is the
     ##    effect variable and dualval != val can be omitted.
     ##    (If var != dualval, then var == val because it is binary,
-    ##    which means that in such situations the effect is a no-op.)
+    ##    which means that in such situations the effect is a noop.)
     ##    The condition can only be omitted if there is no effect
     ##    producing dualval (see issue736).
     ## 2. If conditions contains any empty list, it is equivalent


### PR DESCRIPTION
keep it as "noop" to agree with variable names which can't have a hyphen