### PR TITLE
convert blocks workspace assertion to warning

### DIFF
--- a/predicators/envs/blocks.py
+++ b/predicators/envs/blocks.py
@@ -8,6 +8,7 @@ environment makes it a good testbed for predicate invention.
 """
 
 import json
+import logging
 from pathlib import Path
 from typing import ClassVar, Dict, List, Optional, Sequence, Set, Tuple
 
@@ -544,9 +545,10 @@ class BlocksEnv(BaseEnv):
             id_to_obj[block_id] = block
             x, y, z = block_spec["position"]
             # Make sure that the block is in bounds.
-            assert self.x_lb <= x <= self.x_ub, "x out of bounds in init state"
-            assert self.y_lb <= y <= self.y_ub, "y out of bounds in init state"
-            assert self.table_height <= z, "z out of bounds in init state"
+            if not (self.x_lb <= x <= self.x_ub and \
+                    self.y_lb <= y <= self.y_ub and \
+                    self.table_height <= z):
+                logging.warn("Block out of bounds in initial state!")
             r, g, b = block_spec["color"]
             state_dict[block] = {
                 "pose_x": x,

--- a/tests/envs/test_blocks.py
+++ b/tests/envs/test_blocks.py
@@ -3,12 +3,16 @@
 import json
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
 import pytest
 
+import predicators.envs.blocks
 from predicators import utils
 from predicators.envs.blocks import BlocksEnv
+
+_MODULE_PATH = predicators.envs.blocks.__name__
 
 
 def test_blocks():
@@ -190,7 +194,7 @@ robby              1.35      0.75       0.7          1
         sorted(task.goal)
     ) == "[On(green_block:block, blue_block:block), On(red_block:block, green_block:block), OnTable(blue_block:block)]"
 
-    # Test that an assertion is hit if we try to load from a state where the
+    # Test that a warning is raised if we try to load from a state where the
     # blocks are not in the workspace.
     task_spec = {
         "problem_name": "blocks_test_problem2",
@@ -207,18 +211,21 @@ robby              1.35      0.75       0.7          1
         }
     }
 
-    with tempfile.TemporaryDirectory() as json_dir:
-        json_file = Path(json_dir) / "example_task2.json"
-        with open(json_file, "w", encoding="utf-8") as f:
-            json.dump(task_spec, f)
+    with patch(f"{_MODULE_PATH}.logging") as mock_logging:
 
-        utils.reset_config({
-            "env": "blocks",
-            "num_test_tasks": 1,
-            "blocks_test_task_json_dir": json_dir
-        })
+        with tempfile.TemporaryDirectory() as json_dir:
+            json_file = Path(json_dir) / "example_task2.json"
+            with open(json_file, "w", encoding="utf-8") as f:
+                json.dump(task_spec, f)
 
-        env = BlocksEnv()
-        with pytest.raises(AssertionError) as e:
+            utils.reset_config({
+                "env": "blocks",
+                "num_test_tasks": 1,
+                "blocks_test_task_json_dir": json_dir
+            })
+
+            env = BlocksEnv()
             env.get_test_tasks()
-        assert "x out of bounds in init state" in str(e)
+
+    mock_logging.warn.assert_called_once_with(
+        "Block out of bounds in initial state!")


### PR DESCRIPTION
the assertion crash is annoying if we're using the pybullet blocks simulator to plan, but it's still useful to get the warning, especially in the case where we're actually using the original blocks simulator to plan.