### PR TITLE
two mypy fixes

### DIFF
--- a/scripts/plotting/create_ignore_effects_lineplots.py
+++ b/scripts/plotting/create_ignore_effects_lineplots.py
@@ -72,13 +72,16 @@ def _select_data(env: str, approach: str, df: pd.DataFrame) -> pd.Series:
     # Need to do some additional work because some of the names of
     # the environments are subsets of others.
     if approach == "painting":
-        return df["EXPERIMENT_ID"].apply(lambda v: v.startswith(
+        series = df["EXPERIMENT_ID"].apply(lambda v: v.startswith(
             f"{env}_{approach}_") and "repeated_nextto" not in v)
-    if approach == "satellites":
-        return df["EXPERIMENT_ID"].apply(
+    elif approach == "satellites":
+        series = df["EXPERIMENT_ID"].apply(
             lambda v: v.startswith(f"{env}_{approach}_") and "simple" not in v)
-    return df["EXPERIMENT_ID"].apply(
-        lambda v: v.startswith(f"{env}_{approach}_"))
+    else:
+        series = df["EXPERIMENT_ID"].apply(
+            lambda v: v.startswith(f"{env}_{approach}_"))
+    assert isinstance(series, pd.Series)
+    return series
 
 
 PLOT_GROUPS = {


### PR DESCRIPTION
I'm not sure why there are inconsistencies in when and where these mypy errors are coming up, but they should hopefully be fixed now. there were two issues:

1. the `_S` variable that we use for heuristic search needs to be hashable, but states don't need to be hashable in BiRRT (e.g., they're often numpy arrays)
2. needed to add an assertion to suppress a mypy error in the ignore effects plotting script that I was getting locally