### PR TITLE
make pybullet robot ee orns global settings 

### DIFF
--- a/predicators/envs/pybullet_blocks.py
+++ b/predicators/envs/pybullet_blocks.py
@@ -32,13 +32,6 @@ class PyBulletBlocksEnv(PyBulletEnv, BlocksEnv):
     _table_orientation: ClassVar[Quaternion] = (0., 0., 0., 1.)
 
     # Robot parameters.
-    _ee_orn: ClassVar[Dict[str, Quaternion]] = {
-        # Fetch gripper down since it's thin we don't need to rotate 90 degrees.
-        "fetch": quaternion_from_euler(0.0, np.pi / 2, -np.pi),
-        # Panda gripper down and rotated 90 degrees as it's big and can cause
-        # collisions.
-        "panda": quaternion_from_euler(np.pi, 0, np.pi / 2)
-    }
     _move_to_pose_tol: ClassVar[float] = 1e-4
 
     def __init__(self, use_gui: bool = True) -> None:
@@ -222,10 +215,8 @@ class PyBulletBlocksEnv(PyBulletEnv, BlocksEnv):
     def _create_pybullet_robot(
             self, physics_client_id: int) -> SingleArmPyBulletRobot:
         ee_home = (self.robot_init_x, self.robot_init_y, self.robot_init_z)
-        ee_orn = self._ee_orn[CFG.pybullet_robot]
         return create_single_arm_pybullet_robot(CFG.pybullet_robot,
-                                                physics_client_id, ee_home,
-                                                ee_orn)
+                                                physics_client_id, ee_home)
 
     def _extract_robot_state(self, state: State) -> Array:
         return np.array([

--- a/predicators/envs/pybullet_blocks.py
+++ b/predicators/envs/pybullet_blocks.py
@@ -6,7 +6,6 @@ from typing import Callable, ClassVar, Dict, List, Sequence, Tuple
 import numpy as np
 import pybullet as p
 from gym.spaces import Box
-from pybullet_utils.transformations import quaternion_from_euler
 
 from predicators import utils
 from predicators.envs.blocks import BlocksEnv

--- a/predicators/envs/pybullet_cover.py
+++ b/predicators/envs/pybullet_cover.py
@@ -5,7 +5,6 @@ from typing import ClassVar, Dict, List, Sequence, Tuple
 import numpy as np
 import pybullet as p
 from gym.spaces import Box
-from pybullet_utils.transformations import quaternion_from_euler
 
 from predicators import utils
 from predicators.envs.cover import CoverEnv

--- a/predicators/envs/pybullet_cover.py
+++ b/predicators/envs/pybullet_cover.py
@@ -29,11 +29,6 @@ class PyBulletCoverEnv(PyBulletEnv, CoverEnv):
     _table_orientation: ClassVar[Quaternion] = (0., 0., 0., 1.)
 
     # Robot parameters.
-    _ee_orn: ClassVar[Dict[str, Quaternion]] = {
-        # Fetch and Panda gripper down and parallel to x-axis
-        "fetch": quaternion_from_euler(np.pi / 2, np.pi / 2, -np.pi),
-        "panda": quaternion_from_euler(np.pi, 0, np.pi / 2)
-    }
     _move_to_pose_tol: ClassVar[float] = 1e-4
 
     # Object parameters.
@@ -147,11 +142,8 @@ class PyBulletCoverEnv(PyBulletEnv, CoverEnv):
     def _create_pybullet_robot(
             self, physics_client_id: int) -> SingleArmPyBulletRobot:
         ee_home = (self._workspace_x, self._robot_init_y, self._workspace_z)
-        ee_orn = self._ee_orn[CFG.pybullet_robot]
-
         return create_single_arm_pybullet_robot(CFG.pybullet_robot,
-                                                physics_client_id, ee_home,
-                                                ee_orn)
+                                                physics_client_id, ee_home)
 
     def _extract_robot_state(self, state: State) -> Array:
         if self._HandEmpty_holds(state, []):

--- a/predicators/pybullet_helpers/robots/__init__.py
+++ b/predicators/pybullet_helpers/robots/__init__.py
@@ -1,9 +1,7 @@
 """Handles the creation of robots."""
-from typing import Dict, Optional, Type
+from typing import Dict, Type
 
-import numpy as np
-
-from predicators.pybullet_helpers.geometry import Pose, Pose3D, Quaternion
+from predicators.pybullet_helpers.geometry import Pose, Pose3D
 from predicators.pybullet_helpers.robots.fetch import FetchPyBulletRobot
 from predicators.pybullet_helpers.robots.panda import PandaPyBulletRobot
 from predicators.pybullet_helpers.robots.single_arm import \

--- a/predicators/pybullet_helpers/robots/__init__.py
+++ b/predicators/pybullet_helpers/robots/__init__.py
@@ -26,11 +26,12 @@ def create_single_arm_pybullet_robot(
         ee_home_pose: Pose3D = (1.35, 0.6, 0.7),
 ) -> SingleArmPyBulletRobot:
     """Create a single-arm PyBullet robot."""
-    ee_orientation = CFG.pybullet_robot_ee_orns[CFG.env][robot_name]
-    if robot_name in _ROBOT_TO_CLS:
+    robot_to_ee_orn = CFG.pybullet_robot_ee_orns[CFG.env]
+    if robot_name in _ROBOT_TO_CLS and robot_name in robot_to_ee_orn:
         assert robot_name in _ROBOT_TO_BASE_POSE, \
             f"Base pose not specified for robot {robot_name}."
         base_pose = _ROBOT_TO_BASE_POSE[robot_name]
+        ee_orientation = robot_to_ee_orn[robot_name]
         cls = _ROBOT_TO_CLS[robot_name]
         return cls(ee_home_pose,
                    ee_orientation,

--- a/predicators/pybullet_helpers/robots/__init__.py
+++ b/predicators/pybullet_helpers/robots/__init__.py
@@ -1,11 +1,14 @@
 """Handles the creation of robots."""
-from typing import Dict, Type
+from typing import Dict, Optional, Type
+
+import numpy as np
 
 from predicators.pybullet_helpers.geometry import Pose, Pose3D, Quaternion
 from predicators.pybullet_helpers.robots.fetch import FetchPyBulletRobot
 from predicators.pybullet_helpers.robots.panda import PandaPyBulletRobot
 from predicators.pybullet_helpers.robots.single_arm import \
     SingleArmPyBulletRobot
+from predicators.settings import CFG
 
 # Note: these are static base poses which suffice for the current environments.
 _ROBOT_TO_BASE_POSE: Dict[str, Pose] = {
@@ -20,12 +23,12 @@ _ROBOT_TO_CLS: Dict[str, Type[SingleArmPyBulletRobot]] = {
 
 
 def create_single_arm_pybullet_robot(
-    robot_name: str,
-    physics_client_id: int,
-    ee_home_pose: Pose3D = (1.35, 0.6, 0.7),
-    ee_orientation: Quaternion = (0.0, 0.0, 0.0, 1.0)
+        robot_name: str,
+        physics_client_id: int,
+        ee_home_pose: Pose3D = (1.35, 0.6, 0.7),
 ) -> SingleArmPyBulletRobot:
     """Create a single-arm PyBullet robot."""
+    ee_orientation = CFG.pybullet_robot_ee_orns[CFG.env][robot_name]
     if robot_name in _ROBOT_TO_CLS:
         assert robot_name in _ROBOT_TO_BASE_POSE, \
             f"Base pose not specified for robot {robot_name}."

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -112,6 +112,21 @@ class GlobalSettings:
     pybullet_birrt_smooth_amt = 50
     pybullet_birrt_extend_num_interp = 10
     pybullet_control_mode = "position"
+    pybullet_robot_ee_orns = {
+        # Fetch and Panda gripper down and parallel to x-axis.
+        "pybullet_cover": {
+            "fetch": (0.5, -0.5, -0.5, -0.5),
+            "panda": (0.7071, 0.7071, 0.0, 0.0),
+        },
+        "pybullet_blocks": {
+            # Fetch gripper down since it's thin we don't need to
+            # rotate 90 degrees.
+            "fetch": (0.7071, 0.0, -0.7071, 0.0),
+            # Panda gripper down and rotated 90 degrees as it's big
+            # and can cause collisions.
+            "panda": (0.7071, 0.7071, 0.0, 0.0),
+        },
+    }
 
     # IKFast parameters
     ikfast_max_time = 0.05

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -112,21 +112,21 @@ class GlobalSettings:
     pybullet_birrt_smooth_amt = 50
     pybullet_birrt_extend_num_interp = 10
     pybullet_control_mode = "position"
-    pybullet_robot_ee_orns = {
-        # Fetch and Panda gripper down and parallel to x-axis.
-        "pybullet_cover": {
+    # env -> robot -> quaternion
+    pybullet_robot_ee_orns = defaultdict(
+        # Fetch and Panda gripper down and parallel to x-axis by default.
+        lambda: {
             "fetch": (0.5, -0.5, -0.5, -0.5),
             "panda": (0.7071, 0.7071, 0.0, 0.0),
         },
-        "pybullet_blocks": {
-            # Fetch gripper down since it's thin we don't need to
-            # rotate 90 degrees.
-            "fetch": (0.7071, 0.0, -0.7071, 0.0),
-            # Panda gripper down and rotated 90 degrees as it's big
-            # and can cause collisions.
-            "panda": (0.7071, 0.7071, 0.0, 0.0),
-        },
-    }
+        # In Blocks, Fetch gripper down since it's thin we don't need to
+        # rotate 90 degrees.
+        {
+            "pybullet_blocks": {
+                "fetch": (0.7071, 0.0, -0.7071, 0.0),
+                "panda": (0.7071, 0.7071, 0.0, 0.0),
+            }
+        })
 
     # IKFast parameters
     ikfast_max_time = 0.05

--- a/tests/pybullet_helpers/test_pybullet_robots.py
+++ b/tests/pybullet_helpers/test_pybullet_robots.py
@@ -250,10 +250,9 @@ def test_create_single_arm_pybullet_robot(physics_client_id):
 def test_run_motion_planning(physics_client_id):
     """Tests for run_motion_planning()."""
     ee_home_pose = (1.35, 0.75, 0.75)
-    ee_orn = p.getQuaternionFromEuler([0.0, np.pi / 2, -np.pi])
     seed = 123
     robot = create_single_arm_pybullet_robot("fetch", physics_client_id,
-                                             ee_home_pose, ee_orn)
+                                             ee_home_pose)
     robot_init_state = tuple(ee_home_pose) + (robot.open_fingers, )
     robot.reset_state(robot_init_state)
     joint_initial = robot.get_joints()


### PR DESCRIPTION
should fix a bug in the kinematic action space converter where a bad default (0.0, 0.0, 0.0, 0.1) end effector rotation was getting used during IK (and the wrist was facing upward). also tries to head off similar issues in the future by making the default end effector rotation a global setting.