### PR TITLE
Hill-Climbing Effects Search over PNADs

### DIFF
--- a/predicators/nsrt_learning/strips_learning/base_strips_learner.py
+++ b/predicators/nsrt_learning/strips_learning/base_strips_learner.py
@@ -45,7 +45,10 @@ class BaseSTRIPSLearner(abc.ABC):
         learned_pnads = self._learn()
         if self._verify_harmlessness and not CFG.disable_harmlessness_check:
             logging.info("\nRunning harmlessness check...")
+            # try:
             assert self._check_harmlessness(learned_pnads)
+            # except AssertionError:
+            #     import ipdb; ipdb.set_trace()
         # Remove pnads by increasing min_data_perc until harmlessness breaks.
         if CFG.enable_harmless_op_pruning:
             assert self._verify_harmlessness

--- a/predicators/nsrt_learning/strips_learning/base_strips_learner.py
+++ b/predicators/nsrt_learning/strips_learning/base_strips_learner.py
@@ -45,10 +45,7 @@ class BaseSTRIPSLearner(abc.ABC):
         learned_pnads = self._learn()
         if self._verify_harmlessness and not CFG.disable_harmlessness_check:
             logging.info("\nRunning harmlessness check...")
-            # try:
             assert self._check_harmlessness(learned_pnads)
-            # except AssertionError:
-            #     import ipdb; ipdb.set_trace()
         # Remove pnads by increasing min_data_perc until harmlessness breaks.
         if CFG.enable_harmless_op_pruning:
             assert self._verify_harmlessness

--- a/predicators/nsrt_learning/strips_learning/effect_search_learner.py
+++ b/predicators/nsrt_learning/strips_learning/effect_search_learner.py
@@ -10,10 +10,9 @@ from typing import Callable, Dict, Iterator, List, Optional, Sequence, Set, \
 from predicators import utils
 from predicators.nsrt_learning.strips_learning.gen_to_spec_learner import \
     GeneralToSpecificSTRIPSLearner
-from predicators.structs import GroundAtom, LiftedAtom, LowLevelTrajectory, \
-    Object, OptionSpec, ParameterizedOption, PartialNSRTAndDatastore, \
-    Predicate, Segment, STRIPSOperator, Task, Variable, \
-    _GroundSTRIPSOperator
+from predicators.structs import GroundAtom, LowLevelTrajectory, Object, \
+    ParameterizedOption, PartialNSRTAndDatastore, Predicate, Segment, \
+    STRIPSOperator, Task, Variable, _GroundSTRIPSOperator
 
 # Necessary images and ground operators, in reverse order. Also, if the chain
 # is not full-length, then the "best" operator that backchaining tried to use
@@ -120,7 +119,9 @@ class _BackChainingEffectSearchOperator(_EffectSearchOperator):
             # corresponds to the new_pnad we just induced.
             newly_added_pnad = None
             for new_p in new_pnads:
-                if new_p.op.add_effects == new_pnad.op.add_effects and new_p.op.parameters == new_pnad.op.parameters and new_p.option_spec == new_pnad.option_spec:
+                if new_p.op.add_effects == new_pnad.op.add_effects and \
+                    new_p.op.parameters == new_pnad.op.parameters and \
+                    new_p.option_spec == new_pnad.option_spec:
                     newly_added_pnad = new_p
             assert newly_added_pnad is not None
             new_pnads_with_keep_effs = self._get_pnads_with_keep_effects(
@@ -162,8 +163,8 @@ class _BackChainingEffectSearchOperator(_EffectSearchOperator):
         # Now look for an uncovered segment. If one cannot be found, this
         # method will automatically return None.
         for depth in range(max_chain_len + 1):
-            for seg_traj, atoms_seq, traj_goal, chain in backchaining_results:
-                image_chain, op_chain, last_used_op = chain
+            for seg_traj, _, _, chain in backchaining_results:
+                _, op_chain, _ = chain
                 if not (len(op_chain) > depth
                         or len(op_chain) == len(seg_traj)):
                     # We found an uncovered transition: we now need to return
@@ -210,7 +211,8 @@ class _EffectSearchHeuristic(abc.ABC):
         self._segmented_trajs = segmented_trajs
         self._backchain = backchain
         self._recompute_pnads_from_effects = _recompute_pnads_from_effects
-        self._clear_unnecessary_keep_effs_subs = _clear_unnecessary_keep_effs_subs
+        self._clear_unnecessary_keep_effs_subs = \
+            _clear_unnecessary_keep_effs_subs
         # We compute the total number of segments, which is also the
         # maximum number of operators that we will induce (since, in
         # the worst case, we induce a different operator for every
@@ -338,9 +340,6 @@ class EffectSearchSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
         final_pnads = self._get_uniquely_named_nec_pnads(pnad_map)
         return final_pnads
 
-    # TODO: This code is literally the same as the superclass, except that
-    # we don't compute preconditions here. Is there a nicer SWE way to
-    # make this change without all this code duplication?
     @functools.lru_cache(maxsize=None)
     def _create_general_pnad_for_option(
             self, parameterized_option: ParameterizedOption
@@ -404,14 +403,6 @@ class EffectSearchSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
             # If no match found, terminate.
             if pnad is None:
                 break
-
-            # TODO: Understand why TF this assertion fails so much!
-            # # Assert that this segment is in the PNAD's datastore.
-            # segs_in_pnad = {
-            #     datapoint[0]
-            #     for datapoint in pnad.datastore
-            # }
-            # assert segment in segs_in_pnad
 
             assert var_to_obj is not None
             obj_to_var = {v: k for k, v in var_to_obj.items()}

--- a/predicators/nsrt_learning/strips_learning/effect_search_learner.py
+++ b/predicators/nsrt_learning/strips_learning/effect_search_learner.py
@@ -403,11 +403,9 @@ class EffectSearchSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
             segment.necessary_add_effects = necessary_image - atoms_seq[t]
             pnad, var_to_obj = self._find_best_matching_pnad_and_sub(
                 segment, objects, pnads)
-
             # If no match found, terminate.
             if pnad is None:
                 break
-
             assert var_to_obj is not None
             obj_to_var = {v: k for k, v in var_to_obj.items()}
             assert len(var_to_obj) == len(obj_to_var)

--- a/predicators/nsrt_learning/strips_learning/gen_to_spec_learner.py
+++ b/predicators/nsrt_learning/strips_learning/gen_to_spec_learner.py
@@ -144,7 +144,7 @@ class GeneralToSpecificSTRIPSLearner(BaseSTRIPSLearner):
 
         return new_pnads_with_keep_effects
 
-    def _reset_all_segment_add_effs(self) -> None:
+    def _reset_all_segment_necessary_add_effs(self) -> None:
         """Reset all segments' necessary_add_effects to None."""
         for ll_traj, seg_traj in zip(self._trajectories,
                                      self._segmented_trajs):
@@ -179,13 +179,14 @@ class GeneralToSpecificSTRIPSLearner(BaseSTRIPSLearner):
             pnad.seg_to_keep_effects_sub[segment].update(keep_eff_sub)
 
     @staticmethod
-    def clear_unnecessary_keep_effs_sub(pnad: PartialNSRTAndDatastore) -> None:
-        """Clear unnecessary substitution values from the PNAD's
-        seg_to_keep_effects_sub_dict.
+    def clear_unnecessary_keep_effs(pnad: PartialNSRTAndDatastore) -> None:
+        """Clear the poss_keep_effects, as well as unnecessary substitution
+        values from the PNAD's seg_to_keep_effects_sub_dict.
 
         A substitution is unnecessary if it concerns a variable that
         isn't in the PNAD's op parameters.
         """
+        pnad.poss_keep_effects.clear()
         for segment, keep_eff_sub in pnad.seg_to_keep_effects_sub.items():
             new_keep_eff_sub_dict = {}
             for var, obj in keep_eff_sub.items():
@@ -289,8 +290,7 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
             # method that handles this correctly.
             for pnads in param_opt_to_nec_pnads.values():
                 for pnad in pnads:
-                    pnad.poss_keep_effects.clear()
-                    self.clear_unnecessary_keep_effs_sub(pnad)
+                    self.clear_unnecessary_keep_effs(pnad)
             # Run one pass of backchaining.
             nec_pnad_set_changed = self._backchain_one_pass(
                 param_opt_to_nec_pnads)
@@ -309,7 +309,7 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
         """
         # Reset all segments' necessary_add_effects so that they aren't
         # accidentally used from a previous iteration of backchaining.
-        self._reset_all_segment_add_effs()
+        self._reset_all_segment_necessary_add_effs()
         nec_pnad_set_changed = False
         for ll_traj, seg_traj in zip(self._trajectories,
                                      self._segmented_trajs):

--- a/predicators/nsrt_learning/strips_learning/gen_to_spec_learner.py
+++ b/predicators/nsrt_learning/strips_learning/gen_to_spec_learner.py
@@ -45,6 +45,133 @@ class GeneralToSpecificSTRIPSLearner(BaseSTRIPSLearner):
 
         return pnad
 
+    def _spawn_new_pnad(self, segment: Segment) -> PartialNSRTAndDatastore:
+        """Given some segment with necessary add effects that a new PNAD must
+        achieve, create such a PNAD ("spawn" from the most general one
+        associated with the segment's option) so that it has the necessary add
+        effects contained in the given segment."""
+        # Create a general PNAD for the segment's option.
+        pnad = self._create_general_pnad_for_option(
+            segment.get_option().parent)
+        # Assert that this really is a general PNAD.
+        assert len(pnad.op.add_effects) == 0, \
+            "Can't spawn from non-general PNAD"
+        # Assert that the segment contains necessary_add_effects.
+        necessary_add_effects = segment.necessary_add_effects
+        assert necessary_add_effects is not None
+
+        # Get an arbitrary grounding of the PNAD's operator whose
+        # preconditions hold in segment.init_atoms.
+        objects = set(segment.states[0])
+        _, var_to_obj = self._find_best_matching_pnad_and_sub(
+            segment, objects, [pnad], check_only_preconditions=True)
+        # Assert that such a grounding exists - this must be the case
+        # since we only ever call this method with the most general
+        # PNAD for the option.
+        assert var_to_obj is not None
+        obj_to_var = {v: k for k, v in var_to_obj.items()}
+        assert len(var_to_obj) == len(obj_to_var)
+        # Before we can lift the necessary_add_effects, we need to add new
+        # entries to obj_to_var, since necessary_add_effects may
+        # contain objects that were not in the ground operator's
+        # parameters.
+        all_objs = {o for eff in necessary_add_effects for o in eff.objects}
+        missing_objs = sorted(all_objs - set(obj_to_var))
+        new_vars = utils.create_new_variables([o.type for o in missing_objs],
+                                              existing_vars=pnad.op.parameters)
+        obj_to_var.update(dict(zip(missing_objs, new_vars)))
+        # Finally, we can lift necessary_add_effects.
+        updated_params = sorted(obj_to_var.values())
+        updated_add_effects = {
+            a.lift(obj_to_var)
+            for a in necessary_add_effects
+        }
+
+        # Create a new PNAD with the given parameters and add effects. Set
+        # the preconditions to be trivial. They will be recomputed later.
+        new_pnad_op = pnad.op.copy_with(parameters=updated_params,
+                                        preconditions=set(),
+                                        add_effects=updated_add_effects)
+        new_pnad = PartialNSRTAndDatastore(new_pnad_op, [], pnad.option_spec)
+        # Note: we don't need to copy anything related to keep effects into
+        # new_pnad here, because we only care about keep effects on the final
+        # iteration of backchaining, where this function is never called.
+
+        return new_pnad
+
+    @staticmethod
+    def _get_pnads_with_keep_effects(
+            pnad: PartialNSRTAndDatastore) -> Set[PartialNSRTAndDatastore]:
+        """Return a new set of PNADs that include keep effects into the given
+        PNAD."""
+        # The keep effects that we want are the subset of possible keep
+        # effects which are not already in the PNAD's add effects, and
+        # whose predicates were either (i) determined to be ignore effects,
+        # or (ii) in the delete effects.
+        keep_effects = {
+            eff
+            for eff in pnad.poss_keep_effects
+            if eff not in pnad.op.add_effects and (
+                eff.predicate in pnad.op.ignore_effects
+                or eff in pnad.op.delete_effects)
+        }
+        new_pnads_with_keep_effects = set()
+        # Given these keep effects, we need to create a combinatorial number of
+        # PNADs, one for each unique combination of keep effects. Moreover, we
+        # need to ensure that they are named differently from each other. Some
+        # of these PNADs will be filtered out later if they are not useful to
+        # cover any datapoints.
+        for r in range(1, len(keep_effects) + 1):
+            for keep_effects_subset in itertools.combinations(keep_effects, r):
+                # These keep effects (keep_effects_subset) could involve new
+                # variables, which we need to add to the PNAD parameters.
+                params_set = set(pnad.op.parameters)
+                for eff in keep_effects_subset:
+                    for var in eff.variables:
+                        params_set.add(var)
+                parameters = sorted(params_set)
+                # The keep effects go into both the PNAD preconditions and the
+                # PNAD add effects.
+                preconditions = pnad.op.preconditions | set(
+                    keep_effects_subset)
+                add_effects = pnad.op.add_effects | set(keep_effects_subset)
+                # Create the new PNAD.
+                new_pnad_op = pnad.op.copy_with(parameters=parameters,
+                                                preconditions=preconditions,
+                                                add_effects=add_effects)
+                new_pnad = PartialNSRTAndDatastore(new_pnad_op, [],
+                                                   pnad.option_spec)
+                # Remember to copy seg_to_keep_effects_sub into the new_pnad!
+                new_pnad.seg_to_keep_effects_sub = pnad.seg_to_keep_effects_sub
+                new_pnads_with_keep_effects.add(new_pnad)
+
+        return new_pnads_with_keep_effects
+
+    def _reset_all_segment_add_effs(self) -> None:
+        """Reset all segments' necessary_add_effects to None."""
+        for ll_traj, seg_traj in zip(self._trajectories,
+                                     self._segmented_trajs):
+            if not ll_traj.is_demo:
+                continue
+            for segment in seg_traj:
+                segment.necessary_add_effects = None
+
+    @staticmethod
+    def _clear_unnecessary_keep_effs_sub(
+            pnad: PartialNSRTAndDatastore) -> None:
+        """Clear unnecessary substitution values from the PNAD's
+        seg_to_keep_effects_sub_dict.
+
+        A substitution is unnecessary if it concerns a variable that
+        isn't in the PNAD's op parameters.
+        """
+        for segment, keep_eff_sub in pnad.seg_to_keep_effects_sub.items():
+            new_keep_eff_sub_dict = {}
+            for var, obj in keep_eff_sub.items():
+                if var in pnad.op.parameters:
+                    new_keep_eff_sub_dict[var] = obj
+            pnad.seg_to_keep_effects_sub[segment] = new_keep_eff_sub_dict
+
 
 class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
     """Learn STRIPS operators by backchaining."""
@@ -354,136 +481,9 @@ class BackchainingSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
             param_opt_to_nec_pnads[option].extend(
                 list(pnads_with_keep_effects))
 
-    def _reset_all_segment_add_effs(self) -> None:
-        """Reset all segments' necessary_add_effects to None."""
-        for ll_traj, seg_traj in zip(self._trajectories,
-                                     self._segmented_trajs):
-            if not ll_traj.is_demo:
-                continue
-            for segment in seg_traj:
-                segment.necessary_add_effects = None
-
-    @staticmethod
-    def _clear_unnecessary_keep_effs_sub(
-            pnad: PartialNSRTAndDatastore) -> None:
-        """Clear unnecessary substitution values from the PNAD's
-        seg_to_keep_effects_sub_dict.
-
-        A substitution is unnecessary if it concerns a variable that
-        isn't in the PNAD's op parameters.
-        """
-        for segment, keep_eff_sub in pnad.seg_to_keep_effects_sub.items():
-            new_keep_eff_sub_dict = {}
-            for var, obj in keep_eff_sub.items():
-                if var in pnad.op.parameters:
-                    new_keep_eff_sub_dict[var] = obj
-            pnad.seg_to_keep_effects_sub[segment] = new_keep_eff_sub_dict
-
     @classmethod
     def get_name(cls) -> str:
         return "backchaining"
-
-    def _spawn_new_pnad(self, segment: Segment) -> PartialNSRTAndDatastore:
-        """Given some segment with necessary add effects that a new PNAD must
-        achieve, create such a PNAD ("spawn" from the most general one
-        associated with the segment's option) so that it has the necessary add
-        effects contained in the given segment."""
-        # Create a general PNAD for the segment's option.
-        pnad = self._create_general_pnad_for_option(
-            segment.get_option().parent)
-        # Assert that this really is a general PNAD.
-        assert len(pnad.op.add_effects) == 0, \
-            "Can't spawn from non-general PNAD"
-        # Assert that the segment contains necessary_add_effects.
-        necessary_add_effects = segment.necessary_add_effects
-        assert necessary_add_effects is not None
-
-        # Get an arbitrary grounding of the PNAD's operator whose
-        # preconditions hold in segment.init_atoms.
-        objects = set(segment.states[0])
-        _, var_to_obj = self._find_best_matching_pnad_and_sub(
-            segment, objects, [pnad], check_only_preconditions=True)
-        # Assert that such a grounding exists - this must be the case
-        # since we only ever call this method with the most general
-        # PNAD for the option.
-        assert var_to_obj is not None
-        obj_to_var = {v: k for k, v in var_to_obj.items()}
-        assert len(var_to_obj) == len(obj_to_var)
-        # Before we can lift the necessary_add_effects, we need to add new
-        # entries to obj_to_var, since necessary_add_effects may
-        # contain objects that were not in the ground operator's
-        # parameters.
-        all_objs = {o for eff in necessary_add_effects for o in eff.objects}
-        missing_objs = sorted(all_objs - set(obj_to_var))
-        new_vars = utils.create_new_variables([o.type for o in missing_objs],
-                                              existing_vars=pnad.op.parameters)
-        obj_to_var.update(dict(zip(missing_objs, new_vars)))
-        # Finally, we can lift necessary_add_effects.
-        updated_params = sorted(obj_to_var.values())
-        updated_add_effects = {
-            a.lift(obj_to_var)
-            for a in necessary_add_effects
-        }
-
-        # Create a new PNAD with the given parameters and add effects. Set
-        # the preconditions to be trivial. They will be recomputed later.
-        new_pnad_op = pnad.op.copy_with(parameters=updated_params,
-                                        preconditions=set(),
-                                        add_effects=updated_add_effects)
-        new_pnad = PartialNSRTAndDatastore(new_pnad_op, [], pnad.option_spec)
-        # Note: we don't need to copy anything related to keep effects into
-        # new_pnad here, because we only care about keep effects on the final
-        # iteration of backchaining, where this function is never called.
-
-        return new_pnad
-
-    @staticmethod
-    def _get_pnads_with_keep_effects(
-            pnad: PartialNSRTAndDatastore) -> Set[PartialNSRTAndDatastore]:
-        """Return a new set of PNADs that include keep effects into the given
-        PNAD."""
-        # The keep effects that we want are the subset of possible keep
-        # effects which are not already in the PNAD's add effects, and
-        # whose predicates were either (i) determined to be ignore effects,
-        # or (ii) in the delete effects.
-        keep_effects = {
-            eff
-            for eff in pnad.poss_keep_effects
-            if eff not in pnad.op.add_effects and (
-                eff.predicate in pnad.op.ignore_effects
-                or eff in pnad.op.delete_effects)
-        }
-        new_pnads_with_keep_effects = set()
-        # Given these keep effects, we need to create a combinatorial number of
-        # PNADs, one for each unique combination of keep effects. Moreover, we
-        # need to ensure that they are named differently from each other. Some
-        # of these PNADs will be filtered out later if they are not useful to
-        # cover any datapoints.
-        for r in range(1, len(keep_effects) + 1):
-            for keep_effects_subset in itertools.combinations(keep_effects, r):
-                # These keep effects (keep_effects_subset) could involve new
-                # variables, which we need to add to the PNAD parameters.
-                params_set = set(pnad.op.parameters)
-                for eff in keep_effects_subset:
-                    for var in eff.variables:
-                        params_set.add(var)
-                parameters = sorted(params_set)
-                # The keep effects go into both the PNAD preconditions and the
-                # PNAD add effects.
-                preconditions = pnad.op.preconditions | set(
-                    keep_effects_subset)
-                add_effects = pnad.op.add_effects | set(keep_effects_subset)
-                # Create the new PNAD.
-                new_pnad_op = pnad.op.copy_with(parameters=parameters,
-                                                preconditions=preconditions,
-                                                add_effects=add_effects)
-                new_pnad = PartialNSRTAndDatastore(new_pnad_op, [],
-                                                   pnad.option_spec)
-                # Remember to copy seg_to_keep_effects_sub into the new_pnad!
-                new_pnad.seg_to_keep_effects_sub = pnad.seg_to_keep_effects_sub
-                new_pnads_with_keep_effects.add(new_pnad)
-
-        return new_pnads_with_keep_effects
 
     def _assert_all_data_in_exactly_one_datastore(
             self, pnads: List[PartialNSRTAndDatastore]) -> None:

--- a/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
+++ b/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
@@ -1,4 +1,4 @@
-"""Learn operators by searching over sets of add PNAD sets."""
+"""Learn operators by searching over sets of PNADs."""
 
 from __future__ import annotations
 
@@ -73,7 +73,7 @@ class _BackChainingPNADSearchOperator(_PNADSearchOperator):
         # backchaining.
         for pnad in new_pnads:
             pnad.poss_keep_effects.clear()
-            self._learner.clear_unnecessary_keep_effs_sub(pnad)
+            self._learner.clear_unnecessary_keep_effs(pnad)
         # We rerun backchaining to make sure the seg_to_keep_effects_sub
         # is up-to-date.
         self._get_backchaining_results(new_pnads)
@@ -91,7 +91,7 @@ class _BackChainingPNADSearchOperator(_PNADSearchOperator):
         assert newly_added_pnad is not None
         new_pnads_with_keep_effs = self._learner.get_pnads_with_keep_effects(
             newly_added_pnad)
-        new_pnads += sorted(list(new_pnads_with_keep_effs))
+        new_pnads += sorted(new_pnads_with_keep_effs)
         # We recompute pnads again here to delete keep effect operators
         # that are unnecessary.
         new_pnads = self._learner.recompute_pnads_from_effects(new_pnads)
@@ -185,7 +185,7 @@ class _BackChainingHeuristic(_PNADSearchHeuristic):
                  curr_pnads: FrozenSet[PartialNSRTAndDatastore]) -> float:
         # Start by recomputing all PNADs from their effects.
         recomp_curr_pnads = self._learner.recompute_pnads_from_effects(
-            sorted(list(curr_pnads)))
+            sorted(curr_pnads))
         # Next, run backchaining using these PNADs.
         uncovered_transitions = 0
         for ll_traj, seg_traj in zip(self._trajectories,
@@ -217,7 +217,7 @@ class PNADSearchSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
 
     @classmethod
     def get_name(cls) -> str:
-        return "effect_search"
+        return "pnad_search"
 
     def recompute_pnads_from_effects(
             self, pnads: List[PartialNSRTAndDatastore]
@@ -285,7 +285,7 @@ class PNADSearchSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
         # Recompute these PNADs so that they exactly match the PNADs used
         # to compute the final heuristic.
         recomp_final_pnads = self.recompute_pnads_from_effects(
-            sorted(list(final_pnads)))
+            sorted(final_pnads))
         # Fix naming.
         pnad_map: Dict[ParameterizedOption, List[PartialNSRTAndDatastore]] = {
             p.option_spec[0]: []

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -1236,6 +1236,9 @@ class PartialNSRTAndDatastore:
     def __str__(self) -> str:
         return repr(self)
 
+    def __lt__(self, other: PartialNSRTAndDatastore) -> bool:
+        return repr(self) < repr(other)
+
 
 @dataclass(frozen=True, eq=False, repr=False)
 class InteractionRequest:

--- a/tests/nsrt_learning/strips_learning/test_backchaining_based_learners.py
+++ b/tests/nsrt_learning/strips_learning/test_backchaining_based_learners.py
@@ -150,9 +150,10 @@ def test_backchaining_strips_learner(approach_cls):
     assert str(pnads[0]) == repr(pnads[0]) == expected_str
 
 
-@pytest.mark.parametrize("approach_name,approach_cls",
-                         [("backchaining", _MockBackchainingSTRIPSLearner),
-                          ("effects_search", EffectSearchSTRIPSLearner)])
+@pytest.mark.parametrize(
+    "approach_name,approach_cls",
+    [("backchaining", _MockBackchainingSTRIPSLearner),
+    ("effects_search", EffectSearchSTRIPSLearner)])
 def test_backchaining_strips_learner_order_dependence(approach_name,
                                                       approach_cls):
     """Test that the BackchainingSTRIPSLearner and EffectSearchSTRIPSLearns are
@@ -1473,6 +1474,9 @@ def test_segment_not_in_datastore(approach_cls):
     "approach_cls,use_single_option,num_demos,seed_offset",
     itertools.product([EffectSearchSTRIPSLearner], [True, False], [1, 2, 3, 4],
                       range(250)))
+# @pytest.mark.parametrize(
+#     "approach_cls,use_single_option,num_demos,seed_offset",
+#     itertools.product([EffectSearchSTRIPSLearner], [True], [4], [131]))
 def test_backchaining_randomly_generated(approach_cls, use_single_option,
                                          num_demos, seed_offset):
     """Test the BackchainingSTRIPSLearner on randomly generated test cases."""

--- a/tests/nsrt_learning/strips_learning/test_backchaining_based_learners.py
+++ b/tests/nsrt_learning/strips_learning/test_backchaining_based_learners.py
@@ -150,10 +150,9 @@ def test_backchaining_strips_learner(approach_cls):
     assert str(pnads[0]) == repr(pnads[0]) == expected_str
 
 
-@pytest.mark.parametrize(
-    "approach_name,approach_cls",
-    [("backchaining", _MockBackchainingSTRIPSLearner),
-    ("effects_search", EffectSearchSTRIPSLearner)])
+@pytest.mark.parametrize("approach_name,approach_cls",
+                         [("backchaining", _MockBackchainingSTRIPSLearner),
+                          ("effects_search", EffectSearchSTRIPSLearner)])
 def test_backchaining_strips_learner_order_dependence(approach_name,
                                                       approach_cls):
     """Test that the BackchainingSTRIPSLearner and EffectSearchSTRIPSLearns are
@@ -1351,10 +1350,10 @@ def test_multi_pass_backchaining(approach_cls, val):
         assert str(pnad) in correct_pnads
 
 
-@pytest.mark.parametrize(
-    "approach_cls",
-    [_MockBackchainingSTRIPSLearner, EffectSearchSTRIPSLearner])
-def test_segment_not_in_datastore(approach_cls):
+@pytest.mark.parametrize("approach_name, approach_cls",
+                         [("backchaining", _MockBackchainingSTRIPSLearner),
+                          ("effect_search", EffectSearchSTRIPSLearner)])
+def test_segment_not_in_datastore(approach_name, approach_cls):
     """Test the BackchainingSTRIPSLearner and EffectSearchLearner on a case
     where they can cover a particular segment using an operator that doesn't
     have that segment in its datastore.
@@ -1425,10 +1424,14 @@ def test_segment_not_in_datastore(approach_cls):
                            verify_harmlessness=True)
     # Running this automatically checks that harmlessness passes.
     learned_pnads = learner.learn()
-    assert len(learned_pnads) == 4
-    # NOTE: Only 4 ops are necessary, but there are 5 here because
-    # the two different methods differ in one particular op
-    # (the third and fourth ops in this list).
+
+    # Backchaining requires 4 PNADs for harmlessness here, but effect search
+    # only requires 3.
+    if approach_name == "backchaining":
+        assert len(learned_pnads) == 4
+    else:
+        assert len(learned_pnads) == 3
+
     correct_pnads = [
         """STRIPS-Pick:
     Parameters: []
@@ -1438,15 +1441,15 @@ def test_segment_not_in_datastore(approach_cls):
     Ignore Effects: []
     Option Spec: Pick()""", """STRIPS-Pick:
     Parameters: []
-    Preconditions: [B(), D(), E()]
-    Add Effects: [A(), C()]
-    Delete Effects: [B(), E()]
+    Preconditions: []
+    Add Effects: [B()]
+    Delete Effects: [C(), D()]
     Ignore Effects: []
     Option Spec: Pick()""", """STRIPS-Pick:
     Parameters: []
-    Preconditions: [A(), C(), D()]
-    Add Effects: [A(), D()]
-    Delete Effects: [C()]
+    Preconditions: [B(), D(), E()]
+    Add Effects: [A(), C()]
+    Delete Effects: [B(), E()]
     Ignore Effects: []
     Option Spec: Pick()""", """STRIPS-Pick:
     Parameters: []
@@ -1472,11 +1475,9 @@ def test_segment_not_in_datastore(approach_cls):
 @longrun
 @pytest.mark.parametrize(
     "approach_cls,use_single_option,num_demos,seed_offset",
-    itertools.product([EffectSearchSTRIPSLearner], [True, False], [1, 2, 3, 4],
-                      range(250)))
-# @pytest.mark.parametrize(
-#     "approach_cls,use_single_option,num_demos,seed_offset",
-#     itertools.product([EffectSearchSTRIPSLearner], [True], [4], [131]))
+    itertools.product(
+        [_MockBackchainingSTRIPSLearner, EffectSearchSTRIPSLearner],
+        [True, False], [1, 2, 3, 4], range(250)))
 def test_backchaining_randomly_generated(approach_cls, use_single_option,
                                          num_demos, seed_offset):
     """Test the BackchainingSTRIPSLearner on randomly generated test cases."""

--- a/tests/nsrt_learning/strips_learning/test_backchaining_based_learners.py
+++ b/tests/nsrt_learning/strips_learning/test_backchaining_based_learners.py
@@ -54,7 +54,7 @@ class _MockBackchainingSTRIPSLearner(BackchainingSTRIPSLearner):
 
     def reset_all_segment_add_effs(self):
         """Exposed for testing."""
-        return self._reset_all_segment_add_effs()
+        return self._reset_all_segment_necessary_add_effs()
 
 
 @pytest.mark.parametrize(
@@ -308,7 +308,7 @@ def test_backchaining_strips_learner_order_dependence(approach_name,
     else:
         utils.reset_config({
             "approach": "nsrt_learning",
-            "strips_learner": "effect_search",
+            "strips_learner": "pnad_search",
             # Following are necessary to solve this case.
             "data_orderings_to_search": 1,
             "enable_harmless_op_pruning": False
@@ -1350,7 +1350,7 @@ def test_multi_pass_backchaining(approach_cls, val):
 
 @pytest.mark.parametrize("approach_name, approach_cls",
                          [("backchaining", _MockBackchainingSTRIPSLearner),
-                          ("effect_search", PNADSearchSTRIPSLearner)])
+                          ("pnad_search", PNADSearchSTRIPSLearner)])
 def test_segment_not_in_datastore(approach_name, approach_cls):
     """Test the BackchainingSTRIPSLearner and EffectSearchLearner on a case
     where they can cover a particular segment using an operator that doesn't

--- a/tests/nsrt_learning/strips_learning/test_backchaining_based_learners.py
+++ b/tests/nsrt_learning/strips_learning/test_backchaining_based_learners.py
@@ -296,9 +296,9 @@ def test_backchaining_strips_learner_order_dependence(approach_name,
         assert str(natural_order_pnads[i]) in correct_pnads
         assert str(reverse_order_pnads[i]) in correct_pnads
 
+    # Weird Case: This case shows that our algorithm is not data order
+    # invariant!
     if approach_name == "backchaining":
-        # Weird Case: This case shows that our algorithm is not data order
-        # invariant!
         utils.reset_config({
             "approach": "nsrt_learning",
             "strips_learner": "backchaining",
@@ -306,331 +306,328 @@ def test_backchaining_strips_learner_order_dependence(approach_name,
             "data_orderings_to_search": 10,
             "enable_harmless_op_pruning": True
         })
-        # Agent features are loc: 0, 1, 2, 3 [start, shelf1, shelf2, far away];
-        # holding: True or False whether an object is in hand
-        agent_type = Type("agent_type", ["loc", "holding"])
-        agent = agent_type("agent")
-        # Hardback features are loc: -1, 0, 1, 2, 3 [in_hand, start, shelf1,
-        # shelf2, far away]
-        hardback_type = Type(
-            "hardback_type",
-            ["loc"])  # loc: -1, 0, 1, 2 [in_hand, start, shelf1, shelf2]
-        hardback1 = hardback_type("hardback1")
-        hardback2 = hardback_type("hardback2")
-        book1 = hardback_type("book1")
-        # Shelf features are loc: 2 (only a shelf at location two)
-        shelf_type = Type("shelf_type", ["loc"])
-        shelf = shelf_type("shelf")
-        # Predicates
-        NextTo = Predicate(
-            "NextTo", [hardback_type],
-            lambda s, o: s[o[0]][0] == s[agent][0] or
-            (s[o[0]][0] in [1, 2] and s[agent][0] in [1, 2]))
-        NextToShelf = Predicate("NextToShelf", [shelf_type],
-                                lambda s, o: s[agent][0] == 2)
-        HandEmpty = Predicate("HandEmpty", [], lambda s, o: not s[agent][1])
-        Holding = Predicate("Holding", [hardback_type],
-                            lambda s, o: s[o[0]][0] == -1)
-        OnTop = Predicate("OnTop", [hardback_type, shelf_type],
-                          lambda s, o: s[o[0]][0] == s[o[1]][0])
-        preds = {NextTo, NextToShelf, HandEmpty, Holding, OnTop}
+    else:
+        utils.reset_config({
+            "approach": "nsrt_learning",
+            "strips_learner": "effect_search",
+            # Following are necessary to solve this case.
+            "data_orderings_to_search": 1,
+            "enable_harmless_op_pruning": False
+        })
+    # Agent features are loc: 0, 1, 2, 3 [start, shelf1, shelf2, far away];
+    # holding: True or False whether an object is in hand
+    agent_type = Type("agent_type", ["loc", "holding"])
+    agent = agent_type("agent")
+    # Hardback features are loc: -1, 0, 1, 2, 3 [in_hand, start, shelf1,
+    # shelf2, far away]
+    hardback_type = Type(
+        "hardback_type",
+        ["loc"])  # loc: -1, 0, 1, 2 [in_hand, start, shelf1, shelf2]
+    hardback1 = hardback_type("hardback1")
+    hardback2 = hardback_type("hardback2")
+    book1 = hardback_type("book1")
+    # Shelf features are loc: 2 (only a shelf at location two)
+    shelf_type = Type("shelf_type", ["loc"])
+    shelf = shelf_type("shelf")
+    # Predicates
+    NextTo = Predicate(
+        "NextTo", [hardback_type], lambda s, o: s[o[0]][0] == s[agent][0] or
+        (s[o[0]][0] in [1, 2] and s[agent][0] in [1, 2]))
+    NextToShelf = Predicate("NextToShelf", [shelf_type],
+                            lambda s, o: s[agent][0] == 2)
+    HandEmpty = Predicate("HandEmpty", [], lambda s, o: not s[agent][1])
+    Holding = Predicate("Holding", [hardback_type],
+                        lambda s, o: s[o[0]][0] == -1)
+    OnTop = Predicate("OnTop", [hardback_type, shelf_type],
+                      lambda s, o: s[o[0]][0] == s[o[1]][0])
+    preds = {NextTo, NextToShelf, HandEmpty, Holding, OnTop}
 
-        # Agent not holding anything at location 0, hardbacks at loaction 1,
-        # and shelf at location 2
-        state1 = State({
-            agent: [0, False],
-            book1: [3],
-            hardback1: [1],
-            hardback2: [1],
-            shelf: [2]
-        })
-        # Agent moves to location 1
-        state2 = State({
-            agent: [1, False],
-            book1: [3],
-            hardback1: [1],
-            hardback2: [1],
-            shelf: [2]
-        })
-        # Agent grabs hardback1
-        state3 = State({
-            agent: [1, True],
-            book1: [3],
-            hardback1: [-1],
-            hardback2: [1],
-            shelf: [2]
-        })
-        # Agent moves to location 2
-        state4 = State({
-            agent: [2, True],
-            book1: [3],
-            hardback1: [-1],
-            hardback2: [1],
-            shelf: [2]
-        })
-        # Agent places hardback1
-        state5 = State({
-            agent: [2, False],
-            book1: [3],
-            hardback1: [2],
-            hardback2: [1],
-            shelf: [2]
-        })
-        # Agent moves to location 1
-        state6 = State({
-            agent: [1, False],
-            book1: [3],
-            hardback1: [2],
-            hardback2: [1],
-            shelf: [2]
-        })
-        # Agent grabs hardback2
-        state7 = State({
-            agent: [1, True],
-            book1: [3],
-            hardback1: [2],
-            hardback2: [-1],
-            shelf: [2]
-        })
-        # Agent moves to location 2
-        state8 = State({
-            agent: [2, True],
-            book1: [3],
-            hardback1: [2],
-            hardback2: [-1],
-            shelf: [2]
-        })
-        # Agent places hardback2
-        state9 = State({
-            agent: [2, False],
-            book1: [3],
-            hardback1: [2],
-            hardback2: [2],
-            shelf: [2]
-        })
+    # Agent not holding anything at location 0, hardbacks at loaction 1,
+    # and shelf at location 2
+    state1 = State({
+        agent: [0, False],
+        book1: [3],
+        hardback1: [1],
+        hardback2: [1],
+        shelf: [2]
+    })
+    # Agent moves to location 1
+    state2 = State({
+        agent: [1, False],
+        book1: [3],
+        hardback1: [1],
+        hardback2: [1],
+        shelf: [2]
+    })
+    # Agent grabs hardback1
+    state3 = State({
+        agent: [1, True],
+        book1: [3],
+        hardback1: [-1],
+        hardback2: [1],
+        shelf: [2]
+    })
+    # Agent moves to location 2
+    state4 = State({
+        agent: [2, True],
+        book1: [3],
+        hardback1: [-1],
+        hardback2: [1],
+        shelf: [2]
+    })
+    # Agent places hardback1
+    state5 = State({
+        agent: [2, False],
+        book1: [3],
+        hardback1: [2],
+        hardback2: [1],
+        shelf: [2]
+    })
+    # Agent moves to location 1
+    state6 = State({
+        agent: [1, False],
+        book1: [3],
+        hardback1: [2],
+        hardback2: [1],
+        shelf: [2]
+    })
+    # Agent grabs hardback2
+    state7 = State({
+        agent: [1, True],
+        book1: [3],
+        hardback1: [2],
+        hardback2: [-1],
+        shelf: [2]
+    })
+    # Agent moves to location 2
+    state8 = State({
+        agent: [2, True],
+        book1: [3],
+        hardback1: [2],
+        hardback2: [-1],
+        shelf: [2]
+    })
+    # Agent places hardback2
+    state9 = State({
+        agent: [2, False],
+        book1: [3],
+        hardback1: [2],
+        hardback2: [2],
+        shelf: [2]
+    })
 
-        # States for second trajectory
-        # Agent moves to location 3
-        state10 = State({
-            agent: [3, False],
-            book1: [3],
-            hardback1: [1],
-            hardback2: [1],
-            shelf: [2]
-        })
-        # Agent grabs book1 at location 3
-        state11 = State({
-            agent: [3, True],
-            book1: [-1],
-            hardback1: [1],
-            hardback2: [1],
-            shelf: [2]
-        })
-        # Agent moves to location 2
-        state12 = State({
-            agent: [2, True],
-            book1: [-1],
-            hardback1: [1],
-            hardback2: [1],
-            shelf: [2]
-        })
-        # Agent places hardback1
-        state13 = State({
-            agent: [2, False],
-            book1: [2],
-            hardback1: [1],
-            hardback2: [1],
-            shelf: [2]
-        })
+    # States for second trajectory
+    # Agent moves to location 3
+    state10 = State({
+        agent: [3, False],
+        book1: [3],
+        hardback1: [1],
+        hardback2: [1],
+        shelf: [2]
+    })
+    # Agent grabs book1 at location 3
+    state11 = State({
+        agent: [3, True],
+        book1: [-1],
+        hardback1: [1],
+        hardback2: [1],
+        shelf: [2]
+    })
+    # Agent moves to location 2
+    state12 = State({
+        agent: [2, True],
+        book1: [-1],
+        hardback1: [1],
+        hardback2: [1],
+        shelf: [2]
+    })
+    # Agent places hardback1
+    state13 = State({
+        agent: [2, False],
+        book1: [2],
+        hardback1: [1],
+        hardback2: [1],
+        shelf: [2]
+    })
 
-        moveto_param_option = utils.ParameterizedOption(
-            "MoveTo", [hardback_type],
-            policy=lambda s, m, o, p: Action(p),
-            params_space=Box(0.1, 1, (1, )),
-            initiable=lambda _1, _2, _3, _4: True,
-            terminal=lambda _1, _2, _3, _4: True)
-        moveto_option = moveto_param_option.ground([hardback1],
-                                                   np.array([0.5]))
-        assert moveto_option.initiable(state1)
-        moveto_hard2 = moveto_option.policy(state1)
-        moveto_hard2.set_option(moveto_option)
-        pick_param_option = utils.ParameterizedOption(
-            "Pick", [hardback_type],
-            policy=lambda s, m, o, p: Action(p),
-            params_space=Box(0.1, 1, (1, )),
-            initiable=lambda _1, _2, _3, _4: True,
-            terminal=lambda _1, _2, _3, _4: True)
-        pick_option = pick_param_option.ground([hardback1], np.array([0.5]))
-        assert pick_option.initiable(state2)
-        pick_hard2 = pick_option.policy(state2)
-        pick_hard2.set_option(pick_option)
-        movetoshelf_param_option = utils.ParameterizedOption(
-            "MoveToShelf", [shelf_type],
-            policy=lambda s, m, o, p: Action(p),
-            params_space=Box(0.1, 1, (1, )),
-            initiable=lambda _1, _2, _3, _4: True,
-            terminal=lambda _1, _2, _3, _4: True)
-        movetoshelf_option = movetoshelf_param_option.ground([shelf],
-                                                             np.array([0.5]))
-        assert movetoshelf_option.initiable(state3)
-        movetoshelf1 = movetoshelf_option.policy(state3)
-        movetoshelf1.set_option(movetoshelf_option)
-        place_param_option = utils.ParameterizedOption(
-            "Place", [hardback_type, shelf_type],
-            policy=lambda s, m, o, p: Action(p),
-            params_space=Box(0.1, 1, (1, )),
-            initiable=lambda _1, _2, _3, _4: True,
-            terminal=lambda _1, _2, _3, _4: True)
-        place_option = place_param_option.ground([hardback1, shelf],
-                                                 np.array([0.5]))
-        assert place_option.initiable(state4)
-        place_hard2 = place_option.policy(state4)
-        place_hard2.set_option(place_option)
-        moveto_option_2 = moveto_param_option.ground([hardback2],
-                                                     np.array([0.5]))
-        assert moveto_option_2.initiable(state5)
-        moveto_hard1 = moveto_option_2.policy(state5)
-        moveto_hard1.set_option(moveto_option_2)
-        pick_option_2 = pick_param_option.ground([hardback2], np.array([0.5]))
-        assert pick_option_2.initiable(state6)
-        pick_hard1 = pick_option_2.policy(state6)
-        pick_hard1.set_option(pick_option_2)
-        movetoshelf_option_2 = movetoshelf_param_option.ground([shelf],
-                                                               np.array([0.5]))
-        assert movetoshelf_option_2.initiable(state7)
-        movetoshelf2 = movetoshelf_option_2.policy(state7)
-        movetoshelf2.set_option(movetoshelf_option_2)
-        place_option_2 = place_param_option.ground([hardback2, shelf],
-                                                   np.array([0.5]))
-        assert place_option_2.initiable(state8)
-        place_hard1 = place_option_2.policy(state8)
-        place_hard1.set_option(place_option_2)
+    moveto_param_option = utils.ParameterizedOption(
+        "MoveTo", [hardback_type],
+        policy=lambda s, m, o, p: Action(p),
+        params_space=Box(0.1, 1, (1, )),
+        initiable=lambda _1, _2, _3, _4: True,
+        terminal=lambda _1, _2, _3, _4: True)
+    moveto_option = moveto_param_option.ground([hardback1], np.array([0.5]))
+    assert moveto_option.initiable(state1)
+    moveto_hard2 = moveto_option.policy(state1)
+    moveto_hard2.set_option(moveto_option)
+    pick_param_option = utils.ParameterizedOption(
+        "Pick", [hardback_type],
+        policy=lambda s, m, o, p: Action(p),
+        params_space=Box(0.1, 1, (1, )),
+        initiable=lambda _1, _2, _3, _4: True,
+        terminal=lambda _1, _2, _3, _4: True)
+    pick_option = pick_param_option.ground([hardback1], np.array([0.5]))
+    assert pick_option.initiable(state2)
+    pick_hard2 = pick_option.policy(state2)
+    pick_hard2.set_option(pick_option)
+    movetoshelf_param_option = utils.ParameterizedOption(
+        "MoveToShelf", [shelf_type],
+        policy=lambda s, m, o, p: Action(p),
+        params_space=Box(0.1, 1, (1, )),
+        initiable=lambda _1, _2, _3, _4: True,
+        terminal=lambda _1, _2, _3, _4: True)
+    movetoshelf_option = movetoshelf_param_option.ground([shelf],
+                                                         np.array([0.5]))
+    assert movetoshelf_option.initiable(state3)
+    movetoshelf1 = movetoshelf_option.policy(state3)
+    movetoshelf1.set_option(movetoshelf_option)
+    place_param_option = utils.ParameterizedOption(
+        "Place", [hardback_type, shelf_type],
+        policy=lambda s, m, o, p: Action(p),
+        params_space=Box(0.1, 1, (1, )),
+        initiable=lambda _1, _2, _3, _4: True,
+        terminal=lambda _1, _2, _3, _4: True)
+    place_option = place_param_option.ground([hardback1, shelf],
+                                             np.array([0.5]))
+    assert place_option.initiable(state4)
+    place_hard2 = place_option.policy(state4)
+    place_hard2.set_option(place_option)
+    moveto_option_2 = moveto_param_option.ground([hardback2], np.array([0.5]))
+    assert moveto_option_2.initiable(state5)
+    moveto_hard1 = moveto_option_2.policy(state5)
+    moveto_hard1.set_option(moveto_option_2)
+    pick_option_2 = pick_param_option.ground([hardback2], np.array([0.5]))
+    assert pick_option_2.initiable(state6)
+    pick_hard1 = pick_option_2.policy(state6)
+    pick_hard1.set_option(pick_option_2)
+    movetoshelf_option_2 = movetoshelf_param_option.ground([shelf],
+                                                           np.array([0.5]))
+    assert movetoshelf_option_2.initiable(state7)
+    movetoshelf2 = movetoshelf_option_2.policy(state7)
+    movetoshelf2.set_option(movetoshelf_option_2)
+    place_option_2 = place_param_option.ground([hardback2, shelf],
+                                               np.array([0.5]))
+    assert place_option_2.initiable(state8)
+    place_hard1 = place_option_2.policy(state8)
+    place_hard1.set_option(place_option_2)
 
-        moveto_option_3 = moveto_param_option.ground([book1], np.array([0.5]))
-        assert moveto_option_3.initiable(state1)
-        moveto_book1 = moveto_option_3.policy(state1)
-        moveto_book1.set_option(moveto_option_3)
-        pick_option_3 = pick_param_option.ground([book1], np.array([0.5]))
-        assert pick_option_3.initiable(state2)
-        pick_book1 = pick_option_3.policy(state2)
-        pick_book1.set_option(pick_option_3)
-        movetoshelf_option_3 = movetoshelf_param_option.ground([shelf],
-                                                               np.array([0.5]))
-        assert movetoshelf_option_3.initiable(state10)
-        movetoshelf2 = movetoshelf_option_3.policy(state10)
-        movetoshelf2.set_option(movetoshelf_option_3)
-        place_option_3 = place_param_option.ground([book1, shelf],
-                                                   np.array([0.5]))
-        assert place_option_3.initiable(state11)
-        place_book1 = place_option_3.policy(state11)
-        place_book1.set_option(place_option_3)
+    moveto_option_3 = moveto_param_option.ground([book1], np.array([0.5]))
+    assert moveto_option_3.initiable(state1)
+    moveto_book1 = moveto_option_3.policy(state1)
+    moveto_book1.set_option(moveto_option_3)
+    pick_option_3 = pick_param_option.ground([book1], np.array([0.5]))
+    assert pick_option_3.initiable(state2)
+    pick_book1 = pick_option_3.policy(state2)
+    pick_book1.set_option(pick_option_3)
+    movetoshelf_option_3 = movetoshelf_param_option.ground([shelf],
+                                                           np.array([0.5]))
+    assert movetoshelf_option_3.initiable(state10)
+    movetoshelf2 = movetoshelf_option_3.policy(state10)
+    movetoshelf2.set_option(movetoshelf_option_3)
+    place_option_3 = place_param_option.ground([book1, shelf], np.array([0.5]))
+    assert place_option_3.initiable(state11)
+    place_book1 = place_option_3.policy(state11)
+    place_book1.set_option(place_option_3)
 
-        # Two Tasks: (1) place both close books on top shelf and (2) place
-        # book1 on top of shelf
-        goal1 = set([
-            GroundAtom(OnTop, [hardback1, shelf]),
-            GroundAtom(OnTop, [hardback2, shelf])
-        ])
-        goal2 = set([GroundAtom(OnTop, [book1, shelf])])
-        task1 = Task(init=state1, goal=goal1)
-        task2 = Task(init=state1, goal=goal2)
-        traj1 = LowLevelTrajectory([
-            state1, state2, state3, state4, state5, state6, state7, state8,
-            state9
-        ], [
-            moveto_hard2, pick_hard2, movetoshelf1, place_hard2, moveto_hard1,
-            pick_hard1, movetoshelf2, place_hard1
-        ], True, 0)
-        traj2 = LowLevelTrajectory(
-            [state1, state10, state11, state12, state13],
-            [moveto_book1, pick_book1, movetoshelf1, place_book1], True, 1)
-        ground_atom_trajs = utils.create_ground_atom_dataset([traj1, traj2],
-                                                             preds)
-        segmented_trajs = [
-            segment_trajectory(traj) for traj in ground_atom_trajs
-        ]
-        # Now, run the learner on the demo.
-        learner = _MockBackchainingSTRIPSLearner([traj1, traj2],
-                                                 [task1, task2],
-                                                 preds,
-                                                 segmented_trajs,
-                                                 verify_harmlessness=True)
-        natural_order_pnads = learner.learn()
-        action_space = Box(0, 1, (1, ))
-        dataset = [traj1, traj2]
-        train_tasks = [task1, task2]
-        options = {
-            moveto_param_option, pick_param_option, movetoshelf_param_option,
-            place_param_option
-        }
-        ground_atom_dataset = utils.create_ground_atom_dataset(dataset, preds)
-        natural_order_nsrts, _, _ = learn_nsrts_from_data(
-            dataset,
-            train_tasks,
-            preds,
-            options,
-            action_space,
-            ground_atom_dataset,
-            sampler_learner="random")
+    # Two Tasks: (1) place both close books on top shelf and (2) place
+    # book1 on top of shelf
+    goal1 = set([
+        GroundAtom(OnTop, [hardback1, shelf]),
+        GroundAtom(OnTop, [hardback2, shelf])
+    ])
+    goal2 = set([GroundAtom(OnTop, [book1, shelf])])
+    task1 = Task(init=state1, goal=goal1)
+    task2 = Task(init=state1, goal=goal2)
+    traj1 = LowLevelTrajectory([
+        state1, state2, state3, state4, state5, state6, state7, state8, state9
+    ], [
+        moveto_hard2, pick_hard2, movetoshelf1, place_hard2, moveto_hard1,
+        pick_hard1, movetoshelf2, place_hard1
+    ], True, 0)
+    traj2 = LowLevelTrajectory(
+        [state1, state10, state11, state12, state13],
+        [moveto_book1, pick_book1, movetoshelf1, place_book1], True, 1)
+    ground_atom_trajs = utils.create_ground_atom_dataset([traj1, traj2], preds)
+    segmented_trajs = [segment_trajectory(traj) for traj in ground_atom_trajs]
+    # Now, run the learner on the demo.
+    learner = approach_cls([traj1, traj2], [task1, task2],
+                           preds,
+                           segmented_trajs,
+                           verify_harmlessness=True)
+    natural_order_pnads = learner.learn()
+    action_space = Box(0, 1, (1, ))
+    dataset = [traj1, traj2]
+    train_tasks = [task1, task2]
+    options = {
+        moveto_param_option, pick_param_option, movetoshelf_param_option,
+        place_param_option
+    }
+    ground_atom_dataset = utils.create_ground_atom_dataset(dataset, preds)
+    natural_order_nsrts, _, _ = learn_nsrts_from_data(dataset,
+                                                      train_tasks,
+                                                      preds,
+                                                      options,
+                                                      action_space,
+                                                      ground_atom_dataset,
+                                                      sampler_learner="random")
 
-        traj1 = LowLevelTrajectory([
-            state1, state2, state3, state4, state5, state6, state7, state8,
-            state9
-        ], [
-            moveto_hard2, pick_hard2, movetoshelf1, place_hard2, moveto_hard1,
-            pick_hard1, movetoshelf2, place_hard1
-        ], True, 1)
-        traj2 = LowLevelTrajectory(
-            [state1, state10, state11, state12, state13],
-            [moveto_book1, pick_book1, movetoshelf1, place_book1], True, 0)
-        ground_atom_trajs = utils.create_ground_atom_dataset([traj2, traj1],
-                                                             preds)
-        segmented_trajs = [
-            segment_trajectory(traj) for traj in ground_atom_trajs
-        ]
-        # Now, create and run the learner with the 3 demos in the reverse order.
-        learner = _MockBackchainingSTRIPSLearner([traj2, traj1],
-                                                 [task2, task1],
-                                                 preds,
-                                                 segmented_trajs,
-                                                 verify_harmlessness=True)
+    traj1 = LowLevelTrajectory([
+        state1, state2, state3, state4, state5, state6, state7, state8, state9
+    ], [
+        moveto_hard2, pick_hard2, movetoshelf1, place_hard2, moveto_hard1,
+        pick_hard1, movetoshelf2, place_hard1
+    ], True, 1)
+    traj2 = LowLevelTrajectory(
+        [state1, state10, state11, state12, state13],
+        [moveto_book1, pick_book1, movetoshelf1, place_book1], True, 0)
+    ground_atom_trajs = utils.create_ground_atom_dataset([traj2, traj1], preds)
+    segmented_trajs = [segment_trajectory(traj) for traj in ground_atom_trajs]
+    # Now, create and run the learner with the 3 demos in the reverse order.
+    learner = approach_cls([traj2, traj1], [task2, task1],
+                           preds,
+                           segmented_trajs,
+                           verify_harmlessness=True)
+    if approach_name == "backchaining":
         # Be sure to reset the segment add effects before doing this.
         learner.reset_all_segment_add_effs()
-        reverse_order_pnads = learner.learn()
-        action_space = Box(0, 1, (1, ))
-        dataset = [traj2, traj1]
-        train_tasks = [task2, task1]
-        options = {
-            moveto_param_option, pick_param_option, movetoshelf_param_option,
-            place_param_option
-        }
-        ground_atom_dataset = utils.create_ground_atom_dataset(dataset, preds)
-        reverse_order_nsrts, _, _ = learn_nsrts_from_data(
-            dataset,
-            train_tasks,
-            preds,
-            options,
-            action_space,
-            ground_atom_dataset,
-            sampler_learner="random")
+    reverse_order_pnads = learner.learn()
+    action_space = Box(0, 1, (1, ))
+    dataset = [traj2, traj1]
+    train_tasks = [task2, task1]
+    options = {
+        moveto_param_option, pick_param_option, movetoshelf_param_option,
+        place_param_option
+    }
+    ground_atom_dataset = utils.create_ground_atom_dataset(dataset, preds)
+    reverse_order_nsrts, _, _ = learn_nsrts_from_data(dataset,
+                                                      train_tasks,
+                                                      preds,
+                                                      options,
+                                                      action_space,
+                                                      ground_atom_dataset,
+                                                      sampler_learner="random")
 
-        # First, check that the two sets of PNADs have the same number of PNADs.
-        # Uh oh, they don't
+    # First, check that the two sets of PNADs have the same number of PNADs.
+    # (in the case of EffectSearch).
+    if approach_name == "backchaining":
+        # Uh oh, they don't (in the case of Backchaining).
         assert len(natural_order_pnads) != len(reverse_order_pnads)
-        # Second, check that the two sets of NSRTs have the same number of
-        # NSRTs.
-        # They do! Because our NSRTs were learned with dataset reordering and
-        # harmless operator pruning, as opposed to our PNADs which were learned
-        # with our _MockBackchainingSTRIPSLearner that does not have these
-        # additions.
-        assert len(natural_order_nsrts) == len(reverse_order_nsrts)
-        # Lastly, check whether the natural order nsrts we generate are the
-        # same as the (correct) reverse_order_pnads.
-        for nsrt in natural_order_nsrts:
-            # Rename the output NSRT operators to standardize naming
-            # and make comparison easier.
-            op = nsrt.op.copy_with(name=nsrt.option.name + "0")
-            assert op in set(pnad.op for pnad in reverse_order_pnads)
+    else:
+        assert len(natural_order_pnads) == len(reverse_order_pnads)
+    # Second, check that the two sets of NSRTs have the same number of
+    # NSRTs.
+    # They do! Because our NSRTs were learned with dataset reordering and
+    # harmless operator pruning, as opposed to our PNADs which were learned
+    # with our _MockBackchainingSTRIPSLearner that does not have these
+    # additions.
+    assert len(natural_order_nsrts) == len(reverse_order_nsrts)
+    # Lastly, check whether the natural order nsrts we generate are the
+    # same as the (correct) reverse_order_pnads.
+    for nsrt in natural_order_nsrts:
+        # Rename the output NSRT operators to standardize naming
+        # and make comparison easier.
+        op = nsrt.op.copy_with(name=nsrt.option.name + "0")
+        assert op in set(pnad.op for pnad in reverse_order_pnads)
 
 
 def test_spawn_new_pnad():
@@ -1034,8 +1031,11 @@ def test_combinatorial_keep_effect_data_partitioning(approach_name,
                            segmented_trajs,
                            verify_harmlessness=True)
     output_pnads = learner.learn()
-    # We need 7 PNADs: 4 for configure, and 1 each for turn on, run, and fix.
-    assert len(output_pnads) == 7
+    # We need 6 or 7 PNADs: 3 or 4 for configure, and 1 each for turn on,
+    # run, and fix.
+    # NOTE: Backchaining learns 7 different operators, but effect search
+    # learns only 6 (and both lead to harmlessness on the training data)!
+    assert len(output_pnads) in [6, 7]
     correct_pnads = set([
         """STRIPS-Run:
     Parameters: [?x0:machine_type]
@@ -1350,9 +1350,9 @@ def test_multi_pass_backchaining(approach_cls, val):
         assert str(pnad) in correct_pnads
 
 
-# NOTE: Will update in the future to also run the EffectSearchLearner
-# here. Currently, it just doesn't work.
-@pytest.mark.parametrize("approach_cls", [_MockBackchainingSTRIPSLearner])
+@pytest.mark.parametrize(
+    "approach_cls",
+    [_MockBackchainingSTRIPSLearner, EffectSearchSTRIPSLearner])
 def test_segment_not_in_datastore(approach_cls):
     """Test the BackchainingSTRIPSLearner and EffectSearchLearner on a case
     where they can cover a particular segment using an operator that doesn't
@@ -1424,6 +1424,10 @@ def test_segment_not_in_datastore(approach_cls):
                            verify_harmlessness=True)
     # Running this automatically checks that harmlessness passes.
     learned_pnads = learner.learn()
+    assert len(learned_pnads) == 4
+    # NOTE: Only 4 ops are necessary, but there are 5 here because
+    # the two different methods differ in one particular op
+    # (the third and fourth ops in this list).
     correct_pnads = [
         """STRIPS-Pick:
     Parameters: []
@@ -1436,6 +1440,12 @@ def test_segment_not_in_datastore(approach_cls):
     Preconditions: [B(), D(), E()]
     Add Effects: [A(), C()]
     Delete Effects: [B(), E()]
+    Ignore Effects: []
+    Option Spec: Pick()""", """STRIPS-Pick:
+    Parameters: []
+    Preconditions: [A(), C(), D()]
+    Add Effects: [A(), D()]
+    Delete Effects: [C()]
     Ignore Effects: []
     Option Spec: Pick()""", """STRIPS-Pick:
     Parameters: []
@@ -1459,11 +1469,12 @@ def test_segment_not_in_datastore(approach_cls):
 
 
 @longrun
-@pytest.mark.parametrize("use_single_option,num_demos,seed_offset",
-                         itertools.product([True, False], [1, 2, 3, 4],
-                                           range(250)))
-def test_backchaining_randomly_generated(use_single_option, num_demos,
-                                         seed_offset):
+@pytest.mark.parametrize(
+    "approach_cls,use_single_option,num_demos,seed_offset",
+    itertools.product([EffectSearchSTRIPSLearner], [True, False], [1, 2, 3, 4],
+                      range(250)))
+def test_backchaining_randomly_generated(approach_cls, use_single_option,
+                                         num_demos, seed_offset):
     """Test the BackchainingSTRIPSLearner on randomly generated test cases."""
     utils.reset_config({
         "segmenter": "atom_changes",
@@ -1603,10 +1614,10 @@ def test_backchaining_randomly_generated(use_single_option, num_demos,
     segmented_trajs = [segment_trajectory(traj) for traj in ground_atom_trajs]
 
     # Now, run the learner on the demos.
-    learner = _MockBackchainingSTRIPSLearner(trajs,
-                                             tasks,
-                                             predicates,
-                                             segmented_trajs,
-                                             verify_harmlessness=True)
+    learner = approach_cls(trajs,
+                           tasks,
+                           predicates,
+                           segmented_trajs,
+                           verify_harmlessness=True)
     # Running this automatically checks that harmlessness passes.
     learner.learn()


### PR DESCRIPTION
This PR introduces a sweeping set of changes to simplify the `EffectSearchSTRIPSLearner`. The primary goal here is to get rid of the `EffectSets` class and just search over PNADs, since we realized this allows us to achieve the same functionality. Some other major changes include:

- The `GeneralToSpecificSTRIPSLearner` class now has a number of methods (e.g. for spawning a new PNAD, creating PNADs with keep effects, etc.) that previously lived in the `BackchainingSTRIPSLearner` class. This is to enable sharing these methods with the `EffectSearchSTRIPSLearner`.
- Consequently, the `EffectSearchSTRIPSLearner` is now a subclass of the `GeneralToSpecificSTRIPSLearner`.
- The heuristic/score function for effects search now has a complexity term (previously, it only had a coverage term). The terms are weighted such that an optimizer will always prefer improving coverage to reducing complexity.
- We induce keep effects in the same way as the `BackchainingSTRIPSLearner` (i.e, by inducing a combinatorial set and then partitioning data to tell us which ones to actually keep around).
- The tests have been updated so that they test both the `BackchainingSTRIPSLearner` and the `EffectSearchSTRIPSLearner`. Our new learner is able to pass all tests that backchaining can (unfortunately, Rohan's longrun randomly-generated tests are still currently failing).

Example command:
```
python predicators/main.py --env repeated_nextto_ambiguous --approach nsrt_learning --seed 0 --strips_learner effect_search
```