### PR TITLE
Add flag for toggling usage of necessary atoms sequence in `planning.py`

### DIFF
--- a/predicators/planning.py
+++ b/predicators/planning.py
@@ -194,12 +194,15 @@ def _sesame_plan_with_astar(
                     sorted(proposed_skeletons,
                            key=lambda s: estimator.get_cost(*s)))
             for skeleton, atoms_sequence in gen:
-                necessary_atoms_seq = utils.compute_necessary_atoms_seq(
-                    skeleton, atoms_sequence, task.goal)
+                if CFG.sesame_use_necessary_atoms:
+                    atoms_seq = utils.compute_necessary_atoms_seq(
+                        skeleton, atoms_sequence, task.goal)
+                else:
+                    atoms_seq = atoms_sequence
                 plan, suc = run_low_level_search(
-                    task, option_model, skeleton, necessary_atoms_seq,
-                    new_seed, timeout - (time.perf_counter() - start_time),
-                    metrics, max_horizon)
+                    task, option_model, skeleton, atoms_seq, new_seed,
+                    timeout - (time.perf_counter() - start_time), metrics,
+                    max_horizon)
                 if suc:
                     # Success! It's a complete plan.
                     logging.info(

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -331,6 +331,7 @@ class GlobalSettings:
     sesame_task_planning_heuristic = "lmcut"
     sesame_allow_noops = True  # recommended to keep this False if using replays
     sesame_check_expected_atoms = True
+    sesame_use_necessary_atoms = True
     sesame_use_visited_state_set = False
     # The algorithm used for grounding the planning problem. Choices are
     # "naive" or "fd_translator". The former does a type-aware cross product

--- a/scripts/configs/interactive_learning.yaml
+++ b/scripts/configs/interactive_learning.yaml
@@ -79,5 +79,6 @@ FLAGS:  # common args
   min_data_for_nsrt: 10
   sampler_disable_classifier: True
   mlp_classifier_balance_data: False
+  sesame_use_necessary_atoms: False
 START_SEED: 123
 NUM_SEEDS: 10

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -25,16 +25,20 @@ from predicators.structs import NSRT, Action, ParameterizedOption, Predicate, \
 
 
 @pytest.mark.parametrize(
-    "sesame_check_expected_atoms,sesame_grounder,expectation",
-    [(True, "naive", does_not_raise()), (False, "naive", does_not_raise()),
-     (True, "fd_translator", does_not_raise()),
-     (True, "not a real grounder", pytest.raises(ValueError))])
-def test_sesame_plan(sesame_check_expected_atoms, sesame_grounder,
-                     expectation):
+    "sesame_check_expected_atoms,sesame_grounder,expectation,"
+    "sesame_use_necessary_atoms",
+    [(True, "naive", does_not_raise(), True),
+     (True, "naive", does_not_raise(), False),
+     (False, "naive", does_not_raise(), True),
+     (True, "fd_translator", does_not_raise(), True),
+     (True, "not a real grounder", pytest.raises(ValueError), True)])
+def test_sesame_plan(sesame_check_expected_atoms, sesame_grounder, expectation,
+                     sesame_use_necessary_atoms):
     """Tests for sesame_plan() with A*."""
     utils.reset_config({
         "env": "cover",
         "sesame_check_expected_atoms": sesame_check_expected_atoms,
+        "sesame_use_necessary_atoms": sesame_use_necessary_atoms,
         "sesame_grounder": sesame_grounder,
         "num_test_tasks": 1,
         "sesame_task_planner": "astar",


### PR DESCRIPTION
`CFG.sesame_use_necessary_atoms` defaults to True, but should be set to False for interactive learning experiments as using the necessary atoms sequence was making the GLIB action baseline perform abnormally well