### PR TITLE
Recomputes PNADs after 'delete' operator during hill-climbing

### DIFF
--- a/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
+++ b/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
@@ -144,9 +144,10 @@ class _PruningPNADSearchOperator(_PNADSearchOperator):
     def get_successors(
         self, pnads: FrozenSet[PartialNSRTAndDatastore]
     ) -> Iterator[FrozenSet[PartialNSRTAndDatastore]]:
-        for pnad_to_remove in sorted(pnads):
+        sorted_pnad_list = sorted(pnads)
+        for pnad_to_remove in sorted_pnad_list:
             pnads_after_removal = [
-                pnad for pnad in sorted(pnads) if pnad != pnad_to_remove
+                pnad for pnad in sorted_pnad_list if pnad != pnad_to_remove
             ]
             recomp_pnads = self._learner.recompute_pnads_from_effects(
                 pnads_after_removal)
@@ -208,7 +209,7 @@ class _BackChainingHeuristic(_PNADSearchHeuristic):
         # accurate measures that also take into account the add effects,
         # arity, etc. (though this might involve changing the weighting
         # of the coverage term).
-        complexity_term = len(sorted(curr_pnads))
+        complexity_term = len(curr_pnads)
         return coverage_term + complexity_term
 
 

--- a/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
+++ b/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
@@ -145,8 +145,11 @@ class _PruningPNADSearchOperator(_PNADSearchOperator):
         self, pnads: FrozenSet[PartialNSRTAndDatastore]
     ) -> Iterator[FrozenSet[PartialNSRTAndDatastore]]:
         for pnad_to_remove in sorted(pnads):
-            pnads_after_removal = [pnad for pnad in sorted(pnads) if pnad != pnad_to_remove]
-            recomp_pnads = self._learner.recompute_pnads_from_effects(pnads_after_removal)
+            pnads_after_removal = [
+                pnad for pnad in sorted(pnads) if pnad != pnad_to_remove
+            ]
+            recomp_pnads = self._learner.recompute_pnads_from_effects(
+                pnads_after_removal)
             yield frozenset(recomp_pnads)
 
 

--- a/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
+++ b/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
@@ -144,10 +144,10 @@ class _PruningPNADSearchOperator(_PNADSearchOperator):
     def get_successors(
         self, pnads: FrozenSet[PartialNSRTAndDatastore]
     ) -> Iterator[FrozenSet[PartialNSRTAndDatastore]]:
-        # NOTE: Sorting done here to maintain determinism.
-        for pnad_to_remove in sorted(pnads,
-                                     key=lambda p: len(p.op.add_effects)):
-            yield frozenset([pnad for pnad in pnads if pnad != pnad_to_remove])
+        for pnad_to_remove in sorted(pnads):
+            pnads_after_removal = [pnad for pnad in sorted(pnads) if pnad != pnad_to_remove]
+            recomp_pnads = self._learner.recompute_pnads_from_effects(pnads_after_removal)
+            yield frozenset(recomp_pnads)
 
 
 class _PNADSearchHeuristic(abc.ABC):
@@ -183,16 +183,13 @@ class _BackChainingHeuristic(_PNADSearchHeuristic):
 
     def __call__(self,
                  curr_pnads: FrozenSet[PartialNSRTAndDatastore]) -> float:
-        # Start by recomputing all PNADs from their effects.
-        recomp_curr_pnads = self._learner.recompute_pnads_from_effects(
-            sorted(curr_pnads))
         # Next, run backchaining using these PNADs.
         uncovered_transitions = 0
         for ll_traj, seg_traj in zip(self._trajectories,
                                      self._segmented_trajs):
             if ll_traj.is_demo:
                 traj_goal = self._train_tasks[ll_traj.train_task_idx].goal
-                chain = self._learner.backchain(seg_traj, recomp_curr_pnads,
+                chain = self._learner.backchain(seg_traj, sorted(curr_pnads),
                                                 traj_goal)
                 assert len(chain) <= len(seg_traj)
                 uncovered_transitions += len(seg_traj) - len(chain)
@@ -208,7 +205,7 @@ class _BackChainingHeuristic(_PNADSearchHeuristic):
         # accurate measures that also take into account the add effects,
         # arity, etc. (though this might involve changing the weighting
         # of the coverage term).
-        complexity_term = len(recomp_curr_pnads)
+        complexity_term = len(sorted(curr_pnads))
         return coverage_term + complexity_term
 
 
@@ -282,8 +279,8 @@ class PNADSearchSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
 
         # Extract the best PNADs set.
         final_pnads = path[-1]
-        # Recompute these PNADs so that they exactly match the PNADs used
-        # to compute the final heuristic.
+        # NOTE: Unclear why the below call is necessary... To be investigated.
+        # Recompute these PNADs.
         recomp_final_pnads = self.recompute_pnads_from_effects(
             sorted(final_pnads))
         # Fix naming.


### PR DESCRIPTION
Previously, we always just deleted PNADs during hill-climbing to form a new PNAD set without recomputing them. Rather, we'd always recompute when we started to compute our heuristic. But it makes much more sense to recompute after deletion instead.