### PR TITLE
raise error instead of falling back to random actions when...

### DIFF
--- a/src/approaches/random_options_approach.py
+++ b/src/approaches/random_options_approach.py
@@ -20,4 +20,4 @@ class RandomOptionsApproach(BaseApproach):
 
     def _solve(self, task: Task, timeout: int) -> Callable[[State], Action]:
         return utils.create_random_option_policy(self._initial_options,
-                                                 self._action_space, self._rng)
+                                                 self._rng)

--- a/src/approaches/random_options_approach.py
+++ b/src/approaches/random_options_approach.py
@@ -3,7 +3,7 @@
 from typing import Callable
 
 from predicators.src import utils
-from predicators.src.approaches import BaseApproach
+from predicators.src.approaches import ApproachFailure, BaseApproach
 from predicators.src.structs import Action, State, Task
 
 
@@ -19,5 +19,10 @@ class RandomOptionsApproach(BaseApproach):
         return False
 
     def _solve(self, task: Task, timeout: int) -> Callable[[State], Action]:
+
+        def fallback_policy(state: State) -> Action:
+            del state  # unused
+            raise ApproachFailure("Random option sampling failed!")
+
         return utils.create_random_option_policy(self._initial_options,
-                                                 self._rng)
+                                                 self._rng, fallback_policy)

--- a/src/explorers/random_options_explorer.py
+++ b/src/explorers/random_options_explorer.py
@@ -17,6 +17,9 @@ class RandomOptionsExplorer(BaseExplorer):
         # Take random options, and raise an exception if no applicable option
         # can be found.
 
+        # Note that this fallback policy is different from the one in
+        # RandomOptionsApproach because explorers should raise
+        # RequestActPolicyFailure instead of ApproachFailure.
         def fallback_policy(state: State) -> Action:
             del state  # unused
             raise utils.RequestActPolicyFailure(

--- a/src/explorers/random_options_explorer.py
+++ b/src/explorers/random_options_explorer.py
@@ -15,9 +15,7 @@ class RandomOptionsExplorer(BaseExplorer):
     def get_exploration_strategy(self, train_task_idx: int,
                                  timeout: int) -> ExplorationStrategy:
         # Take random options.
-        policy = utils.create_random_option_policy(self._options,
-                                                   self._action_space,
-                                                   self._rng)
+        policy = utils.create_random_option_policy(self._options, self._rng)
         # Never terminate (until the interaction budget is exceeded).
         termination_function = lambda _: False
         return policy, termination_function

--- a/src/explorers/random_options_explorer.py
+++ b/src/explorers/random_options_explorer.py
@@ -2,7 +2,7 @@
 
 from predicators.src import utils
 from predicators.src.explorers import BaseExplorer
-from predicators.src.structs import ExplorationStrategy
+from predicators.src.structs import Action, ExplorationStrategy, State
 
 
 class RandomOptionsExplorer(BaseExplorer):
@@ -14,8 +14,16 @@ class RandomOptionsExplorer(BaseExplorer):
 
     def get_exploration_strategy(self, train_task_idx: int,
                                  timeout: int) -> ExplorationStrategy:
-        # Take random options.
-        policy = utils.create_random_option_policy(self._options, self._rng)
+        # Take random options, and raise an exception if no applicable option
+        # can be found.
+
+        def fallback_policy(state: State) -> Action:
+            del state  # unused
+            raise utils.RequestActPolicyFailure(
+                "Random option sampling failed!")
+
+        policy = utils.create_random_option_policy(self._options, self._rng,
+                                                   fallback_policy)
         # Never terminate (until the interaction budget is exceeded).
         termination_function = lambda _: False
         return policy, termination_function

--- a/src/utils.py
+++ b/src/utils.py
@@ -1061,7 +1061,7 @@ def option_plan_to_policy(
 
 
 def create_random_option_policy(
-        options: Collection[ParameterizedOption], action_space: Box,
+        options: Collection[ParameterizedOption],
         rng: np.random.Generator) -> Callable[[State], Action]:
     """Create a policy that executes random initiable options."""
     sorted_options = sorted(options, key=lambda o: o.name)
@@ -1082,8 +1082,8 @@ def create_random_option_policy(
                 if opt.initiable(state):
                     cur_option = opt
                     break
-            else:  # fall back to a random action
-                return Action(action_space.sample())
+            else:
+                raise OptionExecutionFailure("Random option sampling failed!")
         act = cur_option.policy(state)
         return act
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1061,9 +1061,13 @@ def option_plan_to_policy(
 
 
 def create_random_option_policy(
-        options: Collection[ParameterizedOption],
-        rng: np.random.Generator) -> Callable[[State], Action]:
-    """Create a policy that executes random initiable options."""
+        options: Collection[ParameterizedOption], rng: np.random.Generator,
+        fallback_policy: Callable[[State],
+                                  Action]) -> Callable[[State], Action]:
+    """Create a policy that executes random initiable options.
+
+    If no applicable option can be found, query the fallback policy.
+    """
     sorted_options = sorted(options, key=lambda o: o.name)
     cur_option = DummyOption
 
@@ -1083,7 +1087,7 @@ def create_random_option_policy(
                     cur_option = opt
                     break
             else:
-                raise OptionExecutionFailure("Random option sampling failed!")
+                return fallback_policy(state)
         act = cur_option.policy(state)
         return act
 

--- a/tests/approaches/test_random_options_approach.py
+++ b/tests/approaches/test_random_options_approach.py
@@ -77,13 +77,15 @@ def test_random_options_approach():
         policy(state)
     assert "Random option sampling failed!" in str(e)
     # Test what happens when there's no object of the right type.
-    parameterized_option3 = ParameterizedOption("Move", [cup_type],
+    dummy_type = Type("dummy_type", ["feat1"])
+    parameterized_option3 = ParameterizedOption("Move", [dummy_type],
                                                 params_space, _policy,
-                                                lambda _1, _2, _3, _4: False,
+                                                lambda _1, _2, _3, _4: True,
                                                 _terminal)
     task = Task(state, {Solved([cup])})
     approach = RandomOptionsApproach({Solved}, {parameterized_option3},
                                      {cup_type}, params_space, task)
+    policy = approach.solve(task, 500)
     with pytest.raises(ApproachFailure) as e:
         policy(state)
     assert "Random option sampling failed!" in str(e)

--- a/tests/approaches/test_random_options_approach.py
+++ b/tests/approaches/test_random_options_approach.py
@@ -1,12 +1,13 @@
 """Test cases for the random options approach class."""
 
+import pytest
 from gym.spaces import Box
 
 from predicators.src import utils
 from predicators.src.approaches.random_options_approach import \
     RandomOptionsApproach
-from predicators.src.structs import Action, DefaultState, \
-    ParameterizedOption, Predicate, State, Task, Type
+from predicators.src.structs import Action, ParameterizedOption, Predicate, \
+    State, Task, Type
 
 
 def test_random_options_approach():
@@ -71,8 +72,9 @@ def test_random_options_approach():
     approach = RandomOptionsApproach({Solved}, {parameterized_option2},
                                      {cup_type}, params_space, task)
     policy = approach.solve(task, 500)
-    act = policy(state)
-    assert not act.has_option()  # should have fallen back to random action
+    with pytest.raises(utils.OptionExecutionFailure) as e:
+        policy(state)
+    assert "Random option sampling failed!" in str(e)
     # Test what happens when there's no object of the right type.
     parameterized_option3 = ParameterizedOption("Move", [cup_type],
                                                 params_space, _policy,
@@ -81,9 +83,9 @@ def test_random_options_approach():
     task = Task(state, {Solved([cup])})
     approach = RandomOptionsApproach({Solved}, {parameterized_option3},
                                      {cup_type}, params_space, task)
-    policy = approach.solve(task, 500)
-    act = policy(DefaultState)
-    assert not act.has_option()  # should have fallen back to random action
+    with pytest.raises(utils.OptionExecutionFailure) as e:
+        policy(state)
+    assert "Random option sampling failed!" in str(e)
     # Test what happens when the option is always terminal.
     parameterized_option4 = ParameterizedOption("Move", [], params_space,
                                                 _policy, _initiable,

--- a/tests/approaches/test_random_options_approach.py
+++ b/tests/approaches/test_random_options_approach.py
@@ -4,6 +4,7 @@ import pytest
 from gym.spaces import Box
 
 from predicators.src import utils
+from predicators.src.approaches import ApproachFailure
 from predicators.src.approaches.random_options_approach import \
     RandomOptionsApproach
 from predicators.src.structs import Action, ParameterizedOption, Predicate, \
@@ -72,7 +73,7 @@ def test_random_options_approach():
     approach = RandomOptionsApproach({Solved}, {parameterized_option2},
                                      {cup_type}, params_space, task)
     policy = approach.solve(task, 500)
-    with pytest.raises(utils.OptionExecutionFailure) as e:
+    with pytest.raises(ApproachFailure) as e:
         policy(state)
     assert "Random option sampling failed!" in str(e)
     # Test what happens when there's no object of the right type.
@@ -83,7 +84,7 @@ def test_random_options_approach():
     task = Task(state, {Solved([cup])})
     approach = RandomOptionsApproach({Solved}, {parameterized_option3},
                                      {cup_type}, params_space, task)
-    with pytest.raises(utils.OptionExecutionFailure) as e:
+    with pytest.raises(ApproachFailure) as e:
         policy(state)
     assert "Random option sampling failed!" in str(e)
     # Test what happens when the option is always terminal.

--- a/tests/envs/test_painting.py
+++ b/tests/envs/test_painting.py
@@ -87,8 +87,7 @@ def test_painting_goals():
 
 
 def test_painting_failure_cases():
-    """Tests for the cases where simulate() is a noop or
-    EnvironmentFailure."""
+    """Tests for the cases where simulate() is a noop or EnvironmentFailure."""
     utils.reset_config({
         "env": "painting",
         "approach": "nsrt_learning",

--- a/tests/envs/test_repeated_nextto_painting.py
+++ b/tests/envs/test_repeated_nextto_painting.py
@@ -41,8 +41,7 @@ def test_repeated_nextto_painting():
 
 
 def test_repeated_nextto_painting_failure_cases():
-    """Tests for the cases where simulate() is a noop or
-    EnvironmentFailure."""
+    """Tests for the cases where simulate() is a noop or EnvironmentFailure."""
     utils.reset_config({
         "env": "repeated_nextto_painting",
         "approach": "nsrt_learning",


### PR DESCRIPTION
 random option policy fails to sample.

justification: it's bad design to have actions returned by this policy sometimes have associated options, and sometimes not (and this was leading to a crash when exploring in pddl envs)