### PR TITLE
Pnad search without deletion

### DIFF
--- a/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
+++ b/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
@@ -10,6 +10,7 @@ from predicators.nsrt_learning.strips_learning.gen_to_spec_learner import \
     GeneralToSpecificSTRIPSLearner
 from predicators.structs import PNAD, GroundAtom, LowLevelTrajectory, \
     ParameterizedOption, Predicate, Segment, Task, _GroundSTRIPSOperator
+from predicators.settings import CFG
 
 
 class _PNADSearchOperator(abc.ABC):
@@ -298,8 +299,10 @@ class PNADSearchSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
 
     def _create_search_operators(self) -> List[_PNADSearchOperator]:
         op_classes = [
-            _BackChainingPNADSearchOperator, _PruningPNADSearchOperator
+            _BackChainingPNADSearchOperator,
         ]
+        if not CFG.pnad_search_without_del:
+            op_classes.append(_PruningPNADSearchOperator)
         ops = [
             cls(self._trajectories, self._train_tasks,
                 self._predicates, self._segmented_trajs, self,

--- a/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
+++ b/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
@@ -8,9 +8,9 @@ from typing import Dict, FrozenSet, Iterator, List, Optional, Set, Tuple
 from predicators import utils
 from predicators.nsrt_learning.strips_learning.gen_to_spec_learner import \
     GeneralToSpecificSTRIPSLearner
+from predicators.settings import CFG
 from predicators.structs import PNAD, GroundAtom, LowLevelTrajectory, \
     ParameterizedOption, Predicate, Segment, Task, _GroundSTRIPSOperator
-from predicators.settings import CFG
 
 
 class _PNADSearchOperator(abc.ABC):
@@ -299,11 +299,11 @@ class PNADSearchSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
 
     def _create_search_operators(self) -> List[_PNADSearchOperator]:
         op_classes = [
-            _BackChainingPNADSearchOperator,
+            _BackChainingPNADSearchOperator, _PruningPNADSearchOperator
         ]
-        if not CFG.pnad_search_without_del:
-            op_classes.append(_PruningPNADSearchOperator)
-        ops = [
+        if CFG.pnad_search_without_del:
+            op_classes.remove(_PruningPNADSearchOperator)
+        ops: List[_PNADSearchOperator] = [
             cls(self._trajectories, self._train_tasks,
                 self._predicates, self._segmented_trajs, self,
                 self._create_heuristic()) for cls in op_classes

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -380,6 +380,7 @@ class GlobalSettings:
     disable_harmlessness_check = False  # some methods may want this to be True
     enable_harmless_op_pruning = False  # some methods may want this to be True
     backchaining_check_intermediate_harmlessness = False
+    pnad_search_without_del = False
     compute_sidelining_objective_value = False
     clustering_learner_true_pos_weight = 10
     clustering_learner_false_pos_weight = 1

--- a/scripts/lisdf_plan_to_reset.py
+++ b/scripts/lisdf_plan_to_reset.py
@@ -1,7 +1,8 @@
 """Create a command that resets the robot from its current state to the initial
 state of another LISDF plan.
 
-Prepend that "reset" command with the other LISDF plan to create a final plan.
+Prepend that "reset" command with the other LISDF plan to create a final
+plan.
 """
 import argparse
 from pathlib import Path

--- a/tests/nsrt_learning/strips_learning/test_backchaining_based_learners.py
+++ b/tests/nsrt_learning/strips_learning/test_backchaining_based_learners.py
@@ -56,9 +56,10 @@ class _MockBackchainingSTRIPSLearner(BackchainingSTRIPSLearner):
         return self._reset_all_segment_necessary_add_effs()
 
 
-@pytest.mark.parametrize(
-    "approach_cls", [_MockBackchainingSTRIPSLearner, PNADSearchSTRIPSLearner])
-def test_backchaining_strips_learner(approach_cls):
+@pytest.mark.parametrize("approach_name, approach_cls",
+                         [("backchaining", _MockBackchainingSTRIPSLearner),
+                          ("pnad_search", PNADSearchSTRIPSLearner)])
+def test_backchaining_strips_learner(approach_name, approach_cls):
     """Test the BackchainingSTRIPSLearner and PNADSearchSTRIPSLearner on a
     simple problem."""
     utils.reset_config({"backchaining_check_intermediate_harmlessness": True})
@@ -146,6 +147,15 @@ def test_backchaining_strips_learner(approach_cls):
     Ignore Effects: []
     Option Spec: Cry()"""
     assert str(pnads[0]) == repr(pnads[0]) == expected_str
+    if approach_name == "pnad_search":
+        # Learn using pnad_search_without_del
+        utils.reset_config({"pnad_search_without_del": True})
+        learner = approach_cls([traj3, traj4], [task3, task4], {Asleep, Sad},
+                               [[segment3], [segment4]],
+                               verify_harmlessness=True)
+        pnads = learner.learn()
+        assert len(pnads) == 1
+        assert str(pnads[0]) == repr(pnads[0]) == expected_str
 
 
 @pytest.mark.parametrize("approach_name,approach_cls",


### PR DESCRIPTION
Includes a new flag to run the `pnad_search` learner without the deletion operator during hill-climbing.

Example:
```
python predicators/main.py --env repeated_nextto_ambiguous --approach nsrt_learning --seed 0 --strips_learner pnad_search --pnad_search_without_del True
```

PS: idk why but the autoformat script changed `lisdf_plan_to_reset.py`...