### PR TITLE
move class variables that use CFG into init

### DIFF
--- a/src/envs/blocks.py
+++ b/src/envs/blocks.py
@@ -46,8 +46,6 @@ class BlocksEnv(BaseEnv):
     on_tol: ClassVar[float] = 0.01
     collision_padding: ClassVar[float] = 2.0
     assert pick_tol < block_size
-    num_blocks_train: ClassVar[List[int]] = CFG.blocks_num_blocks_train
-    num_blocks_test: ClassVar[List[int]] = CFG.blocks_num_blocks_test
 
     def __init__(self) -> None:
         super().__init__()
@@ -89,6 +87,9 @@ class BlocksEnv(BaseEnv):
             params_space=Box(0, 1, (2, )))
         # Static objects (always exist no matter the settings).
         self._robot = Object("robby", self._robot_type)
+        # Hyperparameters from CFG.
+        self.num_blocks_train = CFG.blocks_num_blocks_train
+        self.num_blocks_test = CFG.blocks_num_blocks_test
 
     @classmethod
     def get_name(cls) -> str:

--- a/src/envs/playroom.py
+++ b/src/envs/playroom.py
@@ -42,8 +42,6 @@ class PlayroomEnv(BlocksEnv):
     on_tol: ClassVar[float] = pick_tol
     assert pick_tol < block_size
     pick_z: ClassVar[float] = 1.5
-    num_blocks_train: ClassVar[List[int]] = CFG.playroom_num_blocks_train
-    num_blocks_test: ClassVar[List[int]] = CFG.playroom_num_blocks_test
 
     def __init__(self) -> None:
         super().__init__()
@@ -206,6 +204,9 @@ class PlayroomEnv(BlocksEnv):
         self._region6 = Object("region6", self._region_type)
         self._region7 = Object("region7", self._region_type)
         self._dial = Object("dial", self._dial_type)
+        # Hyperparameters from CFG.
+        self.num_blocks_train = CFG.playroom_num_blocks_train
+        self.num_blocks_test = CFG.playroom_num_blocks_test
 
     @classmethod
     def get_name(cls) -> str:


### PR DESCRIPTION
I think we realized at some point that CFG should not be used in class variables, but there were still two cases where we had them (I checked all the environments).

the reason is that command line overrides will not work for those CFG settings, because by the time the overrides are processed, the class variables have already been set.

for example, `--blocks_num_blocks_test "[2]"` did not work as anticipated before this change.