### PR TITLE
fix rare crash in open loop llm approach

### DIFF
--- a/src/approaches/open_loop_llm_approach.py
+++ b/src/approaches/open_loop_llm_approach.py
@@ -130,7 +130,8 @@ class OpenLoopLLMApproach(NSRTMetacontrollerApproach):
             # Skip empty option strs.
             if not option_str:
                 continue
-            if option_name not in option_name_to_option.keys():
+            if option_name not in option_name_to_option.keys() or \
+                "(" not in option_str:
                 logging.info(
                     f"Line {option_str} output by LLM doesn't "
                     "contain a valid option name. Terminating option plan "


### PR DESCRIPTION
this is the crash that I'm trying to fix:
```
Traceback (most recent call last):
  File "src/main.py", line 399, in <module>
    main()
  File "src/main.py", line 114, in main
    _run_pipeline(env, approach, stripped_train_tasks, offline_dataset)
  File "src/main.py", line 145, in _run_pipeline
    results = _run_testing(env, approach)
  File "src/main.py", line 304, in _run_testing
    traj, execution_metrics = utils.run_policy(
  File "/home/ubuntu/predicators/src/utils.py", line 942, in run_policy
    raise e
  File "/home/ubuntu/predicators/src/utils.py", line 923, in run_policy
    act = policy(state)
  File "/home/ubuntu/predicators/src/approaches/base_approach.py", line 64, in _policy
    act = pi(state)
  File "/home/ubuntu/predicators/src/approaches/nsrt_metacontroller_approach.py", line 41, in _policy
    ground_nsrt = self._predict(state, atoms, task.goal, memory)
  File "/home/ubuntu/predicators/src/approaches/open_loop_llm_approach.py", line 80, in _predict
    ground_nsrt_plan = self._process_single_prediction(
  File "/home/ubuntu/predicators/src/approaches/open_loop_llm_approach.py", line 93, in _process_single_prediction
    option_plan = self._llm_prediction_to_option_plan(
  File "/home/ubuntu/predicators/src/approaches/open_loop_llm_approach.py", line 142, in _llm_prediction_to_option_plan
    typed_objects_str_list = option_str_stripped.split('(')[1].strip(
IndexError: list index out of range
```