### PR TITLE
`BlocksEnvClear`

### DIFF
--- a/predicators/ground_truth_nsrts.py
+++ b/predicators/ground_truth_nsrts.py
@@ -29,7 +29,7 @@ def get_gt_nsrts(env_name: str, predicates: Set[Predicate],
         nsrts = _get_cluttered_table_gt_nsrts(env_name)
     elif env_name == "cluttered_table_place":
         nsrts = _get_cluttered_table_gt_nsrts(env_name, with_place=True)
-    elif env_name in ("blocks", "pybullet_blocks"):
+    elif env_name in ("blocks", "pybullet_blocks", "blocks_clear"):
         nsrts = _get_blocks_gt_nsrts(env_name)
     elif env_name in ("painting", "repeated_nextto_painting"):
         nsrts = _get_painting_gt_nsrts(env_name)

--- a/scripts/configs/interactive_learning.yaml
+++ b/scripts/configs/interactive_learning.yaml
@@ -62,14 +62,21 @@ APPROACHES:
       predicate_mlp_classifier_n_reinitialize_tries: 5
       predicate_mlp_classifier_init: "normal"
 ENVS:
-  cover:
-    NAME: "cover"
+  # cover:
+  #   NAME: "cover_handempty"
+  #   FLAGS:
+  #     excluded_predicates: "Covers,Holding,HandEmpty"
+  #     max_num_steps_interaction_request: 3
+  blocks:
+    NAME: "blocks"
+    FLAGS:
+      # exclude all but Clear
+      excluded_predicates: "On,OnTable,GripperOpen,Holding"
+      max_num_steps_interaction_request: 20
 ARGS: {}
 FLAGS:  # common args
-  excluded_predicates: "Covers,Holding"
   num_online_learning_cycles: 100  # way too many cycles
   online_learning_max_transitions: 1000  # want this to be stop signal
-  max_num_steps_interaction_request: 3
   min_data_for_nsrt: 10
   sampler_disable_classifier: True
   mlp_classifier_balance_data: False

--- a/scripts/configs/interactive_learning.yaml
+++ b/scripts/configs/interactive_learning.yaml
@@ -62,16 +62,15 @@ APPROACHES:
       predicate_mlp_classifier_n_reinitialize_tries: 5
       predicate_mlp_classifier_init: "normal"
 ENVS:
-  # cover:
-  #   NAME: "cover_handempty"
-  #   FLAGS:
-  #     excluded_predicates: "Covers,Holding,HandEmpty"
-  #     max_num_steps_interaction_request: 3
-  blocks:
-    NAME: "blocks"
+  cover:
+    NAME: "cover_handempty"
     FLAGS:
-      # exclude all but Clear
-      excluded_predicates: "On,OnTable,GripperOpen,Holding"
+      excluded_predicates: "Covers,Holding,HandEmpty"
+      max_num_steps_interaction_request: 3
+  blocks:
+    NAME: "blocks_clear"
+    FLAGS:
+      excluded_predicates: "On,OnTable,GripperOpen,Holding,Clear"
       max_num_steps_interaction_request: 20
 ARGS: {}
 FLAGS:  # common args

--- a/tests/envs/test_blocks.py
+++ b/tests/envs/test_blocks.py
@@ -135,18 +135,15 @@ def test_blocks_clear():
     """Tests for BlocksEnvClear class."""
     utils.reset_config({"env": "blocks_clear"})
     env = BlocksEnvClear()
+    clear = env._block_is_clear  # pylint: disable=protected-access
     block_type = [t for t in env.types if t.name == "block"][0]
     assert "clear" in block_type.feature_names
     task = env.get_train_tasks()[0]
     state = task.init
-    print("state:", state)
-    robot = None
-    for item in state:
-        if item.type != block_type:
-            robot = item
-            continue
-        assert not (state.get(item, "held") and env._Clear_holds(item, state))  # pylint: disable=protected-access
-    assert robot is not None
+    block0 = list(state)[0]
+    block1 = list(state)[1]
+    assert clear(block0, state)
+    assert not clear(block1, state)
 
 
 def test_blocks_load_task_from_json():

--- a/tests/envs/test_blocks.py
+++ b/tests/envs/test_blocks.py
@@ -9,7 +9,7 @@ import numpy as np
 
 import predicators.envs.blocks
 from predicators import utils
-from predicators.envs.blocks import BlocksEnv
+from predicators.envs.blocks import BlocksEnv, BlocksEnvClear
 
 _MODULE_PATH = predicators.envs.blocks.__name__
 
@@ -129,6 +129,24 @@ def test_blocks_failure_cases():
     act = Stack.ground([robot, block0], np.zeros(0)).policy(state)
     next_state = env.simulate(state, act)
     assert state.allclose(next_state)
+
+
+def test_blocks_clear():
+    """Tests for BlocksEnvClear class."""
+    utils.reset_config({"env": "blocks_clear"})
+    env = BlocksEnvClear()
+    block_type = [t for t in env.types if t.name == "block"][0]
+    assert "clear" in block_type.feature_names
+    task = env.get_train_tasks()[0]
+    state = task.init
+    print("state:", state)
+    robot = None
+    for item in state:
+        if item.type != block_type:
+            robot = item
+            continue
+        assert not (state.get(item, "held") and env._Clear_holds(item, state))  # pylint: disable=protected-access
+    assert robot is not None
 
 
 def test_blocks_load_task_from_json():


### PR DESCRIPTION
A version of `BlocksEnv` where the block type has a feature name "clear" indicating whether the block is clear. This way we can learn all the predicates in the env with the assumption that the predicates are a function of only their argument's states.