### PR TITLE
add optional log file flag

### DIFF
--- a/predicators/args.py
+++ b/predicators/args.py
@@ -33,6 +33,7 @@ def create_arg_parser(env_required: bool = True,
     parser.add_argument("--skip_until_cycle", default=-1, type=int)
     parser.add_argument("--experiment_id", default="", type=str)
     parser.add_argument("--load_experiment_id", default="", type=str)
+    parser.add_argument("--log_file", default="", type=str)
     parser.add_argument('--debug',
                         action="store_const",
                         dest="loglevel",

--- a/predicators/main.py
+++ b/predicators/main.py
@@ -65,9 +65,14 @@ def main() -> None:
     utils.update_config(args)
     str_args = " ".join(sys.argv)
     # Log to stderr.
+    handlers: List[logging.Handler] = [logging.StreamHandler()]
+    if CFG.log_file:
+        handlers.append(logging.FileHandler(CFG.log_file, mode='w'))
     logging.basicConfig(level=CFG.loglevel,
                         format="%(message)s",
-                        handlers=[logging.StreamHandler()])
+                        handlers=handlers)
+    if CFG.log_file:
+        logging.info(f"Logging to {CFG.log_file}")
     logging.info(f"Running command: python {str_args}")
     logging.info("Full config:")
     logging.info(CFG)
@@ -378,4 +383,9 @@ def _save_test_results(results: Metrics,
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main()
+    # Write out the exception to the log file.
+    try:
+        main()
+    except Exception as _err:  # pylint: disable=broad-except
+        logging.exception("main.py crashed")
+        raise _err

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,7 @@
 import os
 import shutil
 import sys
+import tempfile
 from typing import Callable
 
 import pytest
@@ -110,12 +111,14 @@ def test_main():
         video_dir, "--results_dir", results_dir
     ]
     main()
-    # Test making videos of failures.
+    # Test making videos of failures and local logging.
+    temp_log_file = tempfile.NamedTemporaryFile(delete=False).name
     sys.argv = [
         "dummy", "--env", "painting", "--approach", "oracle", "--seed", "123",
         "--num_test_tasks", "1", "--video_dir", video_dir, "--results_dir",
         results_dir, "--sesame_max_skeletons_optimized", "1",
-        "--painting_lid_open_prob", "0.0", "--make_failure_videos"
+        "--painting_lid_open_prob", "0.0", "--make_failure_videos",
+        "--log_file", temp_log_file
     ]
     main()
     shutil.rmtree(video_dir)


### PR DESCRIPTION
usage example:

```python predicators/main.py --env cover --approach oracle --seed 0 --log_file ~/Desktop/logs_testing/test2.log```

I also verified that when the script crashes, the exception is logged.