### PR TITLE
Saving+Loading GroundAtomTrajectories

### DIFF
--- a/src/approaches/nsrt_learning_approach.py
+++ b/src/approaches/nsrt_learning_approach.py
@@ -5,6 +5,7 @@ or options.
 """
 
 import logging
+import os
 import time
 from typing import Dict, List, Optional, Set
 
@@ -19,7 +20,7 @@ from predicators.src.nsrt_learning.nsrt_learning_main import \
 from predicators.src.planning import task_plan, task_plan_grounding
 from predicators.src.settings import CFG
 from predicators.src.structs import NSRT, Dataset, LowLevelTrajectory, \
-    ParameterizedOption, Predicate, Segment, Task, Type
+    ParameterizedOption, Predicate, Segment, Task, Type, GroundAtom
 
 
 class NSRTLearningApproach(BilevelPlanningApproach):
@@ -53,7 +54,7 @@ class NSRTLearningApproach(BilevelPlanningApproach):
 
     def _learn_nsrts(self, trajectories: List[LowLevelTrajectory],
                      online_learning_cycle: Optional[int]) -> None:
-        dataset_fname = utils.create_dataset_filename_str(
+        dataset_fname, _ = utils.create_dataset_filename_str(
             saving_ground_atoms=True,
             online_learning_cycle=online_learning_cycle)
         # If CFG.load_atoms is set, then try to load the GroundAtomTrajectory
@@ -76,7 +77,7 @@ class NSRTLearningApproach(BilevelPlanningApproach):
         else:
             # Apply predicates to data, producing a dataset of abstract states.
             ground_atom_dataset = utils.create_ground_atom_dataset(
-                trajectories, predicates)
+                trajectories, self._get_current_predicates())
             # Save ground atoms dataset to file.
             if CFG.env == "behavior":  # pragma: no cover
                 # In the case of behavior, we cannot directly pickle the ground

--- a/src/approaches/nsrt_learning_approach.py
+++ b/src/approaches/nsrt_learning_approach.py
@@ -56,7 +56,7 @@ class NSRTLearningApproach(BilevelPlanningApproach):
                      online_learning_cycle: Optional[int]) -> None:
         dataset_fname, _ = utils.create_dataset_filename_str(
             saving_ground_atoms=True,
-            online_learning_cycle=str(online_learning_cycle))
+            online_learning_cycle=online_learning_cycle)
         # If CFG.load_atoms is set, then try to create a GroundAtomTrajectory
         # by loading sets of GroundAtoms directly from a saved file.
         if CFG.load_atoms:
@@ -70,11 +70,25 @@ class NSRTLearningApproach(BilevelPlanningApproach):
                 logging.info("\n\nLOADED GROUND ATOM DATASET")
 
                 if CFG.env == "behavior":  # pragma: no cover
-                    new_ground_atoms = []
-                    import ipdb; ipdb.set_trace()
+                    pred_name_to_pred = {
+                        pred.name: pred
+                        for pred in self._get_current_predicates()
+                    }
+                    new_ground_atom_dataset_atoms = []
                     # Since we save ground atoms for behavior with dummy
                     # classifiers, we need to restore the correct classifers.
-                    # for ground_atom_set in ground_atom_dataset_atoms:
+                    for ground_atom_seq in ground_atom_dataset_atoms:
+                        new_ground_atom_seq = []
+                        for ground_atom_set in ground_atom_seq:
+                            new_ground_atom_set = {
+                                GroundAtom(
+                                    pred_name_to_pred[atom.predicate.name],
+                                    atom.entities)
+                                for atom in ground_atom_set
+                            }
+                            new_ground_atom_seq.append(new_ground_atom_set)
+                        new_ground_atom_dataset_atoms.append(
+                            new_ground_atom_seq)
 
                 # The saved ground atom dataset consists only of sequences
                 # of sets of GroundAtoms, we need to recombine this with

--- a/src/args.py
+++ b/src/args.py
@@ -29,6 +29,7 @@ def create_arg_parser(env_required: bool = True,
     parser.add_argument("--make_demo_videos", action="store_true")
     parser.add_argument("--load_approach", action="store_true")
     parser.add_argument("--load_data", action="store_true")
+    parser.add_argument("--load_atoms", action="store_true")
     parser.add_argument("--skip_until_cycle", default=-1, type=int)
     parser.add_argument("--experiment_id", default="", type=str)
     parser.add_argument("--load_experiment_id", default="", type=str)

--- a/src/datasets/demo_only.py
+++ b/src/datasets/demo_only.py
@@ -24,19 +24,8 @@ def create_demo_data(env: BaseEnv, train_tasks: List[Task],
                      known_options: Set[ParameterizedOption]) -> Dataset:
     """Create offline datasets by collecting demos."""
     assert CFG.demonstrator in ("oracle", "human")
-    regex = r"(\d+)"
-    if CFG.env == "behavior":  # pragma: no cover
-        dataset_fname_template = (
-            f"{CFG.env}__{CFG.behavior_scene_name}__{CFG.behavior_task_name}" +
-            f"__{CFG.offline_data_method}__{CFG.demonstrator}__"
-            f"{regex}__{CFG.included_options}__{CFG.seed}.data")
-    else:
-        dataset_fname_template = (
-            f"{CFG.env}__{CFG.offline_data_method}__{CFG.demonstrator}__"
-            f"{regex}__{CFG.included_options}__{CFG.seed}.data")
-    dataset_fname = os.path.join(
-        CFG.data_dir,
-        dataset_fname_template.replace(regex, str(CFG.num_train_tasks)))
+    dataset_fname = utils.create_dataset_filename_str(
+        saving_ground_atoms=False)
     os.makedirs(CFG.data_dir, exist_ok=True)
     if CFG.load_data:
         dataset = _create_demo_data_with_loading(env, train_tasks,

--- a/src/datasets/demo_only.py
+++ b/src/datasets/demo_only.py
@@ -24,7 +24,7 @@ def create_demo_data(env: BaseEnv, train_tasks: List[Task],
                      known_options: Set[ParameterizedOption]) -> Dataset:
     """Create offline datasets by collecting demos."""
     assert CFG.demonstrator in ("oracle", "human")
-    dataset_fname = utils.create_dataset_filename_str(
+    dataset_fname, dataset_fname_template = utils.create_dataset_filename_str(
         saving_ground_atoms=False)
     os.makedirs(CFG.data_dir, exist_ok=True)
     if CFG.load_data:

--- a/src/nsrt_learning/nsrt_learning_main.py
+++ b/src/nsrt_learning/nsrt_learning_main.py
@@ -14,9 +14,9 @@ from predicators.src.nsrt_learning.segmentation import segment_trajectory
 from predicators.src.nsrt_learning.strips_learning import \
     learn_strips_operators
 from predicators.src.settings import CFG
-from predicators.src.structs import NSRT, LowLevelTrajectory, \
-    ParameterizedOption, PartialNSRTAndDatastore, Predicate, Segment, Task, \
-    GroundAtomTrajectory
+from predicators.src.structs import NSRT, GroundAtomTrajectory, \
+    LowLevelTrajectory, ParameterizedOption, PartialNSRTAndDatastore, \
+    Predicate, Segment, Task
 
 
 def learn_nsrts_from_data(

--- a/src/nsrt_learning/nsrt_learning_main.py
+++ b/src/nsrt_learning/nsrt_learning_main.py
@@ -7,7 +7,6 @@ from typing import Dict, List, Set, Tuple
 
 from gym.spaces import Box
 
-from predicators.src import utils
 from predicators.src.nsrt_learning.option_learning import \
     KnownOptionsOptionLearner, _OptionLearnerBase, create_option_learner
 from predicators.src.nsrt_learning.sampler_learning import learn_samplers
@@ -16,7 +15,8 @@ from predicators.src.nsrt_learning.strips_learning import \
     learn_strips_operators
 from predicators.src.settings import CFG
 from predicators.src.structs import NSRT, LowLevelTrajectory, \
-    ParameterizedOption, PartialNSRTAndDatastore, Predicate, Segment, Task
+    ParameterizedOption, PartialNSRTAndDatastore, Predicate, Segment, Task, \
+    GroundAtomTrajectory
 
 
 def learn_nsrts_from_data(

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import abc
 import contextlib
+import dill as pkl
 import functools
 import gc
 import heapq as hq

--- a/src/utils.py
+++ b/src/utils.py
@@ -1871,8 +1871,7 @@ def create_dataset_filename_str(
     # Setup the dataset filename for saving/loading GroundAtoms.
     regex = r"(\d+)"
     suffix_str = ""
-    if online_learning_cycle is not None:
-        suffix_str += f"__{online_learning_cycle}"
+    suffix_str += f"__{online_learning_cycle}"
     if saving_ground_atoms:
         suffix_str += "__ground_atoms"
     suffix_str += ".data"

--- a/src/utils.py
+++ b/src/utils.py
@@ -22,7 +22,6 @@ from typing import TYPE_CHECKING, Any, Callable, ClassVar, Collection, Dict, \
 from typing import Type as TypingType
 from typing import TypeVar, Union, cast
 
-import dill as pkl
 import imageio
 import matplotlib
 import matplotlib.pyplot as plt
@@ -1858,15 +1857,16 @@ def sample_subsets(universe: Sequence[_T], num_samples: int, min_set_size: int,
         yield sample
 
 
-def create_dataset_filename_str(saving_ground_atoms: bool,
-                                online_learning_cycle: Optional[str] = None) -> Tuple[str, str]:
+def create_dataset_filename_str(
+        saving_ground_atoms: bool,
+        online_learning_cycle: Optional[str] = None) -> Tuple[str, str]:
     """Generate strings to be used for the filename for a dataset file that is
     about to be saved.
 
-    Returns a tuple of strings where the first element is the dataset filename
-    itself and the second is a template string used to generate it. If
-    saving_ground_atoms is True, then we will name the file with a
-    "_ground_atoms" suffix.
+    Returns a tuple of strings where the first element is the dataset
+    filename itself and the second is a template string used to generate
+    it. If saving_ground_atoms is True, then we will name the file with
+    a "_ground_atoms" suffix.
     """
     # Setup the dataset filename for saving/loading GroundAtoms.
     regex = r"(\d+)"

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import abc
 import contextlib
-import dill as pkl
 import functools
 import gc
 import heapq as hq
@@ -23,6 +22,7 @@ from typing import TYPE_CHECKING, Any, Callable, ClassVar, Collection, Dict, \
 from typing import Type as TypingType
 from typing import TypeVar, Union, cast
 
+import dill as pkl
 import imageio
 import matplotlib
 import matplotlib.pyplot as plt
@@ -1886,35 +1886,35 @@ def create_ground_atom_dataset(
     if CFG.load_atoms:
         os.makedirs(CFG.data_dir, exist_ok=True)
         # Check that the dataset file was previously saved.
-        if os.path_exists(dataset_fname):
+        if os.path.exists(dataset_fname):
             # Load the ground atoms dataset.
             with open(dataset_fname, "rb") as f:
                 ground_atom_dataset_trjectories = pkl.load(f)
-            logging.info(f"\n\nLOADED GROUNDED ATOM DATASET")
+            logging.info("\n\nLOADED GROUND ATOM DATASET")
             ground_atom_dataset = []
             for i, traj in enumerate(trajectories):
                 ground_atom_seq = ground_atom_dataset_trjectories[i]
                 ground_atom_dataset.append(
                     (traj, [set(atoms) for atoms in ground_atom_seq]))
         else:
-            raise ValueError(f"Cannot load grounded atoms: {dataset_fname}")
+            raise ValueError(f"Cannot load ground atoms: {dataset_fname}")
     else:
         ground_atom_dataset = []
         for traj in trajectories:
             atoms = [abstract(s, predicates) for s in traj.states]
             ground_atom_dataset.append((traj, atoms))
-        # Save grounded atoms dataset to file.
+        # Save ground atoms dataset to file.
         ground_atom_dataset_to_pkl = []
-        for traj_i, traj in enumerate(ground_atom_dataset):
+        for _, traj in enumerate(ground_atom_dataset):
             trajectory = []
             for i, ground_atom_seq in enumerate(traj[1]):
                 trajectory.append(
-                    set([
+                    {
                         GroundAtom(
                             Predicate(atom.predicate.name,
                                       atom.predicate.types, lambda s, o: None),
                             atom.entities) for atom in ground_atom_seq
-                    ]))
+                    })
             ground_atom_dataset_to_pkl.append(trajectory)
         with open(dataset_fname, "wb") as f:
             pkl.dump(ground_atom_dataset_to_pkl, f)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1905,13 +1905,13 @@ def create_ground_atom_dataset(
             ground_atom_dataset.append((traj, atoms))
         # Save ground atoms dataset to file.
         ground_atom_dataset_to_pkl = []
-        for _, traj in enumerate(ground_atom_dataset):
+        for gt_traj in ground_atom_dataset:
             trajectory = []
-            for i, ground_atom_seq in enumerate(traj[1]):
+            for i, ground_atom_seq in enumerate(gt_traj[1]):
                 trajectory.append({
                     GroundAtom(
                         Predicate(atom.predicate.name, atom.predicate.types,
-                                  lambda s, o: None), atom.entities)
+                                  lambda s, o: False), atom.entities)
                     for atom in ground_atom_seq
                 })
             ground_atom_dataset_to_pkl.append(trajectory)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1899,7 +1899,6 @@ def create_ground_atom_dataset(
     for traj in trajectories:
         atoms = [abstract(s, predicates) for s in traj.states]
         ground_atom_dataset.append((traj, atoms))
-
     return ground_atom_dataset
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1859,7 +1859,7 @@ def sample_subsets(universe: Sequence[_T], num_samples: int, min_set_size: int,
 
 def create_dataset_filename_str(
         saving_ground_atoms: bool,
-        online_learning_cycle: Optional[str] = None) -> Tuple[str, str]:
+        online_learning_cycle: Optional[int] = None) -> Tuple[str, str]:
     """Generate strings to be used for the filename for a dataset file that is
     about to be saved.
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1889,11 +1889,11 @@ def create_ground_atom_dataset(
         if os.path.exists(dataset_fname):
             # Load the ground atoms dataset.
             with open(dataset_fname, "rb") as f:
-                ground_atom_dataset_trjectories = pkl.load(f)
+                ground_atom_dataset_trajectories = pkl.load(f)
             logging.info("\n\nLOADED GROUND ATOM DATASET")
             ground_atom_dataset = []
             for i, traj in enumerate(trajectories):
-                ground_atom_seq = ground_atom_dataset_trjectories[i]
+                ground_atom_seq = ground_atom_dataset_trajectories[i]
                 ground_atom_dataset.append(
                     (traj, [set(atoms) for atoms in ground_atom_seq]))
         else:

--- a/src/utils.py
+++ b/src/utils.py
@@ -1859,11 +1859,13 @@ def sample_subsets(universe: Sequence[_T], num_samples: int, min_set_size: int,
 
 
 def create_dataset_filename_str(saving_ground_atoms: bool,
-                                online_learning_cycle: Optional[str]) -> str:
-    """Generate a string to be used as the filename for a dataset file that is
+                                online_learning_cycle: Optional[str] = None) -> Tuple[str, str]:
+    """Generate strings to be used for the filename for a dataset file that is
     about to be saved.
 
-    If saving_ground_atoms is True, then we will name the file with a
+    Returns a tuple of strings where the first element is the dataset filename
+    itself and the second is a template string used to generate it. If
+    saving_ground_atoms is True, then we will name the file with a
     "_ground_atoms" suffix.
     """
     # Setup the dataset filename for saving/loading GroundAtoms.
@@ -1886,7 +1888,7 @@ def create_dataset_filename_str(saving_ground_atoms: bool,
     dataset_fname = os.path.join(
         CFG.data_dir,
         dataset_fname_template.replace(regex, str(CFG.num_train_tasks)))
-    return dataset_fname
+    return dataset_fname, dataset_fname_template
 
 
 def create_ground_atom_dataset(

--- a/src/utils.py
+++ b/src/utils.py
@@ -1908,13 +1908,12 @@ def create_ground_atom_dataset(
         for _, traj in enumerate(ground_atom_dataset):
             trajectory = []
             for i, ground_atom_seq in enumerate(traj[1]):
-                trajectory.append(
-                    {
-                        GroundAtom(
-                            Predicate(atom.predicate.name,
-                                      atom.predicate.types, lambda s, o: None),
-                            atom.entities) for atom in ground_atom_seq
-                    })
+                trajectory.append({
+                    GroundAtom(
+                        Predicate(atom.predicate.name, atom.predicate.types,
+                                  lambda s, o: None), atom.entities)
+                    for atom in ground_atom_seq
+                })
             ground_atom_dataset_to_pkl.append(trajectory)
         with open(dataset_fname, "wb") as f:
             pkl.dump(ground_atom_dataset_to_pkl, f)

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -180,10 +180,8 @@ def test_saving_and_loading_atoms():
     # environment predicates.
     env = create_new_env("blocks")
     for atoms_seq in ground_atom_dataset_atoms:
-        assert all(
-            atom.predicate in env.predicates
-            for atom_set in atoms_seq for atom in atom_set
-        )
+        assert all(atom.predicate in env.predicates for atom_set in atoms_seq
+                   for atom in atom_set)
     # Next, call NSRT learning with load_atoms=True to test whether loading
     # works.
     approach = _test_approach(env_name="blocks",

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -1,5 +1,8 @@
 """Test cases for the NSRT learning approach."""
 
+import os
+
+import dill as pkl
 import pytest
 
 from predicators.src import utils
@@ -13,7 +16,7 @@ def _test_approach(env_name,
                    approach_name,
                    excluded_predicates="",
                    try_solving=True,
-                   no_loading=False,
+                   no_loading_nsrts=False,
                    check_solution=False,
                    sampler_learner="neural",
                    option_learner="no_learning",
@@ -22,6 +25,7 @@ def _test_approach(env_name,
                    num_train_tasks=1,
                    offline_data_method="demo+replay",
                    solve_exceptions=None,
+                   load_atoms=False,
                    additional_settings=None):
     """Integration test for the given approach."""
     if additional_settings is None:
@@ -45,6 +49,7 @@ def _test_approach(env_name,
         "sampler_learner": sampler_learner,
         "segmenter": segmenter,
         "cover_initial_holding_prob": 0.0,
+        "load_atoms": load_atoms,
         **additional_settings,
     })
     env = create_new_env(env_name)
@@ -87,7 +92,7 @@ def _test_approach(env_name,
             assert task.goal_holds(traj.states[-1])
     # Do not load NSRTs from pickle file. This is because we cannot load
     # NSRTs when they are saved as strings (Necessary for behavior)
-    if no_loading:
+    if no_loading_nsrts:
         return approach
     # We won't check the policy here because we don't want unit tests to
     # have to train very good models, since that would be slow.
@@ -120,7 +125,7 @@ def test_nsrt_learning_approach():
         env_name="blocks",
         approach_name="nsrt_learning",
         try_solving=False,
-        no_loading=True,
+        no_loading_nsrts=True,
         additional_settings={"dump_nsrts_as_strings": True})
     approach = _test_approach(env_name="blocks",
                               approach_name="nsrt_learning",
@@ -152,6 +157,58 @@ def test_nsrt_learning_approach():
                            try_solving=False,
                            sampler_learner="random",
                            strips_learner=strips_learner)
+
+
+def test_saving_and_loading_atoms():
+    """Test learning with saving and loading groudn atoms functionality."""
+    # First, call the approach with load_atoms=False so that the
+    # atoms get saved.
+    approach = _test_approach(
+        env_name="blocks",
+        approach_name="nsrt_learning",
+        try_solving=False,
+        no_loading_nsrts=True,
+        load_atoms=False,
+        additional_settings={"dump_nsrts_as_strings": True})
+    # Next, try to manually load these saved atoms.
+    dataset_fname, _ = utils.create_dataset_filename_str(
+        saving_ground_atoms=True, online_learning_cycle=None)
+    assert os.path.exists(dataset_fname)
+    with open(dataset_fname, "rb") as f:
+        ground_atom_dataset_atoms = pkl.load(f)
+    # Check that each of the loaded atoms is linked to one of the
+    # environment predicates.
+    env = create_new_env("blocks")
+    for atoms_seq in ground_atom_dataset_atoms:
+        assert all(
+            atom.predicate in env.predicates
+            for atom_set in atoms_seq for atom in atom_set
+        )
+    # Next, call NSRT learning with load_atoms=True to test whether loading
+    # works.
+    approach = _test_approach(env_name="blocks",
+                              approach_name="nsrt_learning",
+                              try_solving=False,
+                              no_loading_nsrts=True,
+                              load_atoms=True,
+                              additional_settings={
+                                  "compute_sidelining_objective_value": True,
+                              })
+    # Test assertions to check that learning occurs smoothly after loading.
+    assert "sidelining_obj_num_plans_up_to_n" in approach.metrics
+    assert "sidelining_obj_complexity" in approach.metrics
+    assert approach.metrics["sidelining_obj_num_plans_up_to_n"] == 1.0
+    assert approach.metrics["sidelining_obj_complexity"] == 34.0
+    # Remove the file and test that error is thrown when loading
+    # non-existent file.
+    os.remove(dataset_fname)
+    with pytest.raises(ValueError) as e:
+        approach = _test_approach(env_name="blocks",
+                                  approach_name="nsrt_learning",
+                                  try_solving=False,
+                                  no_loading_nsrts=True,
+                                  load_atoms=True)
+    assert "Cannot load ground atoms" in str(e)
 
 
 def test_unknown_strips_learner():

--- a/tests/nsrt_learning/test_nsrt_learning_main.py
+++ b/tests/nsrt_learning/test_nsrt_learning_main.py
@@ -41,10 +41,12 @@ def test_nsrt_learning_specific_nsrts():
     action1.set_option(option1)
     next_state1 = State({cup0: [0.8], cup1: [0.3], cup2: [1.0]})
     dataset = [LowLevelTrajectory([state1, next_state1], [action1])]
+    ground_atom_dataset = utils.create_ground_atom_dataset(dataset, preds)
     nsrts, _, _ = learn_nsrts_from_data(dataset, [],
                                         preds,
                                         options,
                                         action_space,
+                                        ground_atom_dataset,
                                         sampler_learner="neural")
     assert len(nsrts) == 1
     nsrt = nsrts.pop()
@@ -83,10 +85,12 @@ def test_nsrt_learning_specific_nsrts():
         LowLevelTrajectory([state1, next_state1], [action1]),
         LowLevelTrajectory([state2, next_state2], [action2])
     ]
+    ground_atom_dataset = utils.create_ground_atom_dataset(dataset, preds)
     nsrts, _, _ = learn_nsrts_from_data(dataset, [],
                                         preds,
                                         options,
                                         action_space,
+                                        ground_atom_dataset,
                                         sampler_learner="random")
     assert len(nsrts) == 1
     nsrt = nsrts.pop()
@@ -130,10 +134,12 @@ def test_nsrt_learning_specific_nsrts():
         LowLevelTrajectory([state1, next_state1], [action1]),
         LowLevelTrajectory([state2, next_state2], [action2])
     ]
+    ground_atom_dataset = utils.create_ground_atom_dataset(dataset, preds)
     nsrts, _, _ = learn_nsrts_from_data(dataset, [],
                                         preds,
                                         options,
                                         action_space,
+                                        ground_atom_dataset,
                                         sampler_learner="random")
     assert len(nsrts) == 2
     expected = {
@@ -176,10 +182,12 @@ def test_nsrt_learning_specific_nsrts():
         LowLevelTrajectory([state1, next_state1], [action1]),
         LowLevelTrajectory([state2, next_state2], [action2])
     ]
+    ground_atom_dataset = utils.create_ground_atom_dataset(dataset, preds)
     nsrts, _, _ = learn_nsrts_from_data(dataset, [],
                                         preds,
                                         options,
                                         action_space,
+                                        ground_atom_dataset,
                                         sampler_learner="random")
     assert len(nsrts) == 2
     expected = {
@@ -207,10 +215,12 @@ def test_nsrt_learning_specific_nsrts():
         "min_data_for_nsrt": 3,
         "min_perc_data_for_nsrt": 0,
     })
+    ground_atom_dataset = utils.create_ground_atom_dataset(dataset, preds)
     nsrts, _, _ = learn_nsrts_from_data(dataset, [],
                                         preds,
                                         options,
                                         action_space,
+                                        ground_atom_dataset,
                                         sampler_learner="random")
     assert len(nsrts) == 0
     # Test minimum percent of examples parameter
@@ -218,10 +228,12 @@ def test_nsrt_learning_specific_nsrts():
         "min_data_for_nsrt": 0,
         "min_perc_data_for_nsrt": 90,
     })
+    ground_atom_dataset = utils.create_ground_atom_dataset(dataset, preds)
     nsrts, _, _ = learn_nsrts_from_data(dataset, [],
                                         preds,
                                         options,
                                         action_space,
+                                        ground_atom_dataset,
                                         sampler_learner="random")
     assert len(nsrts) == 0
     # Test max_rejection_sampling_tries = 0
@@ -232,10 +244,12 @@ def test_nsrt_learning_specific_nsrts():
         "sampler_mlp_classifier_max_itr": 1,
         "neural_gaus_regressor_max_itr": 1
     })
+    ground_atom_dataset = utils.create_ground_atom_dataset(dataset, preds)
     nsrts, _, _ = learn_nsrts_from_data(dataset, [],
                                         preds,
                                         options,
                                         action_space,
+                                        ground_atom_dataset,
                                         sampler_learner="neural")
     assert len(nsrts) == 2
     for nsrt in nsrts:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1802,19 +1802,19 @@ def test_create_ground_atom_dataset(load_atoms: bool):
     plate2 = plate_type("plate2")
     states = [
         State({
-            cup1: [0.5],
-            cup2: [0.1],
-            plate1: [1.0],
-            plate2: [1.2]
+            cup1: np.array([0.5]),
+            cup2: np.array([0.1]),
+            plate1: np.array([1.0]),
+            plate2: np.array([1.2])
         }),
         State({
-            cup1: [1.1],
-            cup2: [0.1],
-            plate1: [1.0],
-            plate2: [1.2]
+            cup1: np.array([1.1]),
+            cup2: np.array([0.1]),
+            plate1: np.array([1.0]),
+            plate2: np.array([1.2])
         })
     ]
-    actions = [DummyOption]
+    actions = [Action(np.array([0.0]), DummyOption)]
     dataset = [LowLevelTrajectory(states, actions)]
     ground_atom_dataset = utils.create_ground_atom_dataset(dataset, {on})
     assert len(ground_atom_dataset) == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1781,8 +1781,17 @@ def test_all_possible_ground_atoms():
     assert not utils.abstract(state, {on, not_on})
 
 
-def test_create_ground_atom_dataset():
+@pytest.mark.parametrize("load_atoms", [False, True])
+def test_create_ground_atom_dataset(load_atoms: bool):
     """Tests for create_ground_atom_dataset()."""
+    # First, run the test with load_atoms=False so that the
+    # grounding gets generated and saved. Then, set load_atoms=True
+    # so that the same grounding will be loaded and the same
+    # tests can be run.
+    utils.reset_config({
+        "env": "test_env",
+        "load_atoms": load_atoms,
+    })
     cup_type = Type("cup_type", ["feat1"])
     plate_type = Type("plate_type", ["feat1"])
     on = Predicate("On", [cup_type, plate_type],
@@ -1819,6 +1828,11 @@ def test_create_ground_atom_dataset():
     assert len(ground_atom_dataset[0][1]) == len(states) == 2
     assert ground_atom_dataset[0][1][0] == set()
     assert ground_atom_dataset[0][1][1] == {GroundAtom(on, [cup1, plate1])}
+    if load_atoms:
+        utils.reset_config({"env": "non_existent_env", "load_atoms": True})
+        # Cannot load because env doesn't exist.
+        with pytest.raises(ValueError):
+            utils.create_ground_atom_dataset(dataset, {on})
 
 
 def test_get_reachable_atoms():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1781,16 +1781,10 @@ def test_all_possible_ground_atoms():
     assert not utils.abstract(state, {on, not_on})
 
 
-@pytest.mark.parametrize("load_atoms", [False, True])
-def test_create_ground_atom_dataset(load_atoms: bool):
+def test_create_ground_atom_dataset():
     """Tests for create_ground_atom_dataset()."""
-    # First, run the test with load_atoms=False so that the
-    # grounding gets generated and saved. Then, set load_atoms=True
-    # so that the same grounding will be loaded and the same
-    # tests can be run.
     utils.reset_config({
         "env": "test_env",
-        "load_atoms": load_atoms,
     })
     cup_type = Type("cup_type", ["feat1"])
     plate_type = Type("plate_type", ["feat1"])
@@ -1828,11 +1822,6 @@ def test_create_ground_atom_dataset(load_atoms: bool):
     assert len(ground_atom_dataset[0][1]) == len(states) == 2
     assert ground_atom_dataset[0][1][0] == set()
     assert ground_atom_dataset[0][1][1] == {GroundAtom(on, [cup1, plate1])}
-    if load_atoms:
-        utils.reset_config({"env": "non_existent_env", "load_atoms": True})
-        # Cannot load because env doesn't exist.
-        with pytest.raises(ValueError):
-            utils.create_ground_atom_dataset(dataset, {on})
 
 
 def test_get_reachable_atoms():


### PR DESCRIPTION
This PR allows us to save and load GroundAtomTrajectories with the `--load_atoms` flag. This functionality is extremely useful for BEHAVIOR, where running all the classifiers is slow even if we load trajectory data. 