### PR TITLE
replace `pybullet_use_gui` setting with general `use_gui` flag...

### DIFF
--- a/predicators/args.py
+++ b/predicators/args.py
@@ -34,6 +34,7 @@ def create_arg_parser(env_required: bool = True,
     parser.add_argument("--experiment_id", default="", type=str)
     parser.add_argument("--load_experiment_id", default="", type=str)
     parser.add_argument("--log_file", default="", type=str)
+    parser.add_argument("--use_gui", action="store_true")
     parser.add_argument('--debug',
                         action="store_const",
                         dest="loglevel",

--- a/predicators/envs/__init__.py
+++ b/predicators/envs/__init__.py
@@ -20,7 +20,9 @@ if not TYPE_CHECKING:
             importlib.import_module(f"{__name__}.{module_name}")
 
 
-def create_new_env(name: str, do_cache: bool = True) -> BaseEnv:
+def create_new_env(name: str,
+                   do_cache: bool = True,
+                   use_gui: bool = True) -> BaseEnv:
     """Create a new instance of an environment from its name.
 
     If do_cache is True, then cache this env instance so that it can
@@ -28,7 +30,7 @@ def create_new_env(name: str, do_cache: bool = True) -> BaseEnv:
     """
     for cls in utils.get_all_subclasses(BaseEnv):
         if not cls.__abstractmethods__ and cls.get_name() == name:
-            env = cls()
+            env = cls(use_gui)
             break
     else:
         raise NotImplementedError(f"Unknown env: {name}")
@@ -37,7 +39,7 @@ def create_new_env(name: str, do_cache: bool = True) -> BaseEnv:
     return env
 
 
-def get_or_create_env(name: str) -> BaseEnv:
+def get_or_create_env(name: str, use_gui: bool = True) -> BaseEnv:
     """Get the most recent cached env instance. If one does not exist in the
     cache, create it using create_new_env().
 
@@ -50,4 +52,6 @@ def get_or_create_env(name: str) -> BaseEnv:
             "WARNING: you called get_or_create_env, but I couldn't "
             f"find {name} in the cache. Making a new instance.")
         create_new_env(name, do_cache=True)
-    return _MOST_RECENT_ENV_INSTANCE[name]
+    env = _MOST_RECENT_ENV_INSTANCE[name]
+    assert env.using_gui == use_gui
+    return env

--- a/predicators/envs/__init__.py
+++ b/predicators/envs/__init__.py
@@ -39,19 +39,21 @@ def create_new_env(name: str,
     return env
 
 
-def get_or_create_env(name: str, use_gui: bool = True) -> BaseEnv:
+def get_or_create_env(name: str) -> BaseEnv:
     """Get the most recent cached env instance. If one does not exist in the
     cache, create it using create_new_env().
 
     If you use this function, you should NOT be doing anything that
     relies on the environment's internal state (i.e., you should not
     call reset() or step()).
+
+    Also note that the GUI is always turned off for environments that are
+    newly created by this function. If you want to use the GUI, you should
+    create the environment explicitly through create_new_env().
     """
     if name not in _MOST_RECENT_ENV_INSTANCE:
         logging.warning(
             "WARNING: you called get_or_create_env, but I couldn't "
             f"find {name} in the cache. Making a new instance.")
-        create_new_env(name, do_cache=True)
-    env = _MOST_RECENT_ENV_INSTANCE[name]
-    assert env.using_gui == use_gui
-    return env
+        create_new_env(name, do_cache=True, use_gui=False)
+    return _MOST_RECENT_ENV_INSTANCE[name]

--- a/predicators/envs/base_env.py
+++ b/predicators/envs/base_env.py
@@ -17,7 +17,7 @@ from predicators.structs import Action, DefaultState, DefaultTask, \
 class BaseEnv(abc.ABC):
     """Base environment."""
 
-    def __init__(self) -> None:
+    def __init__(self, use_gui: bool = True) -> None:
         self._current_state = DefaultState  # set in reset
         self._current_task = DefaultTask  # set in reset
         self._set_seed(CFG.seed)
@@ -27,6 +27,8 @@ class BaseEnv(abc.ABC):
         # to be called in those subclasses first, to set the env seed.
         self._train_tasks: List[Task] = []
         self._test_tasks: List[Task] = []
+        # If the environment has a GUI, this determines whether to launch it.
+        self._using_gui = use_gui
 
     @classmethod
     @abc.abstractmethod
@@ -109,6 +111,11 @@ class BaseEnv(abc.ABC):
         because this method returns an active figure object!
         """
         raise NotImplementedError("Matplotlib rendering not implemented!")
+
+    @property
+    def using_gui(self) -> bool:
+        """Whether the GUI for this environment is activated."""
+        return self._using_gui
 
     def render_state(self,
                      state: State,

--- a/predicators/envs/blocks.py
+++ b/predicators/envs/blocks.py
@@ -49,8 +49,9 @@ class BlocksEnv(BaseEnv):
     collision_padding: ClassVar[float] = 2.0
     assert pick_tol < block_size
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
+
         # Types
         self._block_type = Type("block", [
             "pose_x", "pose_y", "pose_z", "held", "color_r", "color_g",

--- a/predicators/envs/cluttered_table.py
+++ b/predicators/envs/cluttered_table.py
@@ -21,8 +21,9 @@ from predicators.structs import Action, Array, GroundAtom, Object, \
 class ClutteredTableEnv(BaseEnv):
     """Toy cluttered table domain."""
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
+
         # Types
         self._can_type = Type(
             "can", ["pose_x", "pose_y", "radius", "is_grasped", "is_trashed"])
@@ -297,8 +298,9 @@ class ClutteredTablePlaceEnv(ClutteredTableEnv):
     the colliding can and place it out of the way of the goal can.
     """
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
+
         self._Place = utils.SingletonParameterizedOption(
             "Place",
             self._Place_policy,

--- a/predicators/envs/coffee.py
+++ b/predicators/envs/coffee.py
@@ -94,8 +94,8 @@ class CoffeeEnv(BaseEnv):
     max_angular_vel: ClassVar[float] = tilt_ub
     max_finger_vel: ClassVar[float] = 1.0
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
 
         # Types
         self._robot_type = Type("robot",

--- a/predicators/envs/cover.py
+++ b/predicators/envs/cover.py
@@ -27,8 +27,9 @@ class CoverEnv(BaseEnv):
     _workspace_x: ClassVar[float] = 1.35
     _workspace_z: ClassVar[float] = 0.65
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
+
         # Types
         self._block_type = Type(
             "block", ["is_block", "is_target", "width", "pose", "grasp"])
@@ -369,8 +370,9 @@ class CoverEnvTypedOptions(CoverEnv):
     This means we need two options (one for block, one for target).
     """
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
+
         del self._PickPlace
         self._Pick: ParameterizedOption = utils.SingletonParameterizedOption(
             "Pick",
@@ -405,8 +407,9 @@ class CoverEnvTypedOptions(CoverEnv):
 class CoverEnvHierarchicalTypes(CoverEnv):
     """Toy cover domain with hierarchical types, just for testing."""
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
+
         # Change blocks to be of a derived type
         self._parent_block_type = self._block_type
         self._block_type = Type(
@@ -444,8 +447,9 @@ class CoverEnvRegrasp(CoverEnv):
     _allow_free_space_placing: ClassVar[bool] = True
     _initial_pick_offsets: ClassVar[List[float]] = [-0.95, 0.0, 0.95]
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
+
         # Add a Clear predicate to prevent attempts at placing on already
         # covered targets.
         self._Clear = Predicate("Clear", [self._target_type],
@@ -508,8 +512,9 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
     grip_ub: ClassVar[float] = 1.0
     snap_tol: ClassVar[float] = 1e-2
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
+
         # Need to now include y and gripper info in state.
         # Removing "pose" because that's ambiguous.
         # Also adding height to blocks.

--- a/predicators/envs/doors.py
+++ b/predicators/envs/doors.py
@@ -33,8 +33,9 @@ class DoorsEnv(BaseEnv):
     move_sq_dist_tol: ClassVar[float] = 1e-5
     open_door_thresh: ClassVar[float] = 1e-2
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
+
         # Types
         self._robot_type = Type("robot", ["x", "y"])
         self._door_type = Type("door", [

--- a/predicators/envs/painting.py
+++ b/predicators/envs/painting.py
@@ -56,8 +56,9 @@ class PaintingEnv(BaseEnv):
     nextto_thresh: ClassVar[float] = 1.0
     on_table_height_tol: ClassVar[float] = 5e-02
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
+
         # Types
         self._obj_type = Type("obj", [
             "pose_x", "pose_y", "pose_z", "dirtiness", "wetness", "color",

--- a/predicators/envs/pddl_env.py
+++ b/predicators/envs/pddl_env.py
@@ -82,8 +82,9 @@ class _PDDLEnv(BaseEnv):
     same object parameters and no continuous parameters.
     """
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
+
         # Parse the domain str.
         self._types, self._predicates, self._strips_operators = \
             _parse_pddl_domain(self._domain_str)

--- a/predicators/envs/playroom.py
+++ b/predicators/envs/playroom.py
@@ -43,8 +43,9 @@ class PlayroomEnv(BlocksEnv):
     assert pick_tol < block_size
     pick_z: ClassVar[float] = 1.5
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
+
         # Types
         self._block_type = Type(
             "block", ["pose_x", "pose_y", "pose_z", "held", "clear"])

--- a/predicators/envs/pybullet_blocks.py
+++ b/predicators/envs/pybullet_blocks.py
@@ -167,8 +167,8 @@ class PyBulletBlocksEnv(PyBulletEnv, BlocksEnv):
         # Skip test coverage because GUI is too expensive to use in unit tests
         # and cannot be used in headless mode.
         if CFG.pybullet_draw_debug:  # pragma: no cover
-            assert CFG.pybullet_use_gui, \
-                "pybullet_use_gui must be True to use pybullet_draw_debug."
+            assert self.using_gui, \
+                "using_gui must be True to use pybullet_draw_debug."
             # Draw the workspace on the table for clarity.
             p.addUserDebugLine([self.x_lb, self.y_lb, self.table_height],
                                [self.x_ub, self.y_lb, self.table_height],

--- a/predicators/envs/pybullet_blocks.py
+++ b/predicators/envs/pybullet_blocks.py
@@ -41,8 +41,8 @@ class PyBulletBlocksEnv(PyBulletEnv, BlocksEnv):
     }
     _move_to_pose_tol: ClassVar[float] = 1e-4
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
 
         # Override options, keeping the types and parameter spaces the same.
         open_fingers_func = lambda s, _1, _2: (self._fingers_state_to_joint(

--- a/predicators/envs/pybullet_cover.py
+++ b/predicators/envs/pybullet_cover.py
@@ -229,8 +229,8 @@ class PyBulletCoverEnv(PyBulletEnv, CoverEnv):
         # Skip test coverage because GUI is too expensive to use in unit tests
         # and cannot be used in headless mode.
         if CFG.pybullet_draw_debug:  # pragma: no cover
-            assert CFG.pybullet_use_gui, \
-                "pybullet_use_gui must be True to use pybullet_draw_debug."
+            assert self.using_gui, \
+                "use_gui must be True to use pybullet_draw_debug."
             p.removeAllUserDebugItems(physicsClientId=self._physics_client_id)
             for hand_lb, hand_rb in self._get_hand_regions(state):
                 # De-normalize hand bounds to actual coordinates.

--- a/predicators/envs/pybullet_cover.py
+++ b/predicators/envs/pybullet_cover.py
@@ -50,8 +50,8 @@ class PyBulletCoverEnv(PyBulletEnv, CoverEnv):
         float] = _table_height + _obj_len_hgt * 0.5 + _offset
     _target_height: ClassVar[float] = 0.0001
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
 
         # Override PickPlace option
         types = self._PickPlace.types

--- a/predicators/envs/pybullet_env.py
+++ b/predicators/envs/pybullet_env.py
@@ -69,7 +69,7 @@ class PyBulletEnv(BaseEnv):
         """One-time initialization of PyBullet assets."""
         # Skip test coverage because GUI is too expensive to use in unit tests
         # and cannot be used in headless mode.
-        if CFG.pybullet_use_gui:  # pragma: no cover
+        if self.using_gui:  # pragma: no cover
             self._physics_client_id = p.connect(p.GUI)
             # Disable the preview windows for faster rendering.
             p.configureDebugVisualizer(p.COV_ENABLE_GUI,
@@ -208,7 +208,7 @@ class PyBulletEnv(BaseEnv):
         # and cannot be used in headless mode.
         del caption  # unused
 
-        if not CFG.pybullet_use_gui:
+        if not self.using_gui:
             raise Exception(
                 "Rendering only works with GUI on. See "
                 "https://github.com/bulletphysics/bullet3/issues/1157")

--- a/predicators/envs/pybullet_env.py
+++ b/predicators/envs/pybullet_env.py
@@ -54,8 +54,8 @@ class PyBulletEnv(BaseEnv):
     _camera_target: ClassVar[Pose3D] = (1.65, 0.75, 0.42)
     _debug_text_position: ClassVar[Pose3D] = (1.65, 0.25, 0.75)
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
 
         # When an object is held, a constraint is created to prevent slippage.
         self._held_constraint_id: Optional[int] = None

--- a/predicators/envs/repeated_nextto.py
+++ b/predicators/envs/repeated_nextto.py
@@ -28,8 +28,9 @@ class RepeatedNextToEnv(BaseEnv):
     grasped_thresh: ClassVar[float] = 0.5
     nextto_thresh: ClassVar[float] = 0.5
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
+
         # Types
         self._robot_type = Type("robot", ["x"])
         self._dot_type = Type("dot", ["x", "grasped"])

--- a/predicators/envs/repeated_nextto.py
+++ b/predicators/envs/repeated_nextto.py
@@ -209,8 +209,9 @@ class RepeatedNextToEnv(BaseEnv):
 class RepeatedNextToSingleOptionEnv(RepeatedNextToEnv):
     """A variation on RepeatedNextToEnv with a single parameterized option."""
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
+
         # Options
         del self._Move
         del self._Grasp

--- a/predicators/envs/repeated_nextto_painting.py
+++ b/predicators/envs/repeated_nextto_painting.py
@@ -22,8 +22,9 @@ from predicators.structs import Action, Array, Object, ParameterizedOption, \
 class RepeatedNextToPaintingEnv(PaintingEnv):
     """RepeatedNextToPainting domain."""
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
+
         # Additional Predicates
         self._NextTo = Predicate("NextTo", [self._robot_type, self._obj_type],
                                  self._NextTo_holds)

--- a/predicators/envs/satellites.py
+++ b/predicators/envs/satellites.py
@@ -43,8 +43,9 @@ class SatellitesEnv(BaseEnv):
     id_tol: ClassVar[float] = 1e-3
     location_tol: ClassVar[float] = 1e-3
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
+
         # Types
         ## `instrument` can be camera (0.0 - 0.33), infrared (0.33 - 0.66), or
         ## Geiger (0.66 - 1.0). `calibration_obj_id` is the ID of the object

--- a/predicators/envs/screws.py
+++ b/predicators/envs/screws.py
@@ -36,8 +36,9 @@ class ScrewsEnv(BaseEnv):
     rz_y_lb = 0.0
     rz_y_ub = 5.0
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
+
         self.num_screws_train = CFG.screws_num_screws_train
         self.num_screws_test = CFG.screws_num_screws_test
         self._rz_width = self.rz_x_ub - self.rz_x_lb

--- a/predicators/envs/stick_button.py
+++ b/predicators/envs/stick_button.py
@@ -46,8 +46,9 @@ class StickButtonEnv(BaseEnv):
     stick_init_ub: ClassVar[float] = 1.6  # start low in the reachable zone
     pick_grasp_tol: ClassVar[float] = 1e-3
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
+
         # Types
         # The (x, y) is the center of the robot. Theta is only relevant when
         # the robot is holding the stick.

--- a/predicators/envs/tools.py
+++ b/predicators/envs/tools.py
@@ -43,8 +43,9 @@ class ToolsEnv(BaseEnv):
     num_hammers: ClassVar[int] = 2
     num_wrenches: ClassVar[int] = 1
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
+
         # Types
         self._robot_type = Type("robot", ["fingers"])
         self._screw_type = Type(

--- a/predicators/envs/touch_point.py
+++ b/predicators/envs/touch_point.py
@@ -33,8 +33,9 @@ class TouchPointEnv(BaseEnv):
     # is less than action_magnitude * touch_multiplier.
     touch_multiplier: ClassVar[float] = 1.5
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
+
         # Types
         self._robot_type = Type("robot", ["x", "y"])
         self._target_type = Type("target", ["x", "y"])

--- a/predicators/main.py
+++ b/predicators/main.py
@@ -83,7 +83,7 @@ def main() -> None:
     # Create the eval trajectories directory.
     os.makedirs(CFG.eval_trajectories_dir, exist_ok=True)
     # Create classes. Note that seeding happens inside the env and approach.
-    env = create_new_env(CFG.env, do_cache=True)
+    env = create_new_env(CFG.env, do_cache=True, use_gui=CFG.use_gui)
     # The action space and options need to be seeded externally, because
     # env.action_space and env.options are often created during env __init__().
     env.action_space.seed(CFG.seed)

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -100,7 +100,6 @@ class GlobalSettings:
     tools_num_contraptions_test = [3]
 
     # general pybullet parameters
-    pybullet_use_gui = False  # must be True to make videos
     pybullet_draw_debug = False  # useful for annotating in the GUI
     pybullet_camera_width = 335  # for high quality, use 1674
     pybullet_camera_height = 180  # for high quality, use 900

--- a/tests/envs/test_pybullet_blocks.py
+++ b/tests/envs/test_pybullet_blocks.py
@@ -86,7 +86,7 @@ def _create_exposed_pybullet_blocks_env(request):
         # Which robot we're using
         "pybullet_robot": request.param,
     })
-    return _ExposedPyBulletBlocksEnv()
+    return _ExposedPyBulletBlocksEnv(use_gui=_GUI_ON)
 
 
 def _get_predicates_by_names(env, names):

--- a/tests/envs/test_pybullet_blocks.py
+++ b/tests/envs/test_pybullet_blocks.py
@@ -80,7 +80,7 @@ def _create_exposed_pybullet_blocks_env(request):
     """Only create once and share among all tests, for efficiency."""
     utils.reset_config({
         "env": "pybullet_blocks",
-        "pybullet_use_gui": _GUI_ON,
+        "use_gui": _GUI_ON,
         # We run this test using the RESET control mode.
         "pybullet_control_mode": "reset",
         # Which robot we're using

--- a/tests/envs/test_pybullet_cover.py
+++ b/tests/envs/test_pybullet_cover.py
@@ -77,7 +77,7 @@ def _create_exposed_pybullet_cover_env(request):
     """Only create once and share among all tests, for efficiency."""
     utils.reset_config({
         "env": "pybullet_cover",
-        "pybullet_use_gui": _GUI_ON,
+        "use_gui": _GUI_ON,
         "cover_initial_holding_prob": 0.0,
         # We run this test using the POSITION control mode.
         "pybullet_control_mode": "position",

--- a/tests/envs/test_pybullet_cover.py
+++ b/tests/envs/test_pybullet_cover.py
@@ -84,7 +84,7 @@ def _create_exposed_pybullet_cover_env(request):
         # Which robot we're using
         "pybullet_robot": request.param,
     })
-    return _ExposedPyBulletCoverEnv()
+    return _ExposedPyBulletCoverEnv(use_gui=_GUI_ON)
 
 
 def test_pybullet_cover_reset(env):


### PR DESCRIPTION
...which is then passed into `create_new_env`. The reason is that I want to be able to use the pybullet GUI for the "main" environment, but turn off the GUI for a secondary environment that will be used in the option model.

note that this should be merged before #1252 and that PR should be updated to pass `use_gui = False` to `create_new_env` in the option model code.

I will also make an announcement after this PR that `--pybullet_use_gui True` is deprecated and now `--use_gui` should be used.