### PR TITLE
exclude scripts from type checking

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 strict_equality = True
 disallow_untyped_calls = True
 warn_unreachable = True
-exclude = (src/envs/assets|third_party|src/scripts)
+exclude = (src/envs/assets|third_party|scripts)
 
 [mypy-predicators.src.*]
 disallow_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 strict_equality = True
 disallow_untyped_calls = True
 warn_unreachable = True
-exclude = (src/envs/assets|third_party)
+exclude = (src/envs/assets|third_party|src/scripts)
 
 [mypy-predicators.src.*]
 disallow_untyped_defs = True


### PR DESCRIPTION
this is a temporary measure until we have time to do the better thing...

- the scripts subdirectory uses `pandas` in a number of places
- the type annotations are not entirely correct, and it's nontrivial to fix them
- we've been getting away with this because the pandas library is mostly untyped
- but there's another library called `pandas-stubs` that adds type annotations for pandas
- the `openai` package has `pandas-stubs` as a dependency
- so in the short term, to add the `openai` package, we'll just stop type checking the entire scripts directory
- in the longer term, we need to close this issue https://github.com/Learning-and-Intelligent-Systems/predicators/issues/973