### PR TITLE
Enables FD to use ignore effects

### DIFF
--- a/predicators/planning.py
+++ b/predicators/planning.py
@@ -737,12 +737,8 @@ def _sesame_plan_with_fast_downward(
         "Please follow the instructions in the docstring of this method!"
     fd_exec_path = os.environ["FD_EXEC_PATH"]
     exec_str = os.path.join(fd_exec_path, "fast-downward.py")
-    cmd_str = (f"{timeout_cmd} {timeout} {exec_str} "
-               f"--sas-file {sas_file} {dom_file} {prob_file}"
-               ' --search "astar(cg())"')
-    print(cmd_str)
-    import ipdb
-    ipdb.set_trace()
+    cmd_str = (f"{timeout_cmd} {timeout} {exec_str} {alias_flag} "
+               f"--sas-file {sas_file} {dom_file} {prob_file}")
     output = subprocess.getoutput(cmd_str)
     cleanup_cmd_str = f"{exec_str} --cleanup"
     subprocess.getoutput(cleanup_cmd_str)

--- a/predicators/planning.py
+++ b/predicators/planning.py
@@ -737,8 +737,12 @@ def _sesame_plan_with_fast_downward(
         "Please follow the instructions in the docstring of this method!"
     fd_exec_path = os.environ["FD_EXEC_PATH"]
     exec_str = os.path.join(fd_exec_path, "fast-downward.py")
-    cmd_str = (f"{timeout_cmd} {timeout} {exec_str} {alias_flag} "
-               f"--sas-file {sas_file} {dom_file} {prob_file}")
+    cmd_str = (f"{timeout_cmd} {timeout} {exec_str} "
+               f"--sas-file {sas_file} {dom_file} {prob_file}"
+               ' --search "astar(cg())"')
+    print(cmd_str)
+    import ipdb
+    ipdb.set_trace()
     output = subprocess.getoutput(cmd_str)
     cleanup_cmd_str = f"{exec_str} --cleanup"
     subprocess.getoutput(cleanup_cmd_str)

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -601,6 +601,17 @@ class STRIPSOperator:
             effects_str += "\n        ".join(
                 f"(not {atom.pddl_str()})"
                 for atom in sorted(self.delete_effects))
+        if self.ignore_effects:
+            if len(effects_str) != 0:
+                effects_str += "\n        "
+            for pred in sorted(self.ignore_effects):
+                pred_types_str = " ".join(f"?x{i} - {t.name}"
+                                          for i, t in enumerate(pred.types))
+                pred_eff_variables_str = " ".join(f"?x{i}"
+                                                  for i in range(pred.arity))
+                effects_str += f"(forall ({pred_types_str})" +\
+                    f"(not ({pred.name} {pred_eff_variables_str})))"
+                effects_str += "\n        "
         return f"""(:action {self.name}
     :parameters ({params_str})
     :precondition (and {preconds_str})

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -610,7 +610,7 @@ class STRIPSOperator:
                 pred_eff_variables_str = " ".join(f"?x{i}"
                                                   for i in range(pred.arity))
                 effects_str += f"(forall ({pred_types_str})" +\
-                    f"(not ({pred.name} {pred_eff_variables_str})))"
+                    f" (not ({pred.name} {pred_eff_variables_str})))"
                 effects_str += "\n        "
         return f"""(:action {self.name}
     :parameters ({params_str})

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -11,8 +11,8 @@ from predicators import utils
 from predicators.approaches import ApproachFailure, ApproachTimeout
 from predicators.approaches.oracle_approach import OracleApproach
 from predicators.envs.cover import CoverEnv
-from predicators.envs. repeated_nextto import RepeatedNextToSingleOptionEnv
 from predicators.envs.painting import PaintingEnv
+from predicators.envs.repeated_nextto import RepeatedNextToSingleOptionEnv
 from predicators.ground_truth_nsrts import get_gt_nsrts
 from predicators.option_model import _OptionModelBase, _OracleOptionModel, \
     create_option_model

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -61,38 +61,7 @@ def test_sesame_plan(sesame_check_expected_atoms, sesame_grounder,
         assert metrics["num_nodes_created"] >= metrics["num_nodes_expanded"]
     else:
         assert "Unrecognized sesame_grounder" in str(e)
-    # Test on the repeated_nextto_single_option env, which requires ignore
-    # effects.
-    utils.reset_config({
-        "env": "repeated_nextto_single_option",
-        "sesame_check_expected_atoms": sesame_check_expected_atoms,
-        "sesame_grounder": sesame_grounder,
-        "num_test_tasks": 1,
-        "sesame_task_planner": "astar",
-    })
-    env = RepeatedNextToSingleOptionEnv()
-    nsrts = get_gt_nsrts(env.predicates, env.options)
-    task = env.get_test_tasks()[0]
-    option_model = create_option_model(CFG.option_model_name)
-    with expectation as e:
-        plan, metrics = sesame_plan(
-            task,
-            option_model,
-            nsrts,
-            env.predicates,
-            env.types,
-            1,  # timeout
-            123,  # seed
-            CFG.sesame_task_planning_heuristic,
-            CFG.sesame_max_skeletons_optimized,
-            max_horizon=CFG.horizon,
-        )
-    if e is None:
-        assert len(plan) == 2
-        assert all(isinstance(act, _Option) for act in plan)
-        assert metrics["num_nodes_created"] >= metrics["num_nodes_expanded"]
-    else:
-        assert "Unrecognized sesame_grounder" in str(e)
+
 
 def test_task_plan():
     """Tests for task_plan()."""
@@ -627,12 +596,14 @@ def test_sesame_plan_fast_downward():
     """
     for sesame_task_planner in ("fdopt", "fdsat", "not a real task planner"):
         utils.reset_config({
-            "env": "painting",
+            "env": "repeated_nextto_single_option",
             "num_test_tasks": 1,
             "painting_lid_open_prob": 1.0,
             "sesame_task_planner": sesame_task_planner,
         })
-        env = PaintingEnv()
+        # Test on the repeated_nextto_single_option env, which requires ignore
+        # effects.
+        env = RepeatedNextToSingleOptionEnv()
         nsrts = get_gt_nsrts(env.predicates, env.options)
         task = env.get_test_tasks()[0]
         option_model = create_option_model(CFG.option_model_name)

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -11,6 +11,7 @@ from predicators import utils
 from predicators.approaches import ApproachFailure, ApproachTimeout
 from predicators.approaches.oracle_approach import OracleApproach
 from predicators.envs.cover import CoverEnv
+from predicators.envs. repeated_nextto import RepeatedNextToSingleOptionEnv
 from predicators.envs.painting import PaintingEnv
 from predicators.ground_truth_nsrts import get_gt_nsrts
 from predicators.option_model import _OptionModelBase, _OracleOptionModel, \
@@ -60,7 +61,38 @@ def test_sesame_plan(sesame_check_expected_atoms, sesame_grounder,
         assert metrics["num_nodes_created"] >= metrics["num_nodes_expanded"]
     else:
         assert "Unrecognized sesame_grounder" in str(e)
-
+    # Test on the repeated_nextto_single_option env, which requires ignore
+    # effects.
+    utils.reset_config({
+        "env": "repeated_nextto_single_option",
+        "sesame_check_expected_atoms": sesame_check_expected_atoms,
+        "sesame_grounder": sesame_grounder,
+        "num_test_tasks": 1,
+        "sesame_task_planner": "astar",
+    })
+    env = RepeatedNextToSingleOptionEnv()
+    nsrts = get_gt_nsrts(env.predicates, env.options)
+    task = env.get_test_tasks()[0]
+    option_model = create_option_model(CFG.option_model_name)
+    with expectation as e:
+        plan, metrics = sesame_plan(
+            task,
+            option_model,
+            nsrts,
+            env.predicates,
+            env.types,
+            1,  # timeout
+            123,  # seed
+            CFG.sesame_task_planning_heuristic,
+            CFG.sesame_max_skeletons_optimized,
+            max_horizon=CFG.horizon,
+        )
+    if e is None:
+        assert len(plan) == 2
+        assert all(isinstance(act, _Option) for act in plan)
+        assert metrics["num_nodes_created"] >= metrics["num_nodes_expanded"]
+    else:
+        assert "Unrecognized sesame_grounder" in str(e)
 
 def test_task_plan():
     """Tests for task_plan()."""

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -504,6 +504,15 @@ def test_operators_and_nsrts(state):
     Add Effects: [On(?cup:cup_type, ?plate:plate_type)]
     Delete Effects: [NotOn(?cup:cup_type, ?plate:plate_type)]
     Ignore Effects: [On]"""
+    assert strips_operator.pddl_str() == \
+        """(:action Pick
+    :parameters (?cup - cup_type ?plate - plate_type)
+    :precondition (and (NotOn ?cup ?plate))
+    :effect (and (On ?cup ?plate)
+        (not (NotOn ?cup ?plate))
+        (forall (?x0 - cup_type ?x1 - plate_type)(not (On ?x0 ?x1)))
+        )
+  )"""
     assert strips_operator.get_complexity() == 4.0  # 2^2
     assert isinstance(hash(strips_operator), int)
     strips_operator2 = STRIPSOperator("Pick", parameters, preconditions,

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -510,7 +510,7 @@ def test_operators_and_nsrts(state):
     :precondition (and (NotOn ?cup ?plate))
     :effect (and (On ?cup ?plate)
         (not (NotOn ?cup ?plate))
-        (forall (?x0 - cup_type ?x1 - plate_type)(not (On ?x0 ?x1)))
+        (forall (?x0 - cup_type ?x1 - plate_type) (not (On ?x0 ?x1)))
         )
   )"""
     assert strips_operator.get_complexity() == 4.0  # 2^2


### PR DESCRIPTION
Previously, FD had no knowledge of operators' ignore effects. As a result, it wasn't able to solve even simple domains (such as `repeated_nextto_single_option`) where ignore effects are necessary.

This PR modifies the PDDL file creation code to parse ignore effects into universally-quantified delete effects that FD can operate on.

You can try this out locally by running the following command before and after this PR:
```
python predicators/main.py --env repeated_nextto_single_option --approach oracle --num_test_tasks 50 --seed 0 --sesame_task_planner fdopt
```

Before this PR, the above would result in slow execution and a large number of failed tasks. Afterwards, FD should be able to solve all 50 tasks.