### PR TITLE
Implements arity-2 classifiers

### DIFF
--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -199,7 +199,7 @@ class _DoubleAttributeCompareClassifier(_BinaryClassifier):
         name2 = CFG.grammar_search_classifier_pretty_str_names[
             self.object2_index]
         vars_str = (f"{name1}:{self.object1_type.name}, "
-                    "{name2}:{self.object2_type.name}")
+                    f"{name2}:{self.object2_type.name}")
         body_str = (f"(|{name1}.{self.attribute1_name} - "
                     f"{name2}.{self.attribute2_name}| "
                     f"{self.compare_str} {self.constant:.3})")

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -31,10 +31,12 @@ from predicators.structs import Dataset, GroundAtom, GroundAtomTrajectory, \
 
 def _create_grammar(dataset: Dataset,
                     given_predicates: Set[Predicate]) -> _PredicateGrammar:
-    # We start with considering various ways to split single feature values
-    # across our dataset.
+    # We start with considering various ways to split either single or
+    # double feature values across our dataset.
     grammar: _PredicateGrammar = _SingleFeatureInequalitiesPredicateGrammar(
         dataset)
+    if CFG.grammar_search_grammar_use_double_features:
+        grammar = _DoubleFeatureInequalitiesPredicateGrammar(dataset)
     # We next optionally add in the given predicates because we want to allow
     # negated and quantified versions of the given predicates, in
     # addition to negated and quantified versions of new predicates.

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -120,6 +120,18 @@ class _UnaryClassifier(_ProgrammaticClassifier):
         raise NotImplementedError("Override me!")
 
 
+class _BinaryClassifier(_ProgrammaticClassifier):
+    """A classifier on two object."""
+
+    def __call__(self, s: State, o: Sequence[Object]) -> bool:
+        assert len(o) == 2
+        return self._classify_object(s, o[0], o[1])
+
+    @abc.abstractmethod
+    def _classify_object(self, s: State, obj1: Object, obj2: Object) -> bool:
+        raise NotImplementedError("Override me!")
+
+
 @dataclass(frozen=True, eq=False, repr=False)
 class _SingleAttributeCompareClassifier(_UnaryClassifier):
     """Compare a single feature value with a constant value."""
@@ -146,6 +158,48 @@ class _SingleAttributeCompareClassifier(_UnaryClassifier):
             self.object_index]
         vars_str = f"{name}:{self.object_type.name}"
         body_str = (f"({name}.{self.attribute_name} "
+                    f"{self.compare_str} {self.constant:.3})")
+        return vars_str, body_str
+
+
+@dataclass(frozen=True, eq=False, repr=False)
+class _DoubleAttributeCompareClassifier(_BinaryClassifier):
+    """Compare a single feature value with a constant value."""
+    object1_index: int
+    object1_type: Type
+    attribute1_name: str
+    object2_index: int
+    object2_type: Type
+    attribute2_name: str
+    constant: float
+    constant_idx: int
+    compare: Callable[[float, float], bool]
+    compare_str: str
+
+    def _classify_object(self, s: State, obj1: Object, obj2: Object) -> bool:
+        assert obj1.type == self.object1_type
+        assert obj2.type == self.object2_type
+        return self.compare(
+            abs(
+                s.get(obj1, self.attribute1_name) -
+                s.get(obj2, self.attribute2_name)), self.constant)
+
+    def __str__(self) -> str:
+        return (f"(|({self.object1_index}:{self.object1_type.name})."
+                f"{self.attribute1_name} - ({self.object2_index}:"
+                f"{self.object2_type.name}).{self.attribute2_name}|"
+                f"{self.compare_str}[idx {self.constant_idx}]"
+                f"{self.constant:.3})")
+
+    def pretty_str(self) -> Tuple[str, str]:
+        name1 = CFG.grammar_search_classifier_pretty_str_names[
+            self.object1_index]
+        name2 = CFG.grammar_search_classifier_pretty_str_names[
+            self.object2_index]
+        vars_str = (f"{name1}:{self.object1_type.name}, "
+                    "{name2}:{self.object2_type.name}")
+        body_str = (f"(|{name1}.{self.attribute1_name} - "
+                    f"{name2}.{self.attribute2_name}| "
                     f"{self.compare_str} {self.constant:.3})")
         return vars_str, body_str
 
@@ -440,6 +494,88 @@ class _SingleFeatureInequalitiesPredicateGrammar(_DataBasedPredicateGrammar):
                             feature_ranges[obj.type][f] = (min(mn,
                                                                v), max(mx, v))
         return feature_ranges
+
+
+@dataclass(frozen=True, eq=False, repr=False)
+class _DoubleFeatureInequalitiesPredicateGrammar(
+        _SingleFeatureInequalitiesPredicateGrammar):
+    """Generates features of the form "|0.feature - 1.feature| >= c" or
+    "|0.feature - 1.feature| <= c". This is also capable of
+    generating single-feature inequalities if 0 and 1 are the
+    same type."""
+
+    def enumerate(self) -> Iterator[Tuple[Predicate, float]]:
+        # Get ranges of feature values from data.
+        feature_ranges = self._get_feature_ranges()
+        # Edge case: if there are no features at all, return immediately.
+        if not any(r for r in feature_ranges.values()):
+            return
+        # 0.5, 0.25, 0.75, 0.125, 0.375, ...
+        constant_generator = _halving_constant_generator(0.0, 1.0)
+        for constant_idx, (constant, cost) in enumerate(constant_generator):
+            for (t1, t2) in itertools.combinations_with_replacement(
+                    sorted(self.types), 2):
+                for f1 in t1.feature_names:
+                    for f2 in t2.feature_names:
+                        if t1 == t2 and f1 == f2:
+                            # Return a single-arity predicate.
+                            lb, ub = feature_ranges[t1][f1]
+                            # Optimization: if lb == ub, there is no variation
+                            # among this feature, so there's no point in trying
+                            # to learn a classifier with it. So, skip the
+                            # feature.
+                            if abs(lb - ub) < 1e-6:
+                                continue
+                            # Scale the constant by the feature range.
+                            k = constant * (ub - lb) + lb
+                            # Only need one of (ge, le) because we can use
+                            # negations to get the other (modulo equality,
+                            # which we shouldn't rely on anyway because of
+                            # precision issues).
+                            comp, comp_str = le, "<="
+                            single_classifier = \
+                                _SingleAttributeCompareClassifier(
+                                0, t1, f1, k, constant_idx, comp, comp_str)
+                            name = str(single_classifier)
+                            types = [t1]
+                            pred = Predicate(name, types, single_classifier)
+                            assert pred.arity == 1
+                            yield (pred, 1 + cost
+                                   )  # cost = arity + cost from constant
+
+                        # In this case, we actually need a binary attribute
+                        # comparison classifier.
+                        lb1, ub1 = feature_ranges[t1][f1]
+                        if abs(lb1 - ub1) < 1e-6:
+                            continue
+                        lb2, ub2 = feature_ranges[t2][f2]
+                        if abs(lb2 - ub2) < 1e-6:
+                            continue
+                        if self.f_range_intersection(lb1, ub1, lb2, ub2):
+                            lb = 0.0
+                        else:
+                            lb = min(abs(lb2 - ub1), abs(lb1 - ub2))
+                        ub = max(abs(ub2 - lb1), abs(ub1 - lb2))
+
+                        # Scale the constant by the correct range.
+                        k = constant * (ub - lb) + lb
+                        # Create classifier.
+                        comp, comp_str = le, "<="
+                        double_classifier = _DoubleAttributeCompareClassifier(
+                            0, t1, f1, 1, t2, f2, k, constant_idx, comp,
+                            comp_str)
+                        name = str(double_classifier)
+                        types = [t1, t2]
+                        pred = Predicate(name, types, double_classifier)
+                        assert pred.arity == 2
+                        yield (pred, 2 + cost
+                               )  # cost = arity + cost from constant
+
+    def f_range_intersection(self, lb1: float, ub1: float, lb2: float,
+                             ub2: float) -> bool:
+        """Given upper and lower bounds for two feature ranges, returns True
+        iff the ranges intersect."""
+        return (lb1 <= lb2 <= ub1) or (lb2 <= lb1 <= ub2)
 
 
 @dataclass(frozen=True, eq=False, repr=False)

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -459,6 +459,7 @@ class GlobalSettings:
     # grammar search invention parameters
     grammar_search_grammar_includes_givens = True
     grammar_search_grammar_includes_foralls = True
+    grammar_search_grammar_use_double_features = True
     grammar_search_use_handcoded_debug_grammar = False
     grammar_search_true_pos_weight = 10
     grammar_search_false_pos_weight = 1

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -459,7 +459,7 @@ class GlobalSettings:
     # grammar search invention parameters
     grammar_search_grammar_includes_givens = True
     grammar_search_grammar_includes_foralls = True
-    grammar_search_grammar_use_double_features = True
+    grammar_search_grammar_use_double_features = False
     grammar_search_use_handcoded_debug_grammar = False
     grammar_search_true_pos_weight = 10
     grammar_search_false_pos_weight = 1

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -459,7 +459,7 @@ class GlobalSettings:
     # grammar search invention parameters
     grammar_search_grammar_includes_givens = True
     grammar_search_grammar_includes_foralls = True
-    grammar_search_grammar_use_double_features = False
+    grammar_search_grammar_use_diff_features = False
     grammar_search_use_handcoded_debug_grammar = False
     grammar_search_true_pos_weight = 10
     grammar_search_false_pos_weight = 1

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -2899,3 +2899,21 @@ def find_all_balanced_expressions(s: str) -> List[str]:
     assert balance == 0
     exprs.append(s[start_index:index + 1])
     return exprs
+
+
+def f_range_intersection(lb1: float, ub1: float, lb2: float,
+                         ub2: float) -> bool:
+    """Given upper and lower bounds for two feature ranges, returns True iff
+    the ranges intersect."""
+    return (lb1 <= lb2 <= ub1) or (lb2 <= lb1 <= ub2)
+
+
+def roundrobin(iterables: Sequence[Iterator]) -> Iterator:
+    """roundrobin(['ABC...', 'D...', 'EF...']) --> A D E B F C..."""
+    # Recipe credited to George Sakkis, code adapted slightly from
+    # from https://docs.python.org/3/library/itertools.html
+    num_active = len(iterables)
+    nexts = itertools.cycle(iter(it).__next__ for it in iterables)
+    while num_active:
+        for nxt in nexts:
+            yield nxt()

--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -81,7 +81,7 @@ def test_predicate_grammar(segmenter):
         "env": "cover"
     })
     forall_grammar = _create_grammar(dataset, env.predicates)
-    assert len(forall_grammar.generate(max_num=100)) == 48
+    assert len(forall_grammar.generate(max_num=100)) == 55
     # Test CFG.grammar_search_predicate_cost_upper_bound.
     default = CFG.grammar_search_predicate_cost_upper_bound
     utils.reset_config({"grammar_search_predicate_cost_upper_bound": 0})


### PR DESCRIPTION
Changes necessary to get arity-2 classifiers. This is being implemented in anticipation of doing predicate invention in domains that are more complex than original AAAI paper domains.

To run, try:
```
python predicators/main.py --env cover --approach grammar_search_invention --excluded_predicates all --num_train_tasks 20 --seed 456 --grammar_search_grammar_use_diff_features True
```
Interestingly, this solves 46/50 eval tasks, while setting the `--grammar_search_grammar_use_diff_features True` arg to `False` only solves 43.
