### PR TITLE
Greedy Lookahead Explorer: NSRT resampling

### DIFF
--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -454,6 +454,7 @@ class GlobalSettings:
     # greedy lookahead explorer parameters
     greedy_lookahead_max_num_trajectories = 100
     greedy_lookahead_max_traj_length = 2
+    greedy_lookahead_max_num_resamples = 10
 
     # grammar search invention parameters
     grammar_search_grammar_includes_givens = True

--- a/tests/explorers/test_greedy_lookahead_explorer.py
+++ b/tests/explorers/test_greedy_lookahead_explorer.py
@@ -112,3 +112,26 @@ def test_greedy_lookahead_explorer_failure_cases():
     policy, _ = explorer.get_exploration_strategy(task_idx, 500)
     with pytest.raises(utils.OptionExecutionFailure):
         policy(task.init)
+    # Test case where NSRT sampling fails to produce an initiable option.
+    new_nsrts = set()
+    for nsrt in nsrts:
+        new_option = utils.SingletonParameterizedOption(
+            "LearnedMockOption",
+            nsrt.option.policy,
+            types=nsrt.option.types,
+            params_space=nsrt.option.params_space,
+            initiable=lambda _1, _2, _3, _4: False)
+        new_nsrt = NSRT(nsrt.name, nsrt.parameters, nsrt.preconditions,
+                        nsrt.add_effects, nsrt.delete_effects, set(),
+                        new_option, nsrt.option_vars, nsrt._sampler)  # pylint: disable=protected-access
+        new_nsrts.add(new_nsrt)
+    explorer = create_explorer("greedy_lookahead",
+                               env.predicates,
+                               env.options,
+                               env.types,
+                               env.action_space,
+                               train_tasks,
+                               new_nsrts,
+                               option_model,
+                               state_score_fn=state_score_fn)
+    policy, _ = explorer.get_exploration_strategy(task_idx, 500)


### PR DESCRIPTION
- currently, NSRT preconditions being satisfied does not guarantee that the resulting option will be initiable, since predicates may be learned incorrectly
- the old assert statement led to experiments crashing, so now it is replaced with resampling (the NSRT)
- if resampling also fails, we simply terminate the current trajectory