### PR TITLE
fix supercloud GPU command string

### DIFF
--- a/scripts/supercloud/submit_supercloud_job.py
+++ b/scripts/supercloud/submit_supercloud_job.py
@@ -47,9 +47,9 @@ def submit_supercloud_job(job_name: str,
     else:
         cmd += "--partition=xeon-p8"
     cmd += ("--nodes=1 --exclusive "
-           f"--job-name={job_name} "
-           f"--array={start_seed}-{start_seed+num_seeds-1} "
-           f"-o {logfile_pattern} {temp_run_file}")
+            f"--job-name={job_name} "
+            f"--array={start_seed}-{start_seed+num_seeds-1} "
+            f"-o {logfile_pattern} {temp_run_file}")
     print(f"Running command: {cmd}")
     output = subprocess.getoutput(cmd)
     if "command not found" in output:

--- a/scripts/supercloud/submit_supercloud_job.py
+++ b/scripts/supercloud/submit_supercloud_job.py
@@ -41,12 +41,15 @@ def submit_supercloud_job(job_name: str,
     assert not os.path.exists(temp_run_file)
     with open(temp_run_file, "w", encoding="utf-8") as f:
         f.write(mystr)
-    cmd = ("sbatch --time=99:00:00 --partition=xeon-p8 "
-           f"--nodes=1 --exclusive --job-name={job_name} "
+    cmd = "sbatch --time=99:00:00 "
+    if use_gpu:
+        cmd += "--partition=xeon-g6-volta --gres=gpu:volta:1 "
+    else:
+        cmd += "--partition=xeon-p8"
+    cmd += ("--nodes=1 --exclusive "
+           f"--job-name={job_name} "
            f"--array={start_seed}-{start_seed+num_seeds-1} "
            f"-o {logfile_pattern} {temp_run_file}")
-    if use_gpu:
-        cmd += " --gres=gpu:volta:1"
     print(f"Running command: {cmd}")
     output = subprocess.getoutput(cmd)
     if "command not found" in output:


### PR DESCRIPTION
When requesting a GPU on supercloud, the partition needs to be `--partition=xeon-g6-volta` and not `--partition=xeon-p8`. Also, the `--gres` argument cannot appear at the end of the string, but rather must appear before the `sh` filename.

Tested and verified this works on launching a BEHAVIOR experiment (in `predicators_behavior` repo).