### PR TITLE
[draft] remove explicit scipy dependency

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -25,6 +25,9 @@ ignore_missing_imports = True
 [mypy-matplotlib.*]
 ignore_missing_imports = True
 
+[mypy-scipy.*]
+ignore_missing_imports = True
+
 [mypy-bddl.*]
 ignore_missing_imports = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -25,9 +25,6 @@ ignore_missing_imports = True
 [mypy-matplotlib.*]
 ignore_missing_imports = True
 
-[mypy-scipy.*]
-ignore_missing_imports = True
-
 [mypy-bddl.*]
 ignore_missing_imports = True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ imageio
 imageio-ffmpeg
 pandas
 torch
-scipy
 tabulate
 dill
 pyperplan

--- a/src/envs/behavior_options.py
+++ b/src/envs/behavior_options.py
@@ -5,7 +5,6 @@ import logging
 from typing import Callable, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
-import scipy
 from numpy.random._generator import Generator
 
 from predicators.src.structs import Array, State
@@ -28,6 +27,7 @@ try:
     from igibson.utils import sampling_utils
     from igibson.utils.behavior_robot_planning_utils import \
         plan_base_motion_br, plan_hand_motion_br
+    import scipy
 
 except (ImportError, ModuleNotFoundError) as e:
     pass

--- a/src/envs/behavior_options.py
+++ b/src/envs/behavior_options.py
@@ -12,6 +12,7 @@ from predicators.src.utils import get_aabb_volume, get_closest_point_on_aabb
 
 try:
     import pybullet as p
+    import scipy
     from igibson import object_states
     from igibson.envs.behavior_env import \
         BehaviorEnv  # pylint: disable=unused-import
@@ -27,7 +28,6 @@ try:
     from igibson.utils import sampling_utils
     from igibson.utils.behavior_robot_planning_utils import \
         plan_base_motion_br, plan_hand_motion_br
-    import scipy
 
 except (ImportError, ModuleNotFoundError) as e:
     pass


### PR DESCRIPTION
[edit: this PR is obsolete because sklearn has scipy as a dependency anyway]

This PR gives scipy the igibson/bddl treatment: if it's not imported, no problem! If it is, great, you need it for BEHAVIOR!

Besides `behavior_options.py`, there is one more usage of scipy in `scripts/plotting/create_interactive_predicate_learning_plots.py`: `from scipy import interpolate`. I'm fine to leave this as is. Whoever runs that script would need to install scipy, which isn't a big deal since most users aren't running that script.

closes #1083 