### PR TITLE
`--crash_on_failure` flag 

### DIFF
--- a/predicators/args.py
+++ b/predicators/args.py
@@ -40,4 +40,5 @@ def create_arg_parser(env_required: bool = True,
                         dest="loglevel",
                         const=logging.DEBUG,
                         default=logging.INFO)
+    parser.add_argument("--crash_on_failure", action="store_true")
     return parser

--- a/predicators/main.py
+++ b/predicators/main.py
@@ -278,6 +278,8 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
                     CFG.horizon)
                 outfile = f"{save_prefix}__task{test_task_idx+1}_failure.mp4"
                 utils.save_video(outfile, video)
+            if CFG.crash_on_failure:
+                raise e
             continue
         solve_time = time.perf_counter() - solve_start
         metrics[f"PER_TASK_task{test_task_idx}_solve_time"] = solve_time
@@ -333,6 +335,8 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
         else:
             if not caught_exception:
                 log_message = "Policy failed to reach goal"
+            if CFG.crash_on_failure:
+                raise RuntimeError(log_message)
             make_video = CFG.make_failure_videos
             video_file = f"{save_prefix}__task{test_task_idx+1}_failure.mp4"
         logging.info(f"Task {test_task_idx+1} / {len(test_tasks)}: "

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -178,6 +178,21 @@ def test_main():
         "--predicate_mlp_classifier_max_itr", "lambda n: n * 50"
     ]
     main()
+    # Tests for --crash_on_failure flag.
+    sys.argv = [
+        "dummy", "--env", "cover", "--approach", "oracle", "--seed", "123",
+        "--num_test_tasks", "3", "--timeout", "0", "--crash_on_failure"
+    ]
+    with pytest.raises(ApproachTimeout) as e:
+        main()  # should time out
+    assert "Planning timed out in grounding!" in str(e)
+    sys.argv = [
+        "dummy", "--env", "cover", "--approach", "random_actions", "--seed",
+        "123", "--num_test_tasks", "3", "--crash_on_failure"
+    ]
+    with pytest.raises(RuntimeError) as e:
+        main()  # should fail to solve the task
+    assert "Policy failed to reach goal" in str(e)
 
 
 def test_bilevel_planning_approach_failure_and_timeout():


### PR DESCRIPTION
will be useful for real robot pipeline where we don't want to continue if planning fails