### PR TITLE
convert max vel norm to setting

### DIFF
--- a/predicators/envs/pybullet_env.py
+++ b/predicators/envs/pybullet_env.py
@@ -25,7 +25,6 @@ class PyBulletEnv(BaseEnv):
     # Parameters that aren't important enough to need to clog up settings.py
 
     # General robot parameters.
-    _max_vel_norm: ClassVar[float] = 0.05
     _grasp_tol: ClassVar[float] = 0.05
     _finger_action_tol: ClassVar[float] = 1e-4
     _finger_action_nudge_magnitude: ClassVar[float] = 1e-3
@@ -56,6 +55,9 @@ class PyBulletEnv(BaseEnv):
 
     def __init__(self, use_gui: bool = True) -> None:
         super().__init__(use_gui)
+
+        # Controls the maximum end effector change between time steps.
+        self._max_vel_norm = CFG.pybullet_max_vel_norm
 
         # When an object is held, a constraint is created to prevent slippage.
         self._held_constraint_id: Optional[int] = None

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -113,6 +113,7 @@ class GlobalSettings:
     pybullet_birrt_smooth_amt = 50
     pybullet_birrt_extend_num_interp = 10
     pybullet_control_mode = "position"
+    pybullet_max_vel_norm = 0.05
     # env -> robot -> quaternion
     pybullet_robot_ee_orns = defaultdict(
         # Fetch and Panda gripper down and parallel to x-axis by default.


### PR DESCRIPTION
example:

```python predicators/main.py --env pybullet_blocks --approach oracle --seed 0 --use_gui --pybullet_robot panda --make_test_videos --pybullet_camera_width 1674 --pybullet_camera_height 900 --pybullet_control_mode reset --pybullet_max_vel_norm 100000```

https://user-images.githubusercontent.com/2816502/202010135-3432d203-bd34-4f85-b2f2-3498a756e2f4.mp4

the lagging is a separate issue (#1296) that is also on master. the command gets 50/50

note that we shouldn't change the defaults because with "position" control mode, you need a small max_vel_norm, otherwise physics leads to chaos
