### PR TITLE
move argparse in analyze script

### DIFF
--- a/scripts/analyze_results_directory.py
+++ b/scripts/analyze_results_directory.py
@@ -10,10 +10,6 @@ import pandas as pd
 
 from predicators.settings import CFG
 
-parser = argparse.ArgumentParser()
-parser.add_argument("--sidelining", action="store_true")
-args = parser.parse_args()
-
 GROUPS = [
     # "ENV",
     # "APPROACH",
@@ -48,14 +44,6 @@ COLUMN_NAMES_AND_KEYS = [
     # ("NUM_ONLINE_TRANSITIONS", "num_online_transitions"),
     # ("QUERY_COST", "query_cost"),
 ]
-
-if args.sidelining:
-    COLUMN_NAMES_AND_KEYS.remove(("AVG_NUM_PREDS", "avg_num_preds"))
-    COLUMN_NAMES_AND_KEYS.append(
-        ("SO_NUM_PLANS_UP_TO_N",
-         "offline_learning_sidelining_obj_num_plans_up_to_n"))
-    COLUMN_NAMES_AND_KEYS.append(
-        ("SO_COMPLEXITY", "offline_learning_sidelining_obj_complexity"))
 
 
 def pd_create_equal_selector(
@@ -181,4 +169,16 @@ def _main() -> None:
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sidelining", action="store_true")
+    args = parser.parse_args()
+
+    if args.sidelining:
+        COLUMN_NAMES_AND_KEYS.remove(("AVG_NUM_PREDS", "avg_num_preds"))
+        COLUMN_NAMES_AND_KEYS.append(
+            ("SO_NUM_PLANS_UP_TO_N",
+             "offline_learning_sidelining_obj_num_plans_up_to_n"))
+        COLUMN_NAMES_AND_KEYS.append(
+            ("SO_COMPLEXITY", "offline_learning_sidelining_obj_complexity"))
+
     _main()


### PR DESCRIPTION
this was leading to a tricky bug where

```
python scripts/plotting/create_classification_plots.py --env cover --approach interactive_learning --seed 123 --excluded_predicates Covers,Holding --experiment_id cover-main --num_online_learning_cycles 100 --load_approach --load_data
```

was leading to

```
usage: create_classification_plots.py [-h] [--sidelining]
create_classification_plots.py: error: unrecognized arguments: --env cover --approach interactive_learning --seed 123 --excluded_predicates Covers,Holding --experiment_id cover-main --num_online_learning_cycles 100 --load_approach --load_data
```

and it was because the argparse was getting created when the analysis script was getting imported, rather than inside of create_classification_plots.py itself.

@amburger66 (who found the bug) -- can you verify that this fixes things on your end?