### PR TITLE
make rgb color part of block state

### DIFF
--- a/predicators/envs/blocks.py
+++ b/predicators/envs/blocks.py
@@ -250,6 +250,7 @@ class BlocksEnv(BaseEnv):
             x = state.get(block, "pose_x")
             y = state.get(block, "pose_y")
             z = state.get(block, "pose_z")
+            # RGB values are between 0 and 1.
             color_r = state.get(block, "color_r")
             color_g = state.get(block, "color_g")
             color_b = state.get(block, "color_b")

--- a/predicators/envs/blocks.py
+++ b/predicators/envs/blocks.py
@@ -50,8 +50,10 @@ class BlocksEnv(BaseEnv):
     def __init__(self) -> None:
         super().__init__()
         # Types
-        self._block_type = Type("block",
-                                ["pose_x", "pose_y", "pose_z", "held"])
+        self._block_type = Type("block", [
+            "pose_x", "pose_y", "pose_z", "held", "color_r", "color_g",
+            "color_b"
+        ])
         self._robot_type = Type("robot",
                                 ["pose_x", "pose_y", "pose_z", "fingers"])
         # Predicates
@@ -242,20 +244,19 @@ class BlocksEnv(BaseEnv):
         yz_ax.set_xlim((self.y_lb - 2 * r, self.y_ub + 2 * r))
         yz_ax.set_ylim((self.table_height, r * 16 + 0.1))
 
-        colors = [
-            "red", "blue", "green", "orange", "purple", "yellow", "brown",
-            "cyan"
-        ]
         blocks = [o for o in state if o.is_instance(self._block_type)]
         held = "None"
-        for i, block in enumerate(sorted(blocks)):
+        for block in sorted(blocks):
             x = state.get(block, "pose_x")
             y = state.get(block, "pose_y")
             z = state.get(block, "pose_z")
-            c = colors[i % len(colors)]  # block color
+            color_r = state.get(block, "color_r")
+            color_g = state.get(block, "color_g")
+            color_b = state.get(block, "color_b")
+            color = (color_r, color_g, color_b)
             if state.get(block, "held") > self.held_tol:
                 assert held == "None"
-                held = f"{block.name} ({c})"
+                held = f"{block.name}"
 
             # xz axis
             xz_rect = patches.Rectangle((x - r, z - r),
@@ -264,7 +265,7 @@ class BlocksEnv(BaseEnv):
                                         zorder=-y,
                                         linewidth=1,
                                         edgecolor='black',
-                                        facecolor=c)
+                                        facecolor=color)
             xz_ax.add_patch(xz_rect)
 
             # yz axis
@@ -274,7 +275,7 @@ class BlocksEnv(BaseEnv):
                                         zorder=-x,
                                         linewidth=1,
                                         edgecolor='black',
-                                        facecolor=c)
+                                        facecolor=color)
             yz_ax.add_patch(yz_rect)
 
         title = f"Held: {held}"
@@ -329,8 +330,9 @@ class BlocksEnv(BaseEnv):
             pile_i, pile_j = pile_idx
             x, y = pile_to_xy[pile_i]
             z = self.table_height + self.block_size * (0.5 + pile_j)
-            # [pose_x, pose_y, pose_z, held]
-            data[block] = np.array([x, y, z, 0.0])
+            r, g, b = rng.uniform(size=3)
+            # [pose_x, pose_y, pose_z, held, color_r, color_g, color_b]
+            data[block] = np.array([x, y, z, 0.0, r, g, b])
         # [pose_x, pose_y, pose_z, fingers]
         # Note: the robot poses are not used in this environment (they are
         # constant), but they change and get used in the PyBullet subclass.

--- a/predicators/envs/pybullet_blocks.py
+++ b/predicators/envs/pybullet_blocks.py
@@ -258,7 +258,7 @@ class PyBulletBlocksEnv(PyBulletEnv, BlocksEnv):
                 block_id, [bx, by, bz],
                 self._default_orn,
                 physicsClientId=self._physics_client_id)
-            # Update the block color.
+            # Update the block color. RGB values are between 0 and 1.
             r = state.get(block_obj, "color_r")
             g = state.get(block_obj, "color_g")
             b = state.get(block_obj, "color_b")

--- a/predicators/envs/pybullet_blocks.py
+++ b/predicators/envs/pybullet_blocks.py
@@ -258,6 +258,15 @@ class PyBulletBlocksEnv(PyBulletEnv, BlocksEnv):
                 block_id, [bx, by, bz],
                 self._default_orn,
                 physicsClientId=self._physics_client_id)
+            # Update the block color.
+            r = state.get(block_obj, "color_r")
+            g = state.get(block_obj, "color_g")
+            b = state.get(block_obj, "color_b")
+            color = (r, g, b, 1.0)  # alpha = 1.0
+            p.changeVisualShape(block_id,
+                                linkIndex=-1,
+                                rgbaColor=color,
+                                physicsClientId=self._physics_client_id)
 
         # For any blocks not involved, put them out of view.
         h = self.block_size
@@ -301,8 +310,12 @@ class PyBulletBlocksEnv(PyBulletEnv, BlocksEnv):
             (bx, by, bz), _ = p.getBasePositionAndOrientation(
                 block_id, physicsClientId=self._physics_client_id)
             held = (block_id == self._held_obj_id)
+            visual_data = p.getVisualShapeData(
+                block_id, physicsClientId=self._physics_client_id)[0]
+            r, g, b, _ = visual_data[7]
             # pose_x, pose_y, pose_z, held
-            state_dict[block] = np.array([bx, by, bz, held], dtype=np.float32)
+            state_dict[block] = np.array([bx, by, bz, held, r, g, b],
+                                         dtype=np.float32)
 
         state = utils.PyBulletState(state_dict,
                                     simulator_state=joint_positions)

--- a/tests/envs/test_pybullet_blocks.py
+++ b/tests/envs/test_pybullet_blocks.py
@@ -138,7 +138,7 @@ def test_pybullet_blocks_picking(env):
     # Create a simple custom state with one block for testing.
     init_state = State({
         robot: np.array([rx, ry, rz, rf]),
-        block: np.array([bx, by, bz, 0.0]),
+        block: np.array([bx, by, bz, 0.0, 1.0, 0.0, 0.0]),
     })
     env.set_state(init_state)
     recovered_state = env.get_state()
@@ -164,7 +164,7 @@ def test_pybullet_blocks_picking_corners(env):
     # Create a simple custom state with one block for testing.
     init_state = State({
         robot: np.array([rx, ry, rz, rf]),
-        block: np.array([bx, by, bz, 0.0]),
+        block: np.array([bx, by, bz, 0.0, 1.0, 0.0, 0.0]),
     })
     corners = [
         (env.x_lb, env.y_lb),
@@ -202,8 +202,8 @@ def test_pybullet_blocks_stacking(env):
     # Create a state with two blocks.
     init_state = State({
         robot: np.array([rx, ry, rz, rf]),
-        block0: np.array([bx0, by0, bz0, 0.0]),
-        block1: np.array([bx0, by1, bz0, 0.0]),
+        block0: np.array([bx0, by0, bz0, 0.0, 1.0, 0.0, 0.0]),
+        block1: np.array([bx0, by1, bz0, 0.0, 0.0, 1.0, 0.0]),
     })
     env.set_state(init_state)
     assert env.get_state().allclose(init_state)
@@ -249,9 +249,11 @@ def test_pybullet_blocks_stacking_corners(env):
     for (bx, by) in corners:
         state = State({
             robot: np.array([rx, ry, rz, rf]),
-            block0: np.array([bx0, by0, bz0, 0.0]),
-            **{b: np.array([bx, by, bz, 0.0])
-               for b, bz in block_to_z.items()}
+            block0: np.array([bx0, by0, bz0, 0.0, 1.0, 0.0, 0.0]),
+            **{
+                b: np.array([bx, by, bz, 0.0, 0.0, 1.0, 0.0])
+                for b, bz in block_to_z.items()
+            }
         })
         env.set_state(state)
         assert env.get_state().allclose(state)
@@ -281,7 +283,7 @@ def test_pybullet_blocks_putontable(env):
     # Create a simple custom state with one block for testing.
     init_state = State({
         robot: np.array([rx, ry, rz, rf]),
-        block: np.array([bx, by, bz, 0.0]),
+        block: np.array([bx, by, bz, 0.0, 1.0, 0.0, 0.0]),
     })
     env.set_state(init_state)
     assert env.get_state().allclose(init_state)
@@ -316,7 +318,7 @@ def test_pybullet_blocks_putontable_corners(env):
     # Create a simple custom state with one block for testing.
     init_state = State({
         robot: np.array([rx, ry, rz, rf]),
-        block: np.array([bx, by, bz, 0.0]),
+        block: np.array([bx, by, bz, 0.0, 1.0, 0.0, 0.0]),
     })
     corners = [
         (env.x_lb, env.y_lb),
@@ -372,9 +374,11 @@ def test_pybullet_blocks_close_pick_place(env):
     }
     state = State({
         robot: np.array([rx, ry, rz, rf]),
-        block: np.array([bx, by0, bz0, 0.0]),
-        **{b: np.array([bx, by, bz, 0.0])
-           for b, bz in block_to_z.items()}
+        block: np.array([bx, by0, bz0, 0.0, 1.0, 0.0, 0.0]),
+        **{
+            b: np.array([bx, by, bz, 0.0, 0.0, 1.0, 0.0])
+            for b, bz in block_to_z.items()
+        }
     })
     env.set_state(state)
     assert env.get_state().allclose(state)
@@ -422,8 +426,8 @@ def test_pybullet_blocks_abstract_states(env):
     # Create a state with two blocks on the table.
     state = State({
         robot: np.array([rx, ry, rz, rf]),
-        block0: np.array([bx0, by0, bz0, 0.0]),
-        block1: np.array([bx0, by1, bz0, 0.0]),
+        block0: np.array([bx0, by0, bz0, 0.0, 1.0, 0.0, 0.0]),
+        block1: np.array([bx0, by1, bz0, 0.0, 0.0, 1.0, 0.0]),
     })
     env.set_state(state)
     assert env.get_state().allclose(state)


### PR DESCRIPTION
as we move toward real world block stacking, we want to be able to consume a task specification that includes block colors (see #1218). the "right" way to handle this in our framework is to make color part of the block state. this PR investigates whether that will break things. in particular, we'll have to see whether any part of the learning pipeline overfits to color (predicate invention especially). if there is obvious performance degradation, we can hack around it by saving the correspondence between object and colors in the environment itself, but that is pretty ugly because objects vary per task.