### PR TITLE
add flag to disable repeated state checking in option model

### DIFF
--- a/predicators/option_model.py
+++ b/predicators/option_model.py
@@ -89,16 +89,19 @@ class _OracleOptionModel(_OptionModelBase):
         # if it does. This is a helpful optimization for planning with
         # fine-grained options over long horizons.
         # Note: mypy complains if this is None instead of DefaultState.
-        last_state = DefaultState
+        if CFG.option_model_terminate_on_repeat:
+            last_state = DefaultState
 
-        def _terminal(s: State) -> bool:
-            nonlocal last_state
-            if option_copy.terminal(s):
-                return True
-            if last_state is not DefaultState and last_state.allclose(s):
-                raise utils.OptionExecutionFailure("Option got stuck.")
-            last_state = s
-            return False
+            def _terminal(s: State) -> bool:
+                nonlocal last_state
+                if option_copy.terminal(s):
+                    return True
+                if last_state is not DefaultState and last_state.allclose(s):
+                    raise utils.OptionExecutionFailure("Option got stuck.")
+                last_state = s
+                return False
+        else:
+            _terminal = lambda s: option_copy.terminal(s)
 
         try:
             traj = utils.run_policy_with_simulator(

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -352,6 +352,9 @@ class GlobalSettings:
     # option learning parameters
     option_learning_action_converter = "identity"
 
+    # option model parameters
+    option_model_terminate_on_repeat = True
+
     # interactive learning parameters
     interactive_num_ensemble_members = 10
     interactive_query_policy = "threshold"

--- a/tests/test_option_model.py
+++ b/tests/test_option_model.py
@@ -156,6 +156,16 @@ def test_default_option_model():
     assert next_state.allclose(state)
     assert num_act == 0
 
+    # Test disabling repeated state checking.
+    utils.reset_config({
+        "option_model_terminate_on_repeat": False,
+        "max_num_steps_option_rollout": 5,
+    })
+
+    model = _OracleOptionModel(env)
+    _, num_act = model.get_next_state_and_num_actions(state, infinite_option)
+    assert num_act == 5
+
 
 def test_option_model_notimplemented():
     """Tests for various NotImplementedErrors."""


### PR DESCRIPTION
I did this because the oracle options for blocks repeat states, so you can't use the oracle option model with them. however, I'm now realizing that if we collect data from the oracle, we're going to have issues with the same state mapping to two different actions. so I probably need to change the oracle options themselves, rather than the option model. but I'm opening this PR anyway because it can't hurt to have this optional functionality and could be useful for debugging.