### PR TITLE
purge `initial_predicates` from planning.py

### DIFF
--- a/src/planning.py
+++ b/src/planning.py
@@ -42,7 +42,7 @@ class _Node:
 def sesame_plan(task: Task,
                 option_model: _OptionModelBase,
                 nsrts: Set[NSRT],
-                initial_predicates: Set[Predicate],
+                predicates: Set[Predicate],
                 types: Set[Type],
                 timeout: float,
                 seed: int,
@@ -59,12 +59,6 @@ def sesame_plan(task: Task,
     run of the planner. Uses the SeSamE strategy: SEarch-and-SAMple
     planning, then Execution.
     """
-    # Note: the types that would be extracted from the NSRTs here may not
-    # include all the environment's types, so it's better to use the
-    # types that are passed in as an argument instead.
-    nsrt_preds, _ = utils.extract_preds_and_types(nsrts)
-    # Ensure that initial predicates are always included.
-    predicates = initial_predicates | set(nsrt_preds.values())
     init_atoms = utils.abstract(task.init, predicates)
     objects = list(task.init)
     start_time = time.time()

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -378,7 +378,7 @@ def test_planning_determinism():
             task1,
             option_model,
             [sleep_nsrt, cry_nsrt],
-            set(),
+            {asleep, cried},
             {robot_type},
             10,  # timeout
             123,  # seed
@@ -392,7 +392,7 @@ def test_planning_determinism():
             task1,
             option_model,
             [cry_nsrt, sleep_nsrt],
-            set(),
+            {asleep, cried},
             {robot_type},
             10,  # timeout
             123,  # seed
@@ -406,7 +406,7 @@ def test_planning_determinism():
             task2,
             option_model,
             [sleep_nsrt, cry_nsrt],
-            set(),
+            {asleep, cried},
             {robot_type},
             10,  # timeout
             123,  # seed
@@ -420,7 +420,7 @@ def test_planning_determinism():
             task2,
             option_model,
             [cry_nsrt, sleep_nsrt],
-            set(),
+            {asleep, cried},
             {robot_type},
             10,  # timeout
             123,  # seed


### PR DESCRIPTION
maybe we should run a nightly after this? @tomsilver 