### PR TITLE
check for changes in assumedly static objects during planning 

### DIFF
--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -323,6 +323,8 @@ class GlobalSettings:
     # OpenLid() operator in painting. So, we'll keep the former as the
     # default.
     sesame_grounder = "naive"
+    sesame_check_static_object_changes = False
+    sesame_static_object_change_tol = 1e-3
 
     # evaluation parameters
     log_dir = "logs"

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -325,6 +325,7 @@ class GlobalSettings:
     # default.
     sesame_grounder = "naive"
     sesame_check_static_object_changes = False
+    # Warning: making this tolerance any lower breaks pybullet_blocks.
     sesame_static_object_change_tol = 1e-3
 
     # evaluation parameters

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -289,7 +289,6 @@ def test_sesame_plan_uninitiable_option():
 
 def test_sesame_check_static_object_changes():
     """Tests for sesame_check_static_object_changes = True."""
-    # pylint: disable=protected-access
     utils.reset_config({
         "env": "cover",
         "sesame_check_static_object_changes": True,

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -10,6 +10,7 @@ from gym.spaces import Box
 from predicators import utils
 from predicators.approaches import ApproachFailure, ApproachTimeout
 from predicators.approaches.oracle_approach import OracleApproach
+from predicators.envs.blocks import BlocksEnv
 from predicators.envs.cover import CoverEnv
 from predicators.envs.painting import PaintingEnv
 from predicators.envs.repeated_nextto import RepeatedNextToSingleOptionEnv
@@ -284,6 +285,59 @@ def test_sesame_plan_uninitiable_option():
             CFG.sesame_max_skeletons_optimized,
             max_horizon=CFG.horizon)
     assert "Planning reached max_skeletons_optimized!" in str(e.value)
+
+
+def test_sesame_check_static_object_changes():
+    """Tests for sesame_check_static_object_changes = True."""
+    # pylint: disable=protected-access
+    utils.reset_config({
+        "env": "cover",
+        "sesame_check_static_object_changes": True,
+        "sesame_static_object_change_tol": 1e-3,
+    })
+    env = CoverEnv()
+    nsrts = get_gt_nsrts(env.get_name(), env.predicates, env.options)
+    task = env.get_test_tasks()[0]
+    option_model = create_option_model(CFG.option_model_name)
+    # In Cover, the NSRTs do not contain the robot as an argument, so planning
+    # is not possible if we are checking for static object changes.
+    with pytest.raises(PlanningFailure) as e:
+        # Planning should reach sesame_max_skeletons_optimized
+        sesame_plan(
+            task,
+            option_model,
+            nsrts,
+            env.predicates,
+            env.types,
+            500,  # timeout
+            123,  # seed
+            CFG.sesame_task_planning_heuristic,
+            CFG.sesame_max_skeletons_optimized,
+            max_horizon=CFG.horizon)
+    assert "Planning reached max_skeletons_optimized!" in str(e.value)
+    # In Blocks, the NSRTs are fully scoped, so planning should succeed even
+    # when sesame_check_static_object_changes is True.
+    utils.reset_config({
+        "env": "blocks",
+        "sesame_check_static_object_changes": True,
+        "sesame_static_object_change_tol": 1e-3,
+    })
+    env = BlocksEnv()
+    nsrts = get_gt_nsrts(env.get_name(), env.predicates, env.options)
+    task = env.get_test_tasks()[0]
+    option_model = create_option_model(CFG.option_model_name)
+    plan, _ = sesame_plan(
+        task,
+        option_model,
+        nsrts,
+        env.predicates,
+        env.types,
+        500,  # timeout
+        123,  # seed
+        CFG.sesame_task_planning_heuristic,
+        CFG.sesame_max_skeletons_optimized,
+        max_horizon=CFG.horizon)
+    assert len(plan) > 0
 
 
 def test_planning_determinism():


### PR DESCRIPTION
intended for use in pybullet blocks (real robot experiments). this should prevent us from finding plans that have major collisions between the robot and neighboring blocks. 

the `1e-3` tolerance can't be lower because things appear to slightly move around on their own in pybullet.

default to False because some environments (e.g., Cover) don't obey this assumption about skill scope.

