### PR TITLE
minor optimization for pg3

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1839,13 +1839,23 @@ def all_possible_ground_atoms(state: State,
     return sorted(ground_atoms)
 
 
-def all_ground_ldl_rules(
-        rule: LDLRule,
-        objects: Collection[Object]) -> Iterator[_GroundLDLRule]:
+def all_ground_ldl_rules(rule: LDLRule,
+                         objects: Collection[Object]) -> List[_GroundLDLRule]:
     """Get all possible groundings of the given rule with the given objects."""
+    return _cached_all_ground_ldl_rules(rule, frozenset(objects))
+
+
+@functools.lru_cache(maxsize=None)
+def _cached_all_ground_ldl_rules(
+        rule: LDLRule,
+        frozen_objects: FrozenSet[Object]) -> List[_GroundLDLRule]:
+    """Helper for all_ground_ldl_rules() that caches the outputs."""
+    ground_rules = []
     types = [p.type for p in rule.parameters]
-    for choice in get_object_combinations(objects, types):
-        yield rule.ground(tuple(choice))
+    for choice in get_object_combinations(frozen_objects, types):
+        ground_rule = rule.ground(tuple(choice))
+        ground_rules.append(ground_rule)
+    return ground_rules
 
 
 _T = TypeVar("_T")  # element of a set

--- a/tests/approaches/test_online_pg3_approach.py
+++ b/tests/approaches/test_online_pg3_approach.py
@@ -28,9 +28,8 @@ def test_online_pg3_approach():
         "num_test_tasks": 3,
         "explorer": "random_options",
         "pg3_heuristic": "demo_plan_comparison",  # faster for tests
-        "pg3_search_method": "gbfs",
-        "pg3_gbfs_max_expansions": 1,
-        "horizon": 1,
+        "pg3_search_method": "hill_climbing",
+        "pg3_hc_enforced_depth": 0,
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()

--- a/tests/approaches/test_online_pg3_approach.py
+++ b/tests/approaches/test_online_pg3_approach.py
@@ -28,8 +28,9 @@ def test_online_pg3_approach():
         "num_test_tasks": 3,
         "explorer": "random_options",
         "pg3_heuristic": "demo_plan_comparison",  # faster for tests
-        "pg3_search_method": "hill_climbing",
-        "pg3_hc_enforced_depth": 0,
+        "pg3_search_method": "gbfs",
+        "pg3_gbfs_max_expansions": 1,
+        "horizon": 1,
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()


### PR DESCRIPTION
from speed profiling, I saw that `all_ground_ldl_rules` can be a bottleneck for pg3/4 learning. adding this caching seems to shave off some time.