### PR TITLE
Minor GitIgnore update to prevent unnecessary traj data from being committed to GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ scripts/results
 llm_cache
 machines.txt
 *_vision_data
+tests/_fake_trajs
+tests/_fake_results
 
 # Jetbrains IDEs
 .idea/


### PR DESCRIPTION
When tests are run locally, the `tests/_fake_trajs` folder gets populated with random trajs. This PR adds that folder to the gitignore so that these aren't committed to the repo unnecessarily.