### PR TITLE
removes unnecessary call to learning

### DIFF
--- a/predicators/nsrt_learning/strips_learning/base_strips_learner.py
+++ b/predicators/nsrt_learning/strips_learning/base_strips_learner.py
@@ -65,7 +65,6 @@ class BaseSTRIPSLearner(abc.ABC):
         # Iterates over each PNAD in the learned PNADs removing the
         # PNAD that uses the least amount of data.
         for min_perc_data_for_nsrt in pnad_perc_data_low_to_high:
-            learned_pnads = self._learn()
             min_data = max(CFG.min_data_for_nsrt,
                            self._num_segments * min_perc_data_for_nsrt)
             learned_pnads = [


### PR DESCRIPTION
This slows us down somewhat substantially when learning takes a while because we're unnecessarily calling learning twice!

@wmcclinton - is it safe to take out this line entirely (seems so to me)? If not, can we at least move it so that it doesn't get called if `CFG.enable_harmless_op_pruning` is False?