### PR TITLE
change glib novelty function to match original implementation

### DIFF
--- a/predicators/approaches/online_nsrt_learning_approach.py
+++ b/predicators/approaches/online_nsrt_learning_approach.py
@@ -130,6 +130,9 @@ class OnlineNSRTLearningApproach(NSRTLearningApproach):
         canonical_atoms = self._get_canonical_lifted_atoms(atoms)
         # Note minus sign: less frequent is better.
         count = self._novelty_counts[canonical_atoms]
+        # Once some goal has been seen online_learning_max_novelty_count
+        # number of times, it is no longer considered "novel" and, for example,
+        # won't be babbled by the GLIB explorer anymore.
         if count > CFG.online_learning_max_novelty_count:
             return -float("inf")
         return -count

--- a/predicators/approaches/online_nsrt_learning_approach.py
+++ b/predicators/approaches/online_nsrt_learning_approach.py
@@ -130,7 +130,7 @@ class OnlineNSRTLearningApproach(NSRTLearningApproach):
         canonical_atoms = self._get_canonical_lifted_atoms(atoms)
         # Note minus sign: less frequent is better.
         count = self._novelty_counts[canonical_atoms]
-        if count > CFG.glib_max_novelty_count:
+        if count > CFG.online_learning_max_novelty_count:
             return -float("inf")
         return -count
 

--- a/predicators/approaches/online_nsrt_learning_approach.py
+++ b/predicators/approaches/online_nsrt_learning_approach.py
@@ -129,7 +129,11 @@ class OnlineNSRTLearningApproach(NSRTLearningApproach):
         assert CFG.glib_min_goal_size <= len(atoms) <= CFG.glib_max_goal_size
         canonical_atoms = self._get_canonical_lifted_atoms(atoms)
         # Note minus sign: less frequent is better.
-        return -self._novelty_counts[canonical_atoms]
+        count = self._novelty_counts[canonical_atoms]
+        if count > 0:
+            return -float("inf")
+        assert count == 0
+        return count
 
     @staticmethod
     def _get_canonical_lifted_atoms(

--- a/predicators/approaches/online_nsrt_learning_approach.py
+++ b/predicators/approaches/online_nsrt_learning_approach.py
@@ -130,10 +130,9 @@ class OnlineNSRTLearningApproach(NSRTLearningApproach):
         canonical_atoms = self._get_canonical_lifted_atoms(atoms)
         # Note minus sign: less frequent is better.
         count = self._novelty_counts[canonical_atoms]
-        if count > 0:
+        if count > CFG.glib_max_novelty_count:
             return -float("inf")
-        assert count == 0
-        return count
+        return -count
 
     @staticmethod
     def _get_canonical_lifted_atoms(

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -440,6 +440,7 @@ class GlobalSettings:
 
     # online NSRT learning parameters
     online_nsrt_learning_requests_per_cycle = 10
+    online_learning_max_novelty_count = 0
 
     # refinement cost estimation parameters
     refinement_estimator = "oracle"  # default refinement cost estimator
@@ -449,7 +450,6 @@ class GlobalSettings:
     glib_min_goal_size = 1
     glib_max_goal_size = 1
     glib_num_babbles = 10
-    glib_max_novelty_count = 0
 
     # greedy lookahead explorer parameters
     greedy_lookahead_max_num_trajectories = 100

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -449,6 +449,7 @@ class GlobalSettings:
     glib_min_goal_size = 1
     glib_max_goal_size = 1
     glib_num_babbles = 10
+    glib_max_novelty_count = 0
 
     # greedy lookahead explorer parameters
     greedy_lookahead_max_num_trajectories = 100

--- a/tests/approaches/test_online_nsrt_learning_approach.py
+++ b/tests/approaches/test_online_nsrt_learning_approach.py
@@ -79,7 +79,7 @@ def test_online_nsrt_learning_approach():
     assert covers_score > is_target_score
     # Scores should now be -inf.
     utils.update_config({
-        "glib_max_novelty_count": 0,
+        "online_learning_max_novelty_count": 0,
     })
     covers_score = approach._score_atoms_novelty(covers)  # pylint: disable=protected-access
     is_block_score = approach._score_atoms_novelty(is_block)  # pylint: disable=protected-access

--- a/tests/approaches/test_online_nsrt_learning_approach.py
+++ b/tests/approaches/test_online_nsrt_learning_approach.py
@@ -28,7 +28,7 @@ def test_online_nsrt_learning_approach():
         "num_train_tasks": 3,
         "num_test_tasks": 3,
         "explorer": "random_options",
-        "glib_max_novelty_count": float("inf"),
+        "online_learning_max_novelty_count": float("inf"),
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()

--- a/tests/approaches/test_online_nsrt_learning_approach.py
+++ b/tests/approaches/test_online_nsrt_learning_approach.py
@@ -28,6 +28,7 @@ def test_online_nsrt_learning_approach():
         "num_train_tasks": 3,
         "num_test_tasks": 3,
         "explorer": "random_options",
+        "glib_max_novelty_count": float("inf"),
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()
@@ -76,3 +77,11 @@ def test_online_nsrt_learning_approach():
     is_target_score = approach._score_atoms_novelty(is_target)  # pylint: disable=protected-access
     assert covers_score > is_block_score
     assert covers_score > is_target_score
+    # Scores should now be -inf.
+    utils.update_config({
+        "glib_max_novelty_count": 0,
+    })
+    covers_score = approach._score_atoms_novelty(covers)  # pylint: disable=protected-access
+    is_block_score = approach._score_atoms_novelty(is_block)  # pylint: disable=protected-access
+    is_target_score = approach._score_atoms_novelty(is_target)  # pylint: disable=protected-access
+    assert covers_score == is_block_score == is_target_score == -float("inf")

--- a/tests/explorers/test_glib_explorer.py
+++ b/tests/explorers/test_glib_explorer.py
@@ -51,6 +51,31 @@ def test_glib_explorer(target_predicate):
     assert target_predicate not in str(init_atoms)
     final_atoms = utils.abstract(final_state, env.predicates)
     assert target_predicate in str(final_atoms)
+    # Now test with a score function that scores everything -inf. Should
+    # cover the case where we fall back to random.
+    score_fn = lambda _: -float("inf")
+    explorer = create_explorer("glib",
+                               env.predicates,
+                               env.options,
+                               env.types,
+                               env.action_space,
+                               train_tasks,
+                               nsrts,
+                               option_model,
+                               babble_predicates=env.predicates,
+                               atom_score_fn=score_fn)
+    task_idx = 0
+    policy, termination_function = explorer.get_exploration_strategy(
+        task_idx, 500)
+    traj, _ = utils.run_policy(
+        policy,
+        env,
+        "train",
+        task_idx,
+        termination_function,
+        max_num_steps=5,
+    )
+    assert len(traj.actions) > 3  # should no longer quickly achieve targets
 
 
 def test_glib_explorer_failure_cases():


### PR DESCRIPTION
in the original implementation of GLIB, we would only babble goals that had _never_ been seen before. in the predicators implementation, we were babbling goals in order of the _number_ of times that they had been seen, so the same goal could get babbled multiple times. this is actually bad because it's possible to get into situations where you babble the same goals that appear reachable over and over again, and never fall back to taking random actions, while not realizing that some other goals would be reachable if you corrected your faulty operators. I saw this happen sometimes while messing around with PDDL blocks.

this change may impact @amburger66 's baseline results, but the old results can be recovered by changing the new `online_interaction_max_novelty_count` flag to inf.