### PR TITLE
generalize loading test tasks from json files

### DIFF
--- a/predicators/envs/base_env.py
+++ b/predicators/envs/base_env.py
@@ -1,6 +1,7 @@
 """Base class for an environment."""
 
 import abc
+from pathlib import Path
 from typing import Callable, List, Optional, Set
 
 import matplotlib
@@ -169,8 +170,23 @@ class BaseEnv(abc.ABC):
     def get_test_tasks(self) -> List[Task]:
         """Return the ordered list of tasks for testing / evaluation."""
         if not self._test_tasks:
-            self._test_tasks = self._generate_test_tasks()
+            if CFG.test_task_json_dir is not None:
+                files = list(Path(CFG.test_task_json_dir).glob("*.json"))
+                assert len(files) >= CFG.num_test_tasks
+                self._test_tasks = [
+                    self._load_task_from_json(f)
+                    for f in files[:CFG.num_test_tasks]
+                ]
+            else:
+                self._test_tasks = self._generate_test_tasks()
         return self._test_tasks
+
+    def _load_task_from_json(self, json_file: Path) -> Task:
+        """Create a task from a JSON file.
+
+        Not all environments support this.
+        """
+        raise NotImplementedError("Override me!")
 
     def get_task(self, train_or_test: str, task_idx: int) -> Task:
         """Return the train or test task at the given index."""

--- a/predicators/envs/base_env.py
+++ b/predicators/envs/base_env.py
@@ -186,7 +186,8 @@ class BaseEnv(abc.ABC):
 
         Not all environments support this.
         """
-        raise NotImplementedError("Override me!")
+        raise NotImplementedError("This environment did not implement an "
+                                  "interface for loading JSON tasks!")
 
     def get_task(self, train_or_test: str, task_idx: int) -> Task:
         """Return the train or test task at the given index."""

--- a/predicators/envs/base_env.py
+++ b/predicators/envs/base_env.py
@@ -2,7 +2,7 @@
 
 import abc
 from pathlib import Path
-from typing import Callable, List, Optional, Set
+from typing import Callable, Dict, List, Optional, Set
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -12,7 +12,8 @@ from gym.spaces import Box
 from predicators import utils
 from predicators.settings import CFG
 from predicators.structs import Action, DefaultState, DefaultTask, \
-    ParameterizedOption, Predicate, State, Task, Type, Video
+    GroundAtom, Object, ParameterizedOption, Predicate, State, Task, Type, \
+    Video
 
 
 class BaseEnv(abc.ABC):
@@ -188,6 +189,20 @@ class BaseEnv(abc.ABC):
         """
         raise NotImplementedError("This environment did not implement an "
                                   "interface for loading JSON tasks!")
+
+    def _parse_goal_from_json(self, spec: Dict[str, List[List[str]]],
+                              id_to_obj: Dict[str, Object]) -> Set[GroundAtom]:
+        """Helper for parsing goals from JSON task specifications."""
+        goal_pred_names = {p.name for p in self.goal_predicates}
+        assert set(spec.keys()).issubset(goal_pred_names)
+        pred_to_args = {p: spec.get(p.name, []) for p in self.goal_predicates}
+        goal: Set[GroundAtom] = set()
+        for pred, args in pred_to_args.items():
+            for id_args in args:
+                obj_args = [id_to_obj[a] for a in id_args]
+                goal_atom = GroundAtom(pred, obj_args)
+                goal.add(goal_atom)
+        return goal
 
     def get_task(self, train_or_test: str, task_idx: int) -> Task:
         """Return the train or test task at the given index."""

--- a/predicators/envs/blocks.py
+++ b/predicators/envs/blocks.py
@@ -204,11 +204,6 @@ class BlocksEnv(BaseEnv):
                                rng=self._train_rng)
 
     def _generate_test_tasks(self) -> List[Task]:
-        if CFG.blocks_test_task_json_dir is not None:
-            files = list(Path(CFG.blocks_test_task_json_dir).glob("*.json"))
-            assert len(files) >= CFG.num_test_tasks
-            return [self._load_task_from_json(f) for f in files]
-
         return self._get_tasks(num_tasks=CFG.num_test_tasks,
                                possible_num_blocks=self._num_blocks_test,
                                rng=self._test_rng)

--- a/predicators/envs/blocks.py
+++ b/predicators/envs/blocks.py
@@ -586,17 +586,10 @@ class BlocksEnv(BaseEnv):
         }
         init_state = utils.create_state_from_dict(state_dict)
         # Create the goal from the task spec.
-        goal_spec = task_spec["goal"]
-        assert set(goal_spec.keys()).issubset({"On", "OnTable"})
-        on_args = goal_spec.get("On", [])
-        on_table_args = goal_spec.get("OnTable", [])
-        pred_to_args = {self._On: on_args, self._OnTable: on_table_args}
-        goal: Set[GroundAtom] = set()
-        for pred, args in pred_to_args.items():
-            for id_args in args:
-                obj_args = [id_to_obj[a] for a in id_args]
-                goal_atom = GroundAtom(pred, obj_args)
-                goal.add(goal_atom)
+        if "goal" in task_spec:
+            goal = self._parse_goal_from_json(task_spec["goal"], id_to_obj)
+        else:
+            raise ValueError("JSON task spec must include 'goal'.")
         task = Task(init_state, goal)
         assert not task.goal_holds(init_state)
         return task

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -64,7 +64,7 @@ class GlobalSettings:
     # blocks env parameters
     blocks_num_blocks_train = [3, 4]
     blocks_num_blocks_test = [5, 6]
-    blocks_test_task_json_dir = None
+    test_task_json_dir = None
     blocks_holding_goals = False
     blocks_block_size = 0.045  # use 0.0505 for real with panda
 

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -32,6 +32,8 @@ class GlobalSettings:
     pretty_print_when_loading = False
     # Used for random seeding in test environment.
     test_env_seed_offset = 10000
+    # Optionally define test tasks in JSON format
+    test_task_json_dir = None
     # The method to use for segmentation. By default, segment using options.
     # If you are learning options, you should change this via the command line.
     segmenter = "option_changes"
@@ -64,7 +66,6 @@ class GlobalSettings:
     # blocks env parameters
     blocks_num_blocks_train = [3, 4]
     blocks_num_blocks_test = [5, 6]
-    test_task_json_dir = None
     blocks_holding_goals = False
     blocks_block_size = 0.045  # use 0.0505 for real with panda
 

--- a/scripts/run_blocks_real.sh
+++ b/scripts/run_blocks_real.sh
@@ -36,7 +36,7 @@ python scripts/run_blocks_perception.py \
 echo "Running planning with oracle models."
 python predicators/main.py --env pybullet_blocks --approach oracle \
     --seed $SEED --num_test_tasks 1 \
-    --blocks_test_task_json_dir $TASK_DIR \
+    --test_task_json_dir $TASK_DIR \
     --pybullet_robot panda \
     --option_model_use_gui $VIZ_PLANNING \
     --option_model_name oracle --option_model_terminate_on_repeat False \

--- a/tests/envs/test_blocks.py
+++ b/tests/envs/test_blocks.py
@@ -181,7 +181,7 @@ def test_blocks_load_task_from_json():
         utils.reset_config({
             "env": "blocks",
             "num_test_tasks": 1,
-            "blocks_test_task_json_dir": json_dir
+            "test_task_json_dir": json_dir
         })
 
         env = BlocksEnv()
@@ -239,7 +239,7 @@ robby              1.35      0.75       0.7          1
             utils.reset_config({
                 "env": "blocks",
                 "num_test_tasks": 1,
-                "blocks_test_task_json_dir": json_dir
+                "test_task_json_dir": json_dir
             })
 
             env = BlocksEnv()

--- a/tests/envs/test_blocks.py
+++ b/tests/envs/test_blocks.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
+import pytest
 
 import predicators.envs.blocks
 from predicators import utils
@@ -207,6 +208,42 @@ robby              1.35      0.75       0.7          1
     assert str(
         sorted(task.goal)
     ) == "[On(green_block:block, blue_block:block), On(red_block:block, green_block:block), OnTable(blue_block:block)]"
+
+    # Test that an error is raised if we try to parse a task with no goal.
+    task_spec = {
+        "problem_name": "blocks_test_problem2",
+        "blocks": {
+            "red_block": {
+                "position": [1.36409716, 1.0389289, 0.2225],
+                "color": [1, 0, 0]
+            },
+            "green_block": {
+                "position": [1.36409716, 1.0389289, 0.2675],
+                "color": [0, 1, 0]
+            },
+            "blue_block": {
+                "position": [1.35479861, 0.91064759, 0.2225],
+                "color": [0, 0, 1]
+            }
+        },
+        "block_size": 0.045,
+    }
+
+    with tempfile.TemporaryDirectory() as json_dir:
+        json_file = Path(json_dir) / "example_task2.json"
+        with open(json_file, "w", encoding="utf-8") as f:
+            json.dump(task_spec, f)
+
+        utils.reset_config({
+            "env": "blocks",
+            "num_test_tasks": 1,
+            "test_task_json_dir": json_dir
+        })
+
+        env = BlocksEnv()
+        with pytest.raises(ValueError) as e:
+            env.get_test_tasks()
+        assert "JSON task spec must include 'goal'" in str(e)
 
     # Test that a warning is raised if we try to load from a state where the
     # blocks are not in the workspace.

--- a/tests/envs/test_cover.py
+++ b/tests/envs/test_cover.py
@@ -118,6 +118,9 @@ def test_cover(env_name):
     with pytest.raises(NotImplementedError) as e:
         env.get_event_to_action_fn()
     assert "did not implement an interface for human demonstrations" in str(e)
+    with pytest.raises(NotImplementedError) as e:
+        env._load_task_from_json("")  # pylint:disable=protected-access
+    assert "did not implement an interface for loading JSON tasks" in str(e)
 
 
 def test_cover_typed_options():

--- a/tests/envs/test_pybullet_blocks.py
+++ b/tests/envs/test_pybullet_blocks.py
@@ -554,7 +554,7 @@ def test_pybullet_blocks_load_task_from_json():
         utils.reset_config({
             "env": "blocks",
             "num_test_tasks": 1,
-            "blocks_test_task_json_dir": json_dir
+            "test_task_json_dir": json_dir
         })
 
         env = PyBulletBlocksEnv(use_gui=False)


### PR DESCRIPTION
this was previously implemented for blocks only. new environments will still need to implement `_load_task_from_json` but that's it.