### PR TITLE
handle cases where oracle learner sees no data for nsrts

### DIFF
--- a/src/ground_truth_nsrts.py
+++ b/src/ground_truth_nsrts.py
@@ -879,11 +879,7 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
     openlid_nsrt = NSRT("OpenLid",
                         parameters, preconditions, add_effects, delete_effects,
                         set(), option, option_vars, null_sampler)
-    # In the case where painting_lid_open_prob is 1.0, the lid is always open,
-    # so we don't need the NSRT for opening it. Without this line, when using
-    # strips_learner oracle, there would be a crash in sampler learning.
-    if CFG.painting_lid_open_prob < 1:
-        nsrts.add(openlid_nsrt)
+    nsrts.add(openlid_nsrt)
 
     # PlaceOnTable
     obj = Variable("?obj", obj_type)
@@ -951,11 +947,7 @@ def _get_painting_gt_nsrts() -> Set[NSRT]:
     placeontable_nsrt = NSRT("PlaceOnTable", parameters, preconditions,
                              add_effects, delete_effects, set(), option,
                              option_vars, placeontable_sampler)
-    # In the case where painting_initial_holding_prob is 0.0, we never need to
-    # place on the table. Without this line, when using strips_learner oracle,
-    # there would be a crash in sampler learning.
-    if CFG.painting_initial_holding_prob > 0:
-        nsrts.add(placeontable_nsrt)
+    nsrts.add(placeontable_nsrt)
 
     if CFG.env == "repeated_nextto_painting":
 

--- a/src/nsrt_learning/nsrt_learning_main.py
+++ b/src/nsrt_learning/nsrt_learning_main.py
@@ -106,7 +106,7 @@ def _learn_pnad_options(pnads: List[PartialNSRTAndDatastore],
     # same known parameterized option, or all actions should have no option.
     known_option_pnads, unknown_option_pnads = [], []
     for pnad in pnads:
-        if not pnad.datastore:
+        if not pnad.datastore:  # pragma: no cover
             raise Exception("No data found for learning an option.")
         example_segment, _ = pnad.datastore[0]
         example_action = example_segment.actions[0]

--- a/src/nsrt_learning/sampler_learning.py
+++ b/src/nsrt_learning/sampler_learning.py
@@ -48,9 +48,9 @@ def _extract_oracle_samplers(
     """Extract the oracle samplers matching the given STRIPSOperator objects
     from the ground truth operators defined in approaches/oracle_approach.py.
 
-    We require every ground truth operator to match one of the given
-    operators, but some of the given operators can match no ground truth
-    operator, in which case such an operator is given a random sampler.
+    If a given operator does not match any ground truth operator, it is
+    given a random sampler. If a ground truth operator has no given
+    operator match, a warning is generated.
     """
     env = get_or_create_env(CFG.env)
     # We don't need to match ground truth NSRTs with no continuous
@@ -88,7 +88,7 @@ def _extract_oracle_samplers(
                 samplers[idx] = _make_reordered_sampler(nsrt, op, sub)
                 break
         else:
-            raise Exception("Can't use oracle samplers, no match for "
+            logging.warning("Oracle sampler learning found no match for "
                             f"ground truth NSRT: {nsrt}")
     return samplers
 

--- a/src/nsrt_learning/strips_learning/oracle_learner.py
+++ b/src/nsrt_learning/strips_learning/oracle_learner.py
@@ -1,5 +1,6 @@
 """Oracle for STRIPS learning."""
 
+import logging
 from typing import List
 
 from predicators.src.envs import get_or_create_env
@@ -27,7 +28,18 @@ class OracleSTRIPSLearner(BaseSTRIPSLearner):
             pnads.append(
                 PartialNSRTAndDatastore(nsrt.op, datastore, option_spec))
         self._recompute_datastores_from_segments(pnads)
-        return pnads
+        # Filter out any pnad that has an empty datastore. This can occur when
+        # using non-standard settings with environments that cause certain
+        # operators to be unnecessary. For example, in painting, when using
+        # --painting_goal_receptacles box, the operator for picking from
+        # the side becomes unnecessary (and no demo data will cover it).
+        nontrivial_pnads = []
+        for pnad in pnads:
+            if not pnad.datastore:
+                logging.warning(f"Discarding PNAD with no data: {pnad}")
+                continue
+            nontrivial_pnads.append(pnad)
+        return nontrivial_pnads
 
     @classmethod
     def get_name(cls) -> str:

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -294,6 +294,14 @@ def test_oracle_samplers():
                    segmenter="atom_changes",
                    check_solution=True,
                    num_train_tasks=3)
+    # In painting, we learn operators that are different from the oracle ones.
+    # The expected behavior is that the learned operators will have random
+    # samplers, so we don't expected planning to necessarily work.
+    _test_approach(env_name="painting",
+                   approach_name="nsrt_learning",
+                   sampler_learner="oracle",
+                   try_solving=False,
+                   num_train_tasks=3)
 
 
 def test_degenerate_mlp_sampler_learning():

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -294,15 +294,6 @@ def test_oracle_samplers():
                    segmenter="atom_changes",
                    check_solution=True,
                    num_train_tasks=3)
-    with pytest.raises(Exception) as e:
-        # In painting, we learn operators that are different from the
-        # oracle ones, so oracle sampler learning is not possible.
-        _test_approach(env_name="painting",
-                       approach_name="nsrt_learning",
-                       sampler_learner="oracle",
-                       check_solution=True,
-                       num_train_tasks=3)
-    assert "no match for ground truth NSRT" in str(e)
 
 
 def test_degenerate_mlp_sampler_learning():

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -379,18 +379,13 @@ def test_oracle_strips_and_segmenter_learning():
         "stick_button_num_buttons_test": [1],
         "segmenter": "oracle",
     }
-    # The expected behavior is that segmentation and STRIPS learning will go
-    # through, but then because there is such a limited number of demos, we
-    # will not see data for all operators, which will lead to a crash
-    # during option learning. This test still covers an important case, which
-    # is recomputing datastores in STRIPS learning when options are unknown.
-    with pytest.raises(Exception) as e:
-        _test_approach(env_name="stick_button",
-                       approach_name="nsrt_learning",
-                       strips_learner="oracle",
-                       option_learner="direct_bc",
-                       offline_data_method="demo",
-                       num_train_tasks=1,
-                       try_solving=False,
-                       additional_settings=additional_settings)
-    assert "No data found for learning an option." in str(e)
+    # This test still covers recomputing datastores in STRIPS learning when
+    # options are unknown.
+    _test_approach(env_name="stick_button",
+                   approach_name="nsrt_learning",
+                   strips_learner="oracle",
+                   option_learner="direct_bc",
+                   offline_data_method="demo",
+                   num_train_tasks=1,
+                   try_solving=False,
+                   additional_settings=additional_settings)

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -106,6 +106,11 @@ EXTRA_ARGS_ORACLE_APPROACH["cluttered_table_place"] = [
         "cluttered_table_num_cans_test": 3
     },
 ]
+EXTRA_ARGS_ORACLE_APPROACH["painting"] = [
+    {
+        "painting_initial_holding_prob": 1.0,
+    },
+]
 EXTRA_ARGS_ORACLE_APPROACH["repeated_nextto_painting"] = [
     {
         "rnt_painting_num_objs_train": [1, 2],


### PR DESCRIPTION
before this PR, this command would crash:
```
python src/main.py --approach nsrt_learning --seed 0 --env painting --strips_learner oracle --sampler_learner oracle --num_train_tasks 10 --painting_lid_open_prob 1.0 --painting_goal_receptacles shelf
```
and in general, if we are doing oracle strips and sampler learning, and we add settings that lead to some NSRTs having no data, we will now raise a warning instead of crashing.

this is meant to be a more general solution to the problem that I papered over in PRs #1057 and #1065 , so those changes are reverted.
