### PR TITLE
RNT environment with ambiguous demos

### DIFF
--- a/predicators/envs/repeated_nextto.py
+++ b/predicators/envs/repeated_nextto.py
@@ -156,13 +156,13 @@ class RepeatedNextToEnv(BaseEnv):
             GroundAtom(self._Grasped, [self._robot, dots[1]]),
             GroundAtom(self._Grasped, [self._robot, dots[2]]),
         }
-        goals = [goal1, goal2, goal3]
+        goals = [goal3, goal2, goal1]
         for i in range(num):
             data: Dict[Object, Array] = {}
             for dot in dots:
-                dot_x = rng.uniform(self.env_lb, self.env_ub)
+                dot_x = rng.uniform(5.0, 5.5)
                 data[dot] = np.array([dot_x, 0.0])
-            robot_x = rng.uniform(self.env_lb, self.env_ub)
+            robot_x = 0.0
             data[self._robot] = np.array([robot_x])
             tasks.append(Task(State(data), goals[i % len(goals)]))
         return tasks
@@ -236,3 +236,35 @@ class RepeatedNextToSingleOptionEnv(RepeatedNextToEnv):
         if params[0] < 0:
             return self._Move_policy(state, memory, objects, params[1:])
         return self._Grasp_policy(state, memory, objects, params[1:])
+
+class RepeatedNextToAmbiguousEnv(RepeatedNextToEnv):
+    """A variation on RepeatedNextToEnv with ambiguous demonstrations that
+    can lead to the backchaining algorithm learning complex move operators."""
+
+    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[Task]:
+        assert self.env_lb <= 4.0
+        assert self.env_ub >= 5.5
+        tasks = []
+        dots = []
+        for i in range(CFG.repeated_nextto_num_dots):
+            dots.append(Object(f"dot{i}", self._dot_type))
+        goal1 = {GroundAtom(self._Grasped, [self._robot, dots[0]])}
+        goal2 = {
+            GroundAtom(self._Grasped, [self._robot, dots[0]]),
+            GroundAtom(self._Grasped, [self._robot, dots[1]]),
+        }
+        goal3 = {
+            GroundAtom(self._Grasped, [self._robot, dots[0]]),
+            GroundAtom(self._Grasped, [self._robot, dots[1]]),
+            GroundAtom(self._Grasped, [self._robot, dots[2]]),
+        }
+        goals = [goal3, goal2, goal1]
+        for i in range(num):
+            data: Dict[Object, Array] = {}
+            for dot in dots:
+                dot_x = rng.uniform(5.0, 5.5)
+                data[dot] = np.array([dot_x, 0.0])
+            robot_x = 0.0
+            data[self._robot] = np.array([robot_x])
+            tasks.append(Task(State(data), goals[i % len(goals)]))
+        return tasks

--- a/predicators/envs/repeated_nextto.py
+++ b/predicators/envs/repeated_nextto.py
@@ -247,10 +247,10 @@ class RepeatedNextToAmbiguousEnv(RepeatedNextToEnv):
         return "repeated_nextto_ambiguous"
 
     def _get_tasks(self, num: int, rng: np.random.Generator) -> List[Task]:
-        assert self.env_lb <= 4.0
-        assert self.env_ub >= 5.5
+        assert self.env_ub - self.env_lb > self.nextto_thresh
         tasks = []
         dots = []
+        assert CFG.repeated_nextto_num_dots >= 3
         for i in range(CFG.repeated_nextto_num_dots):
             dots.append(Object(f"dot{i}", self._dot_type))
         goal1 = {GroundAtom(self._Grasped, [self._robot, dots[0]])}
@@ -267,9 +267,9 @@ class RepeatedNextToAmbiguousEnv(RepeatedNextToEnv):
         for i in range(num):
             data: Dict[Object, Array] = {}
             for dot in dots:
-                dot_x = rng.uniform(5.0, 5.5)
+                dot_x = rng.uniform(self.env_ub - 0.5, self.env_ub)
                 data[dot] = np.array([dot_x, 0.0])
-            robot_x = 0.0
+            robot_x = self.env_lb
             data[self._robot] = np.array([robot_x])
             tasks.append(Task(State(data), goals[i % len(goals)]))
         return tasks

--- a/predicators/envs/repeated_nextto.py
+++ b/predicators/envs/repeated_nextto.py
@@ -237,9 +237,14 @@ class RepeatedNextToSingleOptionEnv(RepeatedNextToEnv):
             return self._Move_policy(state, memory, objects, params[1:])
         return self._Grasp_policy(state, memory, objects, params[1:])
 
+
 class RepeatedNextToAmbiguousEnv(RepeatedNextToEnv):
-    """A variation on RepeatedNextToEnv with ambiguous demonstrations that
-    can lead to the backchaining algorithm learning complex move operators."""
+    """A variation on RepeatedNextToEnv with ambiguous demonstrations that can
+    lead to the backchaining algorithm learning complex move operators."""
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "repeated_nextto_ambiguous"
 
     def _get_tasks(self, num: int, rng: np.random.Generator) -> List[Task]:
         assert self.env_lb <= 4.0

--- a/predicators/envs/repeated_nextto.py
+++ b/predicators/envs/repeated_nextto.py
@@ -156,13 +156,13 @@ class RepeatedNextToEnv(BaseEnv):
             GroundAtom(self._Grasped, [self._robot, dots[1]]),
             GroundAtom(self._Grasped, [self._robot, dots[2]]),
         }
-        goals = [goal3, goal2, goal1]
+        goals = [goal1, goal2, goal3]
         for i in range(num):
             data: Dict[Object, Array] = {}
             for dot in dots:
-                dot_x = rng.uniform(5.0, 5.5)
+                dot_x = rng.uniform(self.env_lb, self.env_ub)
                 data[dot] = np.array([dot_x, 0.0])
-            robot_x = 0.0
+            robot_x = rng.uniform(self.env_lb, self.env_ub)
             data[self._robot] = np.array([robot_x])
             tasks.append(Task(State(data), goals[i % len(goals)]))
         return tasks

--- a/predicators/ground_truth_nsrts.py
+++ b/predicators/ground_truth_nsrts.py
@@ -37,7 +37,7 @@ def get_gt_nsrts(predicates: Set[Predicate],
         nsrts = _get_tools_gt_nsrts()
     elif CFG.env == "playroom":
         nsrts = _get_playroom_gt_nsrts()
-    elif CFG.env in "repeated_nextto":
+    elif CFG.env in ("repeated_nextto", "repeated_nextto_ambiguous"):
         nsrts = _get_repeated_nextto_gt_nsrts(CFG.env)
     elif CFG.env == "repeated_nextto_single_option":
         nsrts = _get_repeated_nextto_single_option_gt_nsrts()

--- a/predicators/ground_truth_nsrts.py
+++ b/predicators/ground_truth_nsrts.py
@@ -37,7 +37,7 @@ def get_gt_nsrts(predicates: Set[Predicate],
         nsrts = _get_tools_gt_nsrts()
     elif CFG.env == "playroom":
         nsrts = _get_playroom_gt_nsrts()
-    elif CFG.env == "repeated_nextto":
+    elif CFG.env in "repeated_nextto":
         nsrts = _get_repeated_nextto_gt_nsrts(CFG.env)
     elif CFG.env == "repeated_nextto_single_option":
         nsrts = _get_repeated_nextto_single_option_gt_nsrts()

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -19,8 +19,8 @@ from predicators.envs.pddl_env import FixedTasksBlocksPDDLEnv, \
     ProceduralTasksBlocksPDDLEnv, ProceduralTasksDeliveryPDDLEnv, \
     ProceduralTasksEasyDeliveryPDDLEnv
 from predicators.envs.playroom import PlayroomEnv
-from predicators.envs.repeated_nextto import RepeatedNextToEnv, \
-    RepeatedNextToSingleOptionEnv, RepeatedNextToAmbiguousEnv
+from predicators.envs.repeated_nextto import RepeatedNextToAmbiguousEnv, \
+    RepeatedNextToEnv, RepeatedNextToSingleOptionEnv
 from predicators.envs.repeated_nextto_painting import RepeatedNextToPaintingEnv
 from predicators.envs.satellites import SatellitesEnv, SatellitesSimpleEnv
 from predicators.envs.screws import ScrewsEnv

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -20,7 +20,7 @@ from predicators.envs.pddl_env import FixedTasksBlocksPDDLEnv, \
     ProceduralTasksEasyDeliveryPDDLEnv
 from predicators.envs.playroom import PlayroomEnv
 from predicators.envs.repeated_nextto import RepeatedNextToEnv, \
-    RepeatedNextToSingleOptionEnv
+    RepeatedNextToSingleOptionEnv, RepeatedNextToAmbiguousEnv
 from predicators.envs.repeated_nextto_painting import RepeatedNextToPaintingEnv
 from predicators.envs.satellites import SatellitesEnv, SatellitesSimpleEnv
 from predicators.envs.screws import ScrewsEnv
@@ -42,6 +42,7 @@ ENV_NAME_AND_CLS = [
     ("painting", PaintingEnv), ("tools", ToolsEnv), ("playroom", PlayroomEnv),
     ("repeated_nextto", RepeatedNextToEnv),
     ("repeated_nextto_single_option", RepeatedNextToSingleOptionEnv),
+    ("repeated_nextto_ambiguous", RepeatedNextToAmbiguousEnv),
     ("satellites", SatellitesEnv), ("satellites_simple", SatellitesSimpleEnv),
     ("screws", ScrewsEnv),
     ("repeated_nextto_painting", RepeatedNextToPaintingEnv),


### PR DESCRIPTION
Includes a new variant of the repeated nextto env that causes our backchaining algorithm to learn unnecessarily complex NSRTs. In this `repeated_nextto_ambiguous` environment, backchaining learns the following NSRTs:

```
STRIPS-Grasp0:
    Parameters: [?x0:robot, ?x1:dot]
    Preconditions: [NextTo(?x0:robot, ?x1:dot)]
    Add Effects: [Grasped(?x0:robot, ?x1:dot)]
    Delete Effects: [NextTo(?x0:robot, ?x1:dot)]
    Ignore Effects: []
    Option Spec: Grasp(?x0:robot, ?x1:dot)
STRIPS-Move0:
    Parameters: [?x0:robot, ?x1:dot]
    Preconditions: [NextTo(?x0:robot, ?x1:dot)]
    Add Effects: []
    Delete Effects: []
    Ignore Effects: []
    Option Spec: Move(?x0:robot, ?x1:dot)
STRIPS-Move1:
    Parameters: [?x0:robot, ?x1:dot, ?x2:dot, ?x3:dot]
    Preconditions: [NextToNothing(?x0:robot)]
    Add Effects: [NextTo(?x0:robot, ?x1:dot), NextTo(?x0:robot, ?x2:dot), NextTo(?x0:robot, ?x3:dot)]
    Delete Effects: [NextToNothing(?x0:robot)]
    Ignore Effects: []
    Option Spec: Move(?x0:robot, ?x1:dot)
```

Ideally, there should only be the `Move0` NSRT. We will use this environment to iterate on various changes to backchaining to help us solve this issue of ambiguous trajectories.