### PR TITLE
added refinement cost estimator classes and refinement_estimation approach

### DIFF
--- a/predicators/approaches/refinement_estimation_approach.py
+++ b/predicators/approaches/refinement_estimation_approach.py
@@ -1,0 +1,64 @@
+"""A bilevel planning approach that uses a refinement cost estimator.
+
+Generates N proposed skeletons and then ranks them based on a given
+refinement cost estimation function (e.g. a heuristic, learned model),
+attempting to refine them in this order.
+"""
+
+from typing import Any, List, Set, Tuple
+
+from gym.spaces import Box
+
+from predicators.approaches.bilevel_planning_approach import \
+    BilevelPlanningApproach
+from predicators.ground_truth_nsrts import get_gt_nsrts
+from predicators.refinement_estimators import create_refinement_estimator
+from predicators.settings import CFG
+from predicators.structs import NSRT, Metrics, ParameterizedOption, \
+    Predicate, Task, Type, _Option
+
+
+class RefinementEstimationApproach(BilevelPlanningApproach):
+    """A bilevel planning approach that uses a refinement cost estimator."""
+
+    def __init__(self,
+                 initial_predicates: Set[Predicate],
+                 initial_options: Set[ParameterizedOption],
+                 types: Set[Type],
+                 action_space: Box,
+                 train_tasks: List[Task],
+                 task_planning_heuristic: str = "default",
+                 max_skeletons_optimized: int = -1) -> None:
+        super().__init__(initial_predicates, initial_options, types,
+                         action_space, train_tasks, task_planning_heuristic,
+                         max_skeletons_optimized)
+        self._nsrts = get_gt_nsrts(CFG.env, self._initial_predicates,
+                                   self._initial_options)
+        self._refinement_estimator = create_refinement_estimator(
+            CFG.refinement_estimator)
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "refinement_estimation"
+
+    @property
+    def is_learning_based(self) -> bool:
+        return False
+
+    def _get_current_nsrts(self) -> Set[NSRT]:
+        return self._nsrts
+
+    def _run_sesame_plan(self, task: Task, nsrts: Set[NSRT],
+                         preds: Set[Predicate], timeout: float, seed: int,
+                         **kwargs: Any) -> Tuple[List[_Option], Metrics]:
+        """Generates a plan choosing the best skeletons based on a given
+        refinement cost estimator."""
+        result = super()._run_sesame_plan(
+            task,
+            nsrts,
+            preds,
+            timeout,
+            seed,
+            refinement_estimator=self._refinement_estimator,
+            **kwargs)
+        return result

--- a/predicators/approaches/refinement_estimation_approach.py
+++ b/predicators/approaches/refinement_estimation_approach.py
@@ -9,16 +9,14 @@ from typing import Any, List, Set, Tuple
 
 from gym.spaces import Box
 
-from predicators.approaches.bilevel_planning_approach import \
-    BilevelPlanningApproach
-from predicators.ground_truth_nsrts import get_gt_nsrts
+from predicators.approaches.oracle_approach import OracleApproach
 from predicators.refinement_estimators import create_refinement_estimator
 from predicators.settings import CFG
 from predicators.structs import NSRT, Metrics, ParameterizedOption, \
     Predicate, Task, Type, _Option
 
 
-class RefinementEstimationApproach(BilevelPlanningApproach):
+class RefinementEstimationApproach(OracleApproach):
     """A bilevel planning approach that uses a refinement cost estimator."""
 
     def __init__(self,
@@ -32,21 +30,16 @@ class RefinementEstimationApproach(BilevelPlanningApproach):
         super().__init__(initial_predicates, initial_options, types,
                          action_space, train_tasks, task_planning_heuristic,
                          max_skeletons_optimized)
-        self._nsrts = get_gt_nsrts(CFG.env, self._initial_predicates,
-                                   self._initial_options)
+        assert (CFG.refinement_estimation_num_skeletons_generated <=
+                CFG.sesame_max_skeletons_optimized), \
+               "refinement_estimation_num_skeletons_generated should not be" \
+               "greater than sesame_max_skeletons_optimized"
         self._refinement_estimator = create_refinement_estimator(
             CFG.refinement_estimator)
 
     @classmethod
     def get_name(cls) -> str:
         return "refinement_estimation"
-
-    @property
-    def is_learning_based(self) -> bool:
-        return False
-
-    def _get_current_nsrts(self) -> Set[NSRT]:
-        return self._nsrts
 
     def _run_sesame_plan(self, task: Task, nsrts: Set[NSRT],
                          preds: Set[Predicate], timeout: float, seed: int,

--- a/predicators/planning.py
+++ b/predicators/planning.py
@@ -192,7 +192,7 @@ def _sesame_plan_with_astar(
                         break
                 gen = iter(
                     sorted(proposed_skeletons,
-                           key=lambda s: estimator.get_cost(s[0])))
+                           key=lambda s: estimator.get_cost(*s)))
             for skeleton, atoms_sequence in gen:
                 necessary_atoms_seq = utils.compute_necessary_atoms_seq(
                     skeleton, atoms_sequence, task.goal)

--- a/predicators/planning.py
+++ b/predicators/planning.py
@@ -23,6 +23,7 @@ import numpy as np
 
 from predicators import utils
 from predicators.option_model import _OptionModelBase
+from predicators.refinement_estimators import BaseRefinementEstimator
 from predicators.settings import CFG
 from predicators.structs import NSRT, AbstractPolicy, DefaultState, \
     DummyOption, GroundAtom, Metrics, Object, OptionSpec, \
@@ -56,6 +57,7 @@ def sesame_plan(
         max_horizon: int,
         abstract_policy: Optional[AbstractPolicy] = None,
         max_policy_guided_rollout: int = 0,
+        refinement_estimator: Optional[BaseRefinementEstimator] = None,
         check_dr_reachable: bool = True,
         allow_noops: bool = False,
         use_visited_state_set: bool = False) -> Tuple[List[_Option], Metrics]:
@@ -73,8 +75,8 @@ def sesame_plan(
         return _sesame_plan_with_astar(
             task, option_model, nsrts, predicates, types, timeout, seed,
             task_planning_heuristic, max_skeletons_optimized, max_horizon,
-            abstract_policy, max_policy_guided_rollout, check_dr_reachable,
-            allow_noops, use_visited_state_set)
+            abstract_policy, max_policy_guided_rollout, refinement_estimator,
+            check_dr_reachable, allow_noops, use_visited_state_set)
     if CFG.sesame_task_planner == "fdopt":
         assert abstract_policy is None
         return _sesame_plan_with_fast_downward(task,
@@ -114,6 +116,7 @@ def _sesame_plan_with_astar(
         max_horizon: int,
         abstract_policy: Optional[AbstractPolicy] = None,
         max_policy_guided_rollout: int = 0,
+        refinement_estimator: Optional[BaseRefinementEstimator] = None,
         check_dr_reachable: bool = True,
         allow_noops: bool = False,
         use_visited_state_set: bool = False) -> Tuple[List[_Option], Metrics]:
@@ -175,6 +178,21 @@ def _sesame_plan_with_astar(
                 timeout - (time.perf_counter() - start_time), metrics,
                 max_skeletons_optimized, abstract_policy,
                 max_policy_guided_rollout, use_visited_state_set)
+            # If a refinement cost estimator is provided, generate a number of
+            # skeletons first, then predict the refinement cost of each skeleton
+            # and attempt to refine them in this order.
+            if refinement_estimator is not None:
+                estimator: BaseRefinementEstimator = refinement_estimator
+                proposed_skeletons = []
+                for _ in range(
+                        CFG.refinement_estimation_num_skeletons_generated):
+                    try:
+                        proposed_skeletons.append(next(gen))
+                    except _MaxSkeletonsFailure:
+                        break
+                gen = iter(
+                    sorted(proposed_skeletons,
+                           key=lambda s: estimator.get_cost(s[0])))
             for skeleton, atoms_sequence in gen:
                 necessary_atoms_seq = utils.compute_necessary_atoms_seq(
                     skeleton, atoms_sequence, task.goal)

--- a/predicators/refinement_estimators/__init__.py
+++ b/predicators/refinement_estimators/__init__.py
@@ -1,0 +1,30 @@
+"""Handle creation of refinement cost estimators."""
+
+import importlib
+import pkgutil
+from typing import TYPE_CHECKING
+
+from predicators import utils
+from predicators.refinement_estimators.base_refinement_estimator import \
+    BaseRefinementEstimator
+
+__all__ = ["BaseRefinementEstimator", "create_refinement_estimator"]
+
+if not TYPE_CHECKING:
+    # Load all modules so that utils.get_all_subclasses() works.
+    for _, module_name, _ in pkgutil.walk_packages(__path__):
+        if "__init__" not in module_name:
+            # Important! We use an absolute import here to avoid issues
+            # with isinstance checking when using relative imports.
+            importlib.import_module(f"{__name__}.{module_name}")
+
+
+def create_refinement_estimator(name: str) -> BaseRefinementEstimator:
+    """Create an approach given its name."""
+    for cls in utils.get_all_subclasses(BaseRefinementEstimator):
+        if not cls.__abstractmethods__ and cls.get_name() == name:
+            estimator = cls()
+            break
+    else:
+        raise NotImplementedError(f"Unknown refinement cost estimator: {name}")
+    return estimator

--- a/predicators/refinement_estimators/base_refinement_estimator.py
+++ b/predicators/refinement_estimators/base_refinement_estimator.py
@@ -1,10 +1,9 @@
 """Base class for a refinement cost estimator."""
 
 import abc
-from typing import List
+from typing import List, Set
 
-from predicators.structs import _GroundNSRT
-from predicators.utils import ExceptionWithInfo
+from predicators.structs import GroundAtom, _GroundNSRT
 
 
 class BaseRefinementEstimator(abc.ABC):
@@ -18,11 +17,7 @@ class BaseRefinementEstimator(abc.ABC):
         raise NotImplementedError("Override me!")
 
     @abc.abstractmethod
-    def get_cost(self, skeleton: List[_GroundNSRT]) -> float:
+    def get_cost(self, skeleton: List[_GroundNSRT],
+                 atoms_sequence: List[Set[GroundAtom]]) -> float:
         """Return an estimated cost for a proposed high-level skeleton."""
         raise NotImplementedError("Override me!")
-
-
-class RefinementCostEstimationFailure(ExceptionWithInfo):
-    """Exception raised when refinement cost estimation fails for some
-    reason."""

--- a/predicators/refinement_estimators/base_refinement_estimator.py
+++ b/predicators/refinement_estimators/base_refinement_estimator.py
@@ -1,0 +1,28 @@
+"""Base class for a refinement cost estimator."""
+
+import abc
+from typing import List
+
+from predicators.structs import _GroundNSRT
+from predicators.utils import ExceptionWithInfo
+
+
+class BaseRefinementEstimator(abc.ABC):
+    """Base refinement cost estimator."""
+
+    @classmethod
+    @abc.abstractmethod
+    def get_name(cls) -> str:
+        """Get the unique name of this refinement cost estimator, for future
+        use as the argument to `--refinement_estimator`."""
+        raise NotImplementedError("Override me!")
+
+    @abc.abstractmethod
+    def get_cost(self, skeleton: List[_GroundNSRT]) -> float:
+        """Return an estimated cost for a proposed high-level skeleton."""
+        raise NotImplementedError("Override me!")
+
+
+class RefinementCostEstimationFailure(ExceptionWithInfo):
+    """Exception raised when refinement cost estimation fails for some
+    reason."""

--- a/predicators/refinement_estimators/oracle_refinement_estimator.py
+++ b/predicators/refinement_estimators/oracle_refinement_estimator.py
@@ -1,0 +1,45 @@
+"""A hand-written refinement cost estimator."""
+
+from typing import List
+
+from predicators.refinement_estimators import BaseRefinementEstimator
+from predicators.settings import CFG
+from predicators.structs import _GroundNSRT
+
+
+class OracleRefinementEstimator(BaseRefinementEstimator):
+    """A refinement cost estimator that returns a hand-designed cost
+    estimation."""
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "oracle"
+
+    def get_cost(self, skeleton: List[_GroundNSRT]) -> float:
+        env_name = CFG.env
+        if env_name == "narrow_passage":
+            return narrow_passage_oracle_estimator(skeleton)
+
+        # Given environment doesn't have an implemented oracle estimator
+        raise NotImplementedError(
+            f"No oracle refinement cost estimator for env {env_name}")
+
+
+def narrow_passage_oracle_estimator(skeleton: List[_GroundNSRT]) -> float:
+    """Oracle refinement estimation function for narrow_passage env."""
+
+    # Hard-coded estimated num_samples needed to refine different operators
+    move_and_open_door = 1
+    move_through_door = 1
+    move_through_passage = 3
+
+    # Sum metric of difficulty over skeleton
+    cost = 0
+    door_open = False
+    for ground_nsrt in skeleton:
+        if ground_nsrt.name == "MoveAndOpenDoor":
+            cost += move_and_open_door
+            door_open = True
+        elif ground_nsrt.name == "MoveToTarget":
+            cost += move_through_door if door_open else move_through_passage
+    return cost

--- a/predicators/refinement_estimators/oracle_refinement_estimator.py
+++ b/predicators/refinement_estimators/oracle_refinement_estimator.py
@@ -1,10 +1,10 @@
 """A hand-written refinement cost estimator."""
 
-from typing import List
+from typing import List, Set
 
 from predicators.refinement_estimators import BaseRefinementEstimator
 from predicators.settings import CFG
-from predicators.structs import _GroundNSRT
+from predicators.structs import GroundAtom, _GroundNSRT
 
 
 class OracleRefinementEstimator(BaseRefinementEstimator):
@@ -15,18 +15,23 @@ class OracleRefinementEstimator(BaseRefinementEstimator):
     def get_name(cls) -> str:
         return "oracle"
 
-    def get_cost(self, skeleton: List[_GroundNSRT]) -> float:
+    def get_cost(self, skeleton: List[_GroundNSRT],
+                 atoms_sequence: List[Set[GroundAtom]]) -> float:
         env_name = CFG.env
         if env_name == "narrow_passage":
-            return narrow_passage_oracle_estimator(skeleton)
+            return narrow_passage_oracle_estimator(skeleton, atoms_sequence)
 
         # Given environment doesn't have an implemented oracle estimator
         raise NotImplementedError(
             f"No oracle refinement cost estimator for env {env_name}")
 
 
-def narrow_passage_oracle_estimator(skeleton: List[_GroundNSRT]) -> float:
+def narrow_passage_oracle_estimator(
+    skeleton: List[_GroundNSRT],
+    atoms_sequence: List[Set[GroundAtom]],
+) -> float:
     """Oracle refinement estimation function for narrow_passage env."""
+    del atoms_sequence  # unused
 
     # Hard-coded estimated num_samples needed to refine different operators
     move_and_open_door = 1

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -426,6 +426,10 @@ class GlobalSettings:
     # online NSRT learning parameters
     online_nsrt_learning_requests_per_cycle = 10
 
+    # refinement cost estimation parameters
+    refinement_estimator = "oracle"  # default refinement cost estimator
+    refinement_estimation_num_skeletons_generated = 3
+
     # glib explorer parameters
     glib_min_goal_size = 1
     glib_max_goal_size = 1

--- a/tests/approaches/test_refinement_estimation_approach.py
+++ b/tests/approaches/test_refinement_estimation_approach.py
@@ -1,0 +1,46 @@
+"""Test cases for the refinement cost estimation--based approach class."""
+
+from predicators import utils
+from predicators.approaches.refinement_estimation_approach import \
+    RefinementEstimationApproach
+from predicators.envs.narrow_passage import NarrowPassageEnv
+from predicators.settings import CFG
+
+
+def _policy_solves_task(policy, task, simulator):
+    """Helper method used in this file, copied from test_oracle_approach.py."""
+    traj = utils.run_policy_with_simulator(policy,
+                                           simulator,
+                                           task.init,
+                                           task.goal_holds,
+                                           max_num_steps=CFG.horizon)
+    return task.goal_holds(traj.states[-1])
+
+
+def test_refinement_estimation_approach():
+    """Tests for RefinementEstimationApproach class."""
+    args = {
+        "env": "narrow_passage",
+        "refinement_estimator": "oracle",
+    }
+    # Default to 2 train and test tasks, but allow them to be specified in
+    # the extra args too.
+    if "num_train_tasks" not in args:
+        args["num_train_tasks"] = 2
+    if "num_test_tasks" not in args:
+        args["num_test_tasks"] = 2
+    utils.reset_config(args)
+    env = NarrowPassageEnv(use_gui=False)
+    train_tasks = env.get_train_tasks()
+    test_tasks = env.get_test_tasks()
+    approach = RefinementEstimationApproach(env.predicates, env.options,
+                                            env.types, env.action_space,
+                                            train_tasks)
+    assert approach.get_name() == "refinement_estimation"
+    assert not approach.is_learning_based
+    for task in train_tasks:
+        policy = approach.solve(task, timeout=500)
+        assert _policy_solves_task(policy, task, env.simulate)
+    for task in test_tasks:
+        policy = approach.solve(task, timeout=500)
+        assert _policy_solves_task(policy, task, env.simulate)

--- a/tests/refinement_estimators/test_base_refinement_estimator.py
+++ b/tests/refinement_estimators/test_base_refinement_estimator.py
@@ -1,0 +1,18 @@
+"""Test cases for the base refinement estimator class."""
+
+import pytest
+
+from predicators.refinement_estimators import BaseRefinementEstimator, \
+    create_refinement_estimator
+
+ESTIMATOR_NAMES = ["oracle"]
+
+
+def test_refinement_estimator_creation():
+    """Tests for create_refinement_estimator()."""
+    for est_name in ESTIMATOR_NAMES:
+        estimator = create_refinement_estimator(est_name)
+        assert isinstance(estimator, BaseRefinementEstimator)
+        assert estimator.get_name() == est_name
+    with pytest.raises(NotImplementedError):
+        create_refinement_estimator("non-existent refinement estimator")

--- a/tests/refinement_estimators/test_oracle_refinement_estimator.py
+++ b/tests/refinement_estimators/test_oracle_refinement_estimator.py
@@ -16,7 +16,7 @@ def test_oracle_refinement_estimator():
     estimator = OracleRefinementEstimator()
     assert estimator.get_name() == "oracle"
     with pytest.raises(NotImplementedError):
-        estimator.get_cost([])
+        estimator.get_cost([], [])
 
 
 def test_narrow_passage_oracle_refinement_estimator():
@@ -40,7 +40,7 @@ def test_narrow_passage_oracle_refinement_estimator():
 
     # Test direct MoveToTarget skeleton
     move_direct_skeleton = [ground_move_to_target]
-    move_direct_cost = estimator.get_cost(move_direct_skeleton)
+    move_direct_cost = estimator.get_cost(move_direct_skeleton, [])
     assert move_direct_cost == 3
 
     # Test open door then move skeleton
@@ -48,7 +48,7 @@ def test_narrow_passage_oracle_refinement_estimator():
         ground_move_and_open_door,
         ground_move_to_target,
     ]
-    move_through_door_cost = estimator.get_cost(move_through_door_skeleton)
+    move_through_door_cost = estimator.get_cost(move_through_door_skeleton, [])
     assert move_through_door_cost == 1 + 1
 
     # Test open door multiple times then move skeleton
@@ -58,7 +58,8 @@ def test_narrow_passage_oracle_refinement_estimator():
         ground_move_and_open_door,
         ground_move_to_target,
     ]
-    move_door_multiple_cost = estimator.get_cost(move_door_multiple_skeleton)
+    move_door_multiple_cost = estimator.get_cost(move_door_multiple_skeleton,
+                                                 [])
     assert move_door_multiple_cost == 4
 
     # Make sure that sorting the costs makes sense

--- a/tests/refinement_estimators/test_oracle_refinement_estimator.py
+++ b/tests/refinement_estimators/test_oracle_refinement_estimator.py
@@ -1,0 +1,67 @@
+"""Test cases for the oracle refinement cost estimator."""
+
+import pytest
+
+from predicators import utils
+from predicators.envs.narrow_passage import NarrowPassageEnv
+from predicators.ground_truth_nsrts import get_gt_nsrts
+from predicators.refinement_estimators.oracle_refinement_estimator import \
+    OracleRefinementEstimator
+from predicators.settings import CFG
+
+
+def test_oracle_refinement_estimator():
+    """Test general properties of oracle refinement cost estimator."""
+    utils.reset_config({"env": "non-existent env"})
+    estimator = OracleRefinementEstimator()
+    assert estimator.get_name() == "oracle"
+    with pytest.raises(NotImplementedError):
+        estimator.get_cost([])
+
+
+def test_narrow_passage_oracle_refinement_estimator():
+    """Test oracle refinement cost estimator for narrow_passage env."""
+    utils.reset_config({"env": "narrow_passage"})
+    estimator = OracleRefinementEstimator()
+
+    # Get env objects and NSRTs
+    env = NarrowPassageEnv()
+    door_type, _, robot_type, target_type, _ = sorted(env.types)
+    sample_state = env.get_train_tasks()[0].init
+    door, = sample_state.get_objects(door_type)
+    robot, = sample_state.get_objects(robot_type)
+    target, = sample_state.get_objects(target_type)
+    gt_nsrts = get_gt_nsrts(CFG.env, env.predicates, env.options)
+    move_and_open_door_nsrt, move_to_target_nsrt = sorted(gt_nsrts)
+
+    # Ground NSRTs using objects
+    ground_move_and_open_door = move_and_open_door_nsrt.ground([robot, door])
+    ground_move_to_target = move_to_target_nsrt.ground([robot, target])
+
+    # Test direct MoveToTarget skeleton
+    move_direct_skeleton = [ground_move_to_target]
+    move_direct_cost = estimator.get_cost(move_direct_skeleton)
+    assert move_direct_cost == 3
+
+    # Test open door then move skeleton
+    move_through_door_skeleton = [
+        ground_move_and_open_door,
+        ground_move_to_target,
+    ]
+    move_through_door_cost = estimator.get_cost(move_through_door_skeleton)
+    assert move_through_door_cost == 1 + 1
+
+    # Test open door multiple times then move skeleton
+    move_door_multiple_skeleton = [
+        ground_move_and_open_door,
+        ground_move_and_open_door,
+        ground_move_and_open_door,
+        ground_move_to_target,
+    ]
+    move_door_multiple_cost = estimator.get_cost(move_door_multiple_skeleton)
+    assert move_door_multiple_cost == 4
+
+    # Make sure that sorting the costs makes sense
+    assert sorted([
+        move_direct_cost, move_through_door_cost, move_door_multiple_cost
+    ]) == [move_through_door_cost, move_direct_cost, move_door_multiple_cost]


### PR DESCRIPTION
###  Refinement cost estimator classes and RefinementEstimationApproach

**Changes:**

- Created `predicators/refinement_estimators/` which contains an abstract `BaseRefinementEstimator` and implemented `OracleRefinementEstimator` class (oracle implemented for `narrow_passage` env only)
- Added tests for the refinement cost estimators
- Created a new `RefinementEstimationApproach` which passes a refinement estimator to the planner, and tests based on the oracle approach tests
- `sesame_plan()` takes in an optional refinement estimator. If it is provided, during A* search we pre-generate N skeletons, sort them by estimated refinement cost, and attempt to refine them in that order
- New CFG parameters:
    - `refinement_estimator` is a choice of refinement estimator (default: `oracle`)
    - `refinement_estimation_num_skeletons_generated` is the number of skeletons to pre-generate

**Example usage**

`python main.py --env narrow_passage --approach refinement_estimation --seed 0`

**Tests**

`pytest tests/approaches/test_refinement_estimation_approach.py` (takes approx 4.1s)

`pytest tests/refinement_estimators/` (takes approx 1.4s total)
