### PR TITLE
allow PG3 init approach to suggest multiple initial LDLs

### DIFF
--- a/predicators/approaches/pg3_approach.py
+++ b/predicators/approaches/pg3_approach.py
@@ -99,8 +99,9 @@ class PG3Approach(NSRTLearningApproach):
         # The heuristic is what distinguishes PG3 from baseline approaches.
         heuristic = self._create_heuristic()
 
-        # Initialize the search.
-        initial_state = self._get_policy_search_initial_ldl()
+        # Initialize the search with the best candidate.
+        candidate_initial_states = self._get_policy_search_initial_ldls()
+        initial_state = min(candidate_initial_states, key=heuristic)
 
         def get_successors(ldl: _S) -> Iterator[Tuple[_A, _S, float]]:
             for op in search_operators:
@@ -173,10 +174,10 @@ class PG3Approach(NSRTLearningApproach):
         return cls(preds, nsrts, self._train_tasks)
 
     @staticmethod
-    def _get_policy_search_initial_ldl() -> LiftedDecisionList:
+    def _get_policy_search_initial_ldls() -> List[LiftedDecisionList]:
         # Initialize with an empty list by default, but subclasses may
         # override.
-        return LiftedDecisionList([])
+        return [LiftedDecisionList([])]
 
 
 ############################## Search Operators ###############################

--- a/tests/approaches/test_initialized_pg3_approach.py
+++ b/tests/approaches/test_initialized_pg3_approach.py
@@ -60,7 +60,9 @@ def test_initialized_pg3_approach():
                                       env.action_space, train_tasks)
     assert approach.get_name() == "initialized_pg3"
 
-    assert approach._get_policy_search_initial_ldl() == ldl  # pylint: disable=protected-access
+    init_ldls = approach._get_policy_search_initial_ldls()  # pylint: disable=protected-access
+    assert len(init_ldls) == 1
+    assert init_ldls[0] == ldl
 
     # Test loading from file.
     ldl_str = """(define (policy delivery-individual-policy)
@@ -101,8 +103,9 @@ def test_initialized_pg3_approach():
         })
     approach = InitializedPG3Approach(env.predicates, env.options, env.types,
                                       env.action_space, train_tasks)
-    init_ldl = approach._get_policy_search_initial_ldl()  # pylint: disable=protected-access
-    assert str(init_ldl) == """LiftedDecisionList[
+    init_ldls = approach._get_policy_search_initial_ldls()  # pylint: disable=protected-access
+    assert len(init_ldls) == 1
+    assert str(init_ldls[0]) == """LiftedDecisionList[
 LDLRule-rule1:
     Parameters: [?loc:loc, ?paper:paper]
     Pos State Pre: [at(?loc:loc), ishomebase(?loc:loc), unpacked(?paper:paper)]


### PR DESCRIPTION
this is because we want to consider multiple analogical mappings. for now we just use the "best" initial LDL according to the heuristic and discard the rest, but in the future we may instead want to initialize the search with all candidates. that would require a deeper code change because the heuristic search utility functions all assume a single initial state.