### PR TITLE
Fixes heuristic stochasticity issue with PNAD search

### DIFF
--- a/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
+++ b/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
@@ -52,7 +52,7 @@ class _BackChainingPNADSearchOperator(_PNADSearchOperator):
                 new_pnad = self._learner.spawn_new_pnad(uncovered_segment)
                 ret_pnads_list = self._append_new_pnad_and_keep_effects(
                     new_pnad, ret_pnads_list)
-                ret_pnads = frozenset(ret_pnads_list)
+                ret_pnads = frozenset(pnad.copy() for pnad in ret_pnads_list)
                 new_heuristic_val = self._associated_heuristic(ret_pnads)
                 uncovered_segment = self._get_first_uncovered_segment(
                     ret_pnads_list)
@@ -145,7 +145,8 @@ class _PruningPNADSearchOperator(_PNADSearchOperator):
         sorted_pnad_list = sorted(pnads)
         for pnad_to_remove in sorted_pnad_list:
             pnads_after_removal = [
-                pnad for pnad in sorted_pnad_list if pnad != pnad_to_remove
+                pnad.copy() for pnad in sorted_pnad_list
+                if pnad != pnad_to_remove
             ]
             recomp_pnads = self._learner.recompute_pnads_from_effects(
                 pnads_after_removal)

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -1227,6 +1227,21 @@ class PNAD:
         param_option, option_vars = self.option_spec
         return self.op.make_nsrt(param_option, option_vars, self.sampler)
 
+    def copy(self) -> PNAD:
+        new_op = self.op.copy_with()
+        new_poss_keep_effects = set(self.poss_keep_effects)
+        new_seg_to_keep_effects_sub = {}
+        # NOTE: Below line effectively does a deep-copy of the nested dicts
+        # here. This is crucial for the PNAD search learner (since otherwise,
+        # updating a PNAD in a different set may change this dict for a PNAD
+        # in the current set).
+        for k, v in self.seg_to_keep_effects_sub.items():
+            new_seg_to_keep_effects_sub[k] = dict(v)
+        new_pnad = PNAD(new_op, self.datastore, self.option_spec)
+        new_pnad.poss_keep_effects = new_poss_keep_effects
+        new_pnad.seg_to_keep_effects_sub = new_seg_to_keep_effects_sub
+        return new_pnad
+
     def __repr__(self) -> str:
         param_option, option_vars = self.option_spec
         vars_str = ", ".join(str(v) for v in option_vars)

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -1228,6 +1228,8 @@ class PNAD:
         return self.op.make_nsrt(param_option, option_vars, self.sampler)
 
     def copy(self) -> PNAD:
+        """Make a copy of this PNAD object, taking care to ensure that
+        modifying the original will not affect the copy."""
         new_op = self.op.copy_with()
         new_poss_keep_effects = set(self.poss_keep_effects)
         new_seg_to_keep_effects_sub = {}


### PR DESCRIPTION
This PR adds a `copy()` method to the PNAD datatype such that if a PNAD is copied, modifying any aspect of the original PNAD will not affect this new copied PNAD.

Previously, when running the `pnad_search` learner, it was possible to modify a PNADs `seg_to_keep_effects_sub` by calling the `BackchainingHeuristic` on the same PNAD from a different PNAD set. This led to an extremely strange situation where the heuristic value of a particular PNAD set would change. This apparently doesn't affect most of our domains/tests, but causes some nasty bugs on particular BEHAVIOR seeds where we tend to learn complex operators due to local minima. This change fixes that (confirmed by testing on the `predicators_behavior` repo).

```
AGGREGATED DATA OVER SEEDS:
                                                NUM_TRAIN_TASKS     NUM_SOLVED AVG_NUM_PREDS AVG_TEST_TIME    AVG_NODES_CREATED  LEARNING_TIME  NUM_SEEDS
EXPERIMENT_ID                                                                                                                                            
painting_pnadsearch_10demo                         10.00 (0.00)   45.50 (4.48)  14.00 (0.00)   0.44 (0.11)     2097.87 (782.35)   54.48 (2.69)         10
painting_pnadsearch_25demo                         25.00 (0.00)   49.30 (1.00)  14.00 (0.00)   0.38 (0.09)     2366.76 (817.05)   62.91 (4.47)         10
painting_pnadsearch_50demo                         50.00 (0.00)   49.40 (0.66)  14.00 (0.00)   0.44 (0.14)    2765.83 (1096.68)   69.35 (3.58)         10
painting_pnadsearch_5demo                           5.00 (0.00)   13.20 (9.50)  14.00 (0.00)   1.12 (0.89)    1734.46 (1644.97)   53.59 (1.63)         10
repeated_nextto_painting_pnadsearch_10demo         10.00 (0.00)   37.30 (7.56)  18.00 (0.00)   1.04 (0.31)    3348.08 (2946.81)   88.17 (5.44)         10
repeated_nextto_painting_pnadsearch_25demo         25.00 (0.00)   45.60 (3.29)  18.00 (0.00)   0.69 (0.03)     1693.55 (427.41)  105.93 (2.89)         10
repeated_nextto_painting_pnadsearch_50demo         50.00 (0.00)   49.60 (0.66)  18.00 (0.00)   0.73 (0.06)     1814.71 (455.68)  131.68 (5.05)         10
repeated_nextto_painting_pnadsearch_5demo           5.00 (0.00)  23.20 (10.74)  18.00 (0.00)   1.05 (0.49)    4394.47 (3633.91)   81.14 (6.26)         10
repeated_nextto_single_option_pnadsearch_10demo    10.00 (0.00)   50.00 (0.00)   3.00 (0.00)   0.04 (0.01)         88.50 (2.35)   18.79 (2.15)         10
repeated_nextto_single_option_pnadsearch_25demo    25.00 (0.00)   50.00 (0.00)   3.00 (0.00)   0.03 (0.00)         88.50 (2.35)   17.38 (1.81)         10
repeated_nextto_single_option_pnadsearch_50demo    50.00 (0.00)   50.00 (0.00)   3.00 (0.00)   0.03 (0.00)         88.50 (2.35)   17.98 (1.06)         10
repeated_nextto_single_option_pnadsearch_5demo      5.00 (0.00)   49.90 (0.30)   3.00 (0.00)   0.04 (0.01)        83.84 (14.86)   23.96 (2.55)         10
satellites_pnadsearch_10demo                       10.00 (0.00)   23.40 (7.94)  13.00 (0.00)   1.66 (0.36)    5165.85 (3336.84)   11.19 (0.82)         10
satellites_pnadsearch_25demo                       25.00 (0.00)   38.30 (5.69)  13.00 (0.00)   1.30 (0.27)    5051.04 (2523.20)   12.67 (0.82)         10
satellites_pnadsearch_50demo                       50.00 (0.00)   47.60 (1.20)  13.00 (0.00)   1.13 (0.25)    6487.61 (3123.81)   16.12 (0.55)         10
satellites_pnadsearch_5demo                         5.00 (0.00)    7.40 (9.60)  13.00 (0.00)   2.10 (1.21)  10543.22 (11412.26)   10.14 (0.88)         10
satellites_simple_pnadsearch_10demo                10.00 (0.00)   33.30 (6.66)  13.00 (0.00)   0.91 (0.45)      391.61 (204.53)   10.77 (0.64)         10
satellites_simple_pnadsearch_25demo                25.00 (0.00)   43.90 (3.70)  13.00 (0.00)   0.43 (0.27)      328.57 (111.29)   14.94 (5.42)         10
satellites_simple_pnadsearch_50demo                50.00 (0.00)   46.70 (5.57)  13.00 (0.00)   0.38 (0.45)     812.47 (1295.92)   19.38 (7.83)         10
satellites_simple_pnadsearch_5demo                  5.00 (0.00)    7.30 (8.12)  13.00 (0.00)   1.42 (1.90)      532.54 (343.75)    9.84 (0.63)         10
screws_pnadsearch_10demo                           10.00 (0.00)   50.00 (0.00)   4.00 (0.00)   0.10 (0.00)        117.32 (1.06)    0.27 (0.01)         10
screws_pnadsearch_25demo                           25.00 (0.00)   50.00 (0.00)   4.00 (0.00)   0.10 (0.00)        117.32 (1.06)    0.64 (0.01)         10
screws_pnadsearch_50demo                           50.00 (0.00)   50.00 (0.00)   4.00 (0.00)   0.10 (0.00)        117.32 (1.06)    1.31 (0.04)         10
screws_pnadsearch_5demo                             5.00 (0.00)   50.00 (0.00)   4.00 (0.00)   0.10 (0.00)        117.32 (1.06)    0.15 (0.01)         10

```