### PR TITLE
sandwich environment

### DIFF
--- a/predicators/envs/sandwich.py
+++ b/predicators/envs/sandwich.py
@@ -1,8 +1,8 @@
 """Sandwich making domain."""
 
+import itertools
 import json
 import logging
-import itertools
 from pathlib import Path
 from typing import ClassVar, Dict, List, Optional, Sequence, Set, Tuple
 
@@ -284,21 +284,24 @@ class SandwichEnv(BaseEnv):
         }
         state_dict = {self._holder: holder_state, self._board: board_state}
         # Sample ingredients.
-        ing_count = itertools.count()
         ing_spacing = self.ingredient_thickness
         # Add padding.
         tot_num_ings = sum(ingredient_to_num.values())
         tot_thickness = tot_num_ings * self.ingredient_thickness
         ing_spacing += (self.holder_length - tot_thickness) / (tot_num_ings -
                                                                1)
+        # Randomly order the ingredients.
+        order_indices = list(range(tot_num_ings))
         for ing, num in ingredient_to_num.items():
             ing_static_features = self._ingredient_to_static_features(ing)
             radius = ing_static_features["radius"]
             for ing_i in range(num):
                 obj_name = f"{ing}{ing_i}"
                 obj = Object(obj_name, self._ingredient_type)
+                order_idx = rng.choice(order_indices)
+                order_indices.remove(order_idx)
                 pose_y = (holder_y - self.holder_length / 2) + \
-                         next(ing_count) * ing_spacing + \
+                         order_idx * ing_spacing + \
                          self.ingredient_thickness / 2.
                 state_dict[obj] = {
                     "pose_x": holder_x,

--- a/predicators/envs/sandwich.py
+++ b/predicators/envs/sandwich.py
@@ -1,0 +1,290 @@
+"""Sandwich making domain."""
+
+import json
+import logging
+from pathlib import Path
+from typing import ClassVar, Dict, List, Optional, Sequence, Set, Tuple
+
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+from gym.spaces import Box
+from matplotlib import patches
+
+from predicators import utils
+from predicators.envs import BaseEnv
+from predicators.settings import CFG
+from predicators.structs import Action, Array, GroundAtom, Object, \
+    ParameterizedOption, Predicate, State, Task, Type
+
+
+class SandwichEnv(BaseEnv):
+    """Sandwich making domain."""
+    # Parameters that aren't important enough to need to clog up settings.py
+    # The table x bounds are (1.1, 1.6), but the workspace is smaller.
+    # Make it narrow enough that blocks can be only horizontally arranged.
+    # Note that these boundaries are for the block positions, and that a
+    # block's origin is its center, so the block itself may extend beyond
+    # the boundaries while the origin remains in bounds.
+    x_lb: ClassVar[float] = 1.325
+    x_ub: ClassVar[float] = 1.375
+    # The table y bounds are (0.3, 1.2), but the workspace is smaller.
+    y_lb: ClassVar[float] = 0.4
+    y_ub: ClassVar[float] = 1.1
+    held_tol: ClassVar[float] = 0.5
+    on_tol: ClassVar[float] = 0.01
+
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__(use_gui)
+
+        # Types
+        self._ingredient_type = Type("ingredient", [
+            "pose_x", "pose_y", "pose_z", "held", "color_r", "color_g",
+            "color_b", "thickness", "radius", "shape"
+        ])
+        self._robot_type = Type("robot",
+                                ["pose_x", "pose_y", "pose_z", "fingers"])
+        self._holder_type = Type(
+            "holder", ["pose_x", "pose_y", "pose_z", "width", "height"])
+        self._board_type = Type(
+            "board", ["pose_x", "pose_y", "pose_z", "width", "height"])
+        # Predicates
+        self._InHolder = Predicate("InHolder",
+                                   [self._ingredient_type, self._holder_type],
+                                   self._InHolder_holds)
+        self._On = Predicate("On",
+                             [self._ingredient_type, self._ingredient_type],
+                             self._On_holds)
+        self._OnBoard = Predicate("OnBoard",
+                                  [self._ingredient_type, self._board_type],
+                                  self._OnBoard_holds)
+        self._GripperOpen = Predicate("GripperOpen", [self._robot_type],
+                                      self._GripperOpen_holds)
+        self._Holding = Predicate("Holding",
+                                  [self._ingredient_type, self._robot_type],
+                                  self._Holding_holds)
+        self._Clear = Predicate("Clear", [self._ingredient_type],
+                                self._Clear_holds)
+        self._IsBread = Predicate("IsBread", [self._ingredient_type],
+                                  self._IsBread_holds)
+        self._IsBurger = Predicate("IsBurger", [self._ingredient_type],
+                                   self._IsBurger_holds)
+        self._IsHam = Predicate("IsHam", [self._ingredient_type],
+                                self._IsHam_holds)
+        self._IsEgg = Predicate("IsEgg", [self._ingredient_type],
+                                self._IsEgg_holds)
+        self._IsCheese = Predicate("IsCheese", [self._ingredient_type],
+                                   self._IsCheese_holds)
+        self._IsLettuce = Predicate("IsLettuce", [self._ingredient_type],
+                                    self._IsLettuce_holds)
+        self._IsTomato = Predicate("IsTomato", [self._ingredient_type],
+                                   self._IsTomato_holds)
+        self._IsGreenPepper = Predicate("IsGreenPepper",
+                                        [self._ingredient_type],
+                                        self._IsGreenPepper_holds)
+        # Options
+        self._Pick: ParameterizedOption = utils.SingletonParameterizedOption(
+            # variables: [robot, object to pick]
+            # params: []
+            "Pick",
+            self._Pick_policy,
+            types=[self._robot_type, self._ingredient_type])
+        self._Stack: ParameterizedOption = utils.SingletonParameterizedOption(
+            # variables: [robot, object on which to stack currently-held-object]
+            # params: []
+            "Stack",
+            self._Stack_policy,
+            types=[self._robot_type, self._ingredient_type])
+        self._PutOnBoard: ParameterizedOption = \
+            utils.SingletonParameterizedOption(
+            # variables: [robot]
+            "PutOnBoard",
+            self._PutOnBoard_policy,
+            types=[self._robot_type])
+        # Static objects (always exist no matter the settings).
+        self._robot = Object("robby", self._robot_type)
+        self._num_ingredients_train = CFG.sandwich_ingredients_train
+        self._num_ingredients_test = CFG.sandwich_ingredients_test
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "sandwich"
+
+    def simulate(self, state: State, action: Action) -> State:
+        assert self.action_space.contains(action.arr)
+        # TODO
+        return state.copy()
+
+    def _generate_train_tasks(self) -> List[Task]:
+        return self._get_tasks(num_tasks=CFG.num_train_tasks,
+                               num_ingredients=self._num_ingredients_train,
+                               rng=self._train_rng)
+
+    def _generate_test_tasks(self) -> List[Task]:
+        return self._get_tasks(num_tasks=CFG.num_test_tasks,
+                               num_ingredients=self._num_ingredients_test,
+                               rng=self._test_rng)
+
+    @property
+    def predicates(self) -> Set[Predicate]:
+        return {
+            self._On, self._OnBoard, self._GripperOpen, self._Holding,
+            self._Clear, self._InHolder, self._IsBread, self._IsBurger,
+            self._IsHam, self._IsEgg, self._IsCheese, self._IsLettuce,
+            self._IsTomato, self._IsGreenPepper
+        }
+
+    @property
+    def goal_predicates(self) -> Set[Predicate]:
+        return {
+            self._On, self._OnBoard, self._IsBread, self._IsBurger,
+            self._IsHam, self._IsEgg, self._IsCheese, self._IsLettuce,
+            self._IsTomato, self._IsGreenPepper
+        }
+
+    @property
+    def types(self) -> Set[Type]:
+        return {self._ingredient_type, self._robot_type}
+
+    @property
+    def options(self) -> Set[ParameterizedOption]:
+        return {self._Pick, self._Stack, self._PutOnBoard}
+
+    @property
+    def action_space(self) -> Box:
+        # dimensions: [x, y, z, fingers]
+        lowers = np.array([self.x_lb, self.y_lb, 0.0, 0.0], dtype=np.float32)
+        uppers = np.array([self.x_ub, self.y_ub, 10.0, 1.0], dtype=np.float32)
+        return Box(lowers, uppers)
+
+    def render_state_plt(
+            self,
+            state: State,
+            task: Task,
+            action: Optional[Action] = None,
+            caption: Optional[str] = None) -> matplotlib.figure.Figure:
+        fig = plt.figure()
+        title = ""
+        if caption is not None:
+            title += f"; {caption}"
+        plt.suptitle(title, fontsize=24, wrap=True)
+        plt.tight_layout()
+        return fig
+
+    def _get_tasks(self, num_tasks: int, num_ingredients: Dict[str, List[int]],
+                   rng: np.random.Generator) -> List[Task]:
+        tasks = []
+        for _ in range(num_tasks):
+            ing_to_num: Dict[str, int] = {}
+            for ing_name, possible_ing_nums in num_ingredients.items():
+                num_ing = rng.choice(possible_ing_nums)
+                ing_to_num[ing_name] = num_ing
+            init_state = self._sample_initial_state(ing_to_num, rng)
+            goal = self._sample_goal(ing_to_num, rng)
+            goal_holds = all(goal_atom.holds(init_state) for goal_atom in goal)
+            assert not goal_holds
+            tasks.append(Task(init_state, goal))
+        return tasks
+
+    def _sample_initial_state(self, ingredient_to_num: Dict[str, int],
+                              rng: np.random.Generator) -> State:
+        import ipdb; ipdb.set_trace()
+
+    def _sample_goal(self, ingredient_to_num: Dict[str, int],
+                     rng: np.random.Generator) -> Set[GroundAtom]:
+        import ipdb; ipdb.set_trace()
+
+    def _On_holds(self, state: State, objects: Sequence[Object]) -> bool:
+        obj1, obj2 = objects
+        if state.get(obj1, "held") >= self.held_tol or \
+           state.get(obj2, "held") >= self.held_tol:
+            return False
+        x1 = state.get(obj1, "pose_x")
+        y1 = state.get(obj1, "pose_y")
+        z1 = state.get(obj1, "pose_z")
+        thick1 = state.get(obj1, "thickness")
+        x2 = state.get(obj2, "pose_x")
+        y2 = state.get(obj2, "pose_y")
+        z2 = state.get(obj2, "pose_z")
+        thick2 = state.get(obj2, "thickness")
+        offset = thick1 / 2 + thick2 / 2
+        return np.allclose([x1, y1, z1], [x2, y2, z2 + offset],
+                           atol=self.on_tol)
+
+    def _InHolder_holds(self, state: State, objects: Sequence[Object]) -> bool:
+        # TODO
+        return False
+
+    def _OnBoard_holds(self, state: State, objects: Sequence[Object]) -> bool:
+        # TODO
+        return False
+
+    @staticmethod
+    def _GripperOpen_holds(state: State, objects: Sequence[Object]) -> bool:
+        robot, = objects
+        rf = state.get(robot, "fingers")
+        assert rf in (0.0, 1.0)
+        return rf == 1.0
+
+    def _Holding_holds(self, state: State, objects: Sequence[Object]) -> bool:
+        # TODO
+        return False
+
+    def _Clear_holds(self, state: State, objects: Sequence[Object]) -> bool:
+        # TODO
+        return False
+
+    def _IsBread_holds(self, state: State, objects: Sequence[Object]) -> bool:
+        # TODO
+        return False
+
+    def _IsBurger_holds(self, state: State, objects: Sequence[Object]) -> bool:
+        # TODO
+        return False
+
+    def _IsHam_holds(self, state: State, objects: Sequence[Object]) -> bool:
+        # TODO
+        return False
+
+    def _IsEgg_holds(self, state: State, objects: Sequence[Object]) -> bool:
+        # TODO
+        return False
+
+    def _IsLettuce_holds(self, state: State,
+                         objects: Sequence[Object]) -> bool:
+        # TODO
+        return False
+
+    def _IsTomato_holds(self, state: State, objects: Sequence[Object]) -> bool:
+        # TODO
+        return False
+
+    def _IsCheese_holds(self, state: State, objects: Sequence[Object]) -> bool:
+        # TODO
+        return False
+
+    def _IsGreenPepper_holds(self, state: State,
+                             objects: Sequence[Object]) -> bool:
+        # TODO
+        return False
+
+    def _Pick_policy(self, state: State, memory: Dict,
+                     objects: Sequence[Object], params: Array) -> Action:
+        del memory, params  # unused
+        # TODO
+        arr = np.add(self.action_space.low, self.action_space.high) / 2.
+        return Action(arr)
+
+    def _Stack_policy(self, state: State, memory: Dict,
+                      objects: Sequence[Object], params: Array) -> Action:
+        del memory, params  # unused
+        # TODO
+        arr = np.add(self.action_space.low, self.action_space.high) / 2.
+        return Action(arr)
+
+    def _PutOnBoard_policy(self, state: State, memory: Dict,
+                           objects: Sequence[Object], params: Array) -> Action:
+        del state, memory, objects  # unused
+        # TODO
+        arr = np.add(self.action_space.low, self.action_space.high) / 2.
+        return Action(arr)

--- a/predicators/envs/sandwich.py
+++ b/predicators/envs/sandwich.py
@@ -1,18 +1,11 @@
 """Sandwich making domain."""
 
-import itertools
-import json
-import logging
-from collections import defaultdict
-from pathlib import Path
-from typing import ClassVar, DefaultDict, Dict, List, Optional, Sequence, \
-    Set, Tuple
+from typing import ClassVar, Dict, List, Optional, Sequence, Set, Tuple
 
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 from gym.spaces import Box
-from matplotlib import patches
 
 from predicators import utils
 from predicators.envs import BaseEnv
@@ -177,7 +170,7 @@ class SandwichEnv(BaseEnv):
             return self._transition_pick(state, x, y, z)
         thickness = self.ingredient_thickness + self.board_thickness
         if z < self.table_height + thickness:
-            return self._transition_putonboard(state, x, y, z)
+            return self._transition_putonboard(state, x, y)
         return self._transition_stack(state, x, y, z)
 
     def _transition_pick(self, state: State, x: float, y: float,
@@ -200,8 +193,8 @@ class SandwichEnv(BaseEnv):
         next_state.set(self._robot, "fingers", 0.0)  # close fingers
         return next_state
 
-    def _transition_putonboard(self, state: State, x: float, y: float,
-                               z: float) -> State:
+    def _transition_putonboard(self, state: State, x: float,
+                               y: float) -> State:
         next_state = state.copy()
         # Can only putonboard if fingers are closed.
         if self._GripperOpen_holds(state, [self._robot]):
@@ -654,7 +647,7 @@ class SandwichEnv(BaseEnv):
 
     def _PutOnBoard_policy(self, state: State, memory: Dict,
                            objects: Sequence[Object], params: Array) -> Action:
-        del memory  # unused
+        del memory, params  # unused
         _, board = objects
         x = state.get(board, "pose_x")
         y = state.get(board, "pose_y")

--- a/predicators/envs/sandwich.py
+++ b/predicators/envs/sandwich.py
@@ -804,7 +804,7 @@ class SandwichEnv(BaseEnv):
         return None
 
     def _get_highest_object_below(self, state: State, x: float, y: float,
-                                 z: float) -> Optional[Object]:
+                                  z: float) -> Optional[Object]:
         objs_here = []
         for obj in state.get_objects(self._ingredient_type):
             pose = np.array(

--- a/predicators/envs/sandwich.py
+++ b/predicators/envs/sandwich.py
@@ -225,6 +225,21 @@ class SandwichEnv(BaseEnv):
         workspace_rect = utils.Rectangle(ws_x, ws_y, ws_width, ws_length, 0.0)
         workspace_rect.plot(ax, facecolor="white", edgecolor="black")
 
+        # Draw robot base (roughly) for reference.
+        rob_base_x_pad = 0.75 * ws_width
+        rob_base_x = ws_x + ws_width / 2 + rob_base_x_pad
+        rob_base_y = ws_y + ws_length / 2
+        rob_base_radius = min(ws_width, ws_length) * 0.2
+        robot_circ = utils.Circle(rob_base_x, rob_base_y, rob_base_radius)
+        robot_circ.plot(ax, facecolor="gray", edgecolor="black")
+        ax.text(rob_base_x,
+                rob_base_y,
+                "robot",
+                fontsize="x-small",
+                ha="center",
+                va="center",
+                bbox=dict(facecolor="white", edgecolor="black", alpha=0.5))
+
         # Draw objects, sorted in z order.
 
         def _get_z(obj: Object) -> float:
@@ -237,15 +252,29 @@ class SandwichEnv(BaseEnv):
             geom = self._obj_to_geom2d(obj, state, "topdown")
             color = self._obj_to_color(obj, state)
             geom.plot(ax, facecolor=color, edgecolor="black")
+            # Add text box.
+            if obj.is_instance(self._ingredient_type):
+                x = state.get(obj, "pose_x")
+                y = state.get(obj, "pose_y")
+                s = obj.name
+                ax.text(x,
+                        y,
+                        s,
+                        fontsize="x-small",
+                        ha="center",
+                        va="center",
+                        bbox=dict(facecolor="white",
+                                  edgecolor="black",
+                                  alpha=0.5))
 
         title = ""
         if caption is not None:
             title += f"; {caption}"
         plt.suptitle(title, fontsize=24, wrap=True)
 
-        ax.set_xlim(self.x_lb, self.x_ub)
+        ax.set_xlim(self.x_lb, rob_base_x + rob_base_radius)
         ax.set_ylim(self.y_lb, self.y_ub)
-        # ax.axis("off")
+        ax.axis("off")
         plt.tight_layout()
         return fig
 
@@ -464,7 +493,7 @@ class SandwichEnv(BaseEnv):
 
     def _ingredient_to_static_features(self,
                                        ing_name: str) -> Dict[str, float]:
-        color_r, color_b, color_g = self.ingredient_colors[ing_name]
+        color_r, color_g, color_b = self.ingredient_colors[ing_name]
         radius = self.ingredient_radii[ing_name]
         shape = self.ingredient_shapes[ing_name]
         return {

--- a/predicators/ground_truth_nsrts.py
+++ b/predicators/ground_truth_nsrts.py
@@ -57,6 +57,8 @@ def get_gt_nsrts(env_name: str, predicates: Set[Predicate],
         nsrts = _get_coffee_gt_nsrts(env_name)
     elif env_name in ("satellites", "satellites_simple"):
         nsrts = _get_satellites_gt_nsrts(env_name)
+    elif env_name == "sandwich":
+        nsrts = _get_sandwich_gt_nsrts(env_name)
     else:
         raise NotImplementedError("Ground truth NSRTs not implemented")
     # Filter out excluded predicates from NSRTs, and filter out NSRTs whose
@@ -2858,5 +2860,96 @@ def _get_pddl_env_gt_nsrts(name: str) -> Set[NSRT]:
             sampler=null_sampler,
         )
         nsrts.add(nsrt)
+
+    return nsrts
+
+
+def _get_sandwich_gt_nsrts(env_name: str) -> Set[NSRT]:
+    """Create ground truth NSRTs for SandwichEnv."""
+    robot_type, ingredient_type, board_type, holder_type = _get_types_by_names(
+        env_name, ["robot", "ingredient", "board", "holder"])
+
+    On, OnBoard, InHolder, GripperOpen, Holding, Clear, BoardClear = \
+        _get_predicates_by_names(env_name, ["On", "OnBoard", "InHolder",
+                                            "GripperOpen", "Holding", "Clear",
+                                            "BoardClear"])
+
+    Pick, Stack, PutOnBoard = _get_options_by_names(
+        env_name, ["Pick", "Stack", "PutOnBoard"])
+
+    nsrts = set()
+
+    # PickFromHolder
+    ing = Variable("?ing", ingredient_type)
+    robot = Variable("?robot", robot_type)
+    holder = Variable("?holder", holder_type)
+    parameters = [ing, robot, holder]
+    option_vars = [robot, ing]
+    option = Pick
+    preconditions = {
+        LiftedAtom(InHolder, [ing, holder]),
+        LiftedAtom(GripperOpen, [robot])
+    }
+    add_effects = {LiftedAtom(Holding, [ing, robot])}
+    delete_effects = {
+        LiftedAtom(InHolder, [ing, holder]),
+        LiftedAtom(GripperOpen, [robot])
+    }
+
+    pickfromholder_nsrt = NSRT("PickFromHolder", parameters, preconditions,
+                               add_effects, delete_effects, set(), option,
+                               option_vars, null_sampler)
+    nsrts.add(pickfromholder_nsrt)
+
+    # Stack
+    ing = Variable("?ing", ingredient_type)
+    othering = Variable("?othering", ingredient_type)
+    robot = Variable("?robot", robot_type)
+    parameters = [ing, othering, robot]
+    option_vars = [robot, othering]
+    option = Stack
+    preconditions = {
+        LiftedAtom(Holding, [ing, robot]),
+        LiftedAtom(Clear, [othering])
+    }
+    add_effects = {
+        LiftedAtom(On, [ing, othering]),
+        LiftedAtom(Clear, [ing]),
+        LiftedAtom(GripperOpen, [robot])
+    }
+    delete_effects = {
+        LiftedAtom(Holding, [ing, robot]),
+        LiftedAtom(Clear, [othering])
+    }
+
+    stack_nsrt = NSRT("Stack", parameters, preconditions, add_effects,
+                      delete_effects, set(), option, option_vars, null_sampler)
+    nsrts.add(stack_nsrt)
+
+    # PutOnBoard
+    ing = Variable("?ing", ingredient_type)
+    robot = Variable("?robot", robot_type)
+    board = Variable("?board", board_type)
+    parameters = [ing, robot, board]
+    option_vars = [robot, board]
+    option = PutOnBoard
+    preconditions = {
+        LiftedAtom(Holding, [ing, robot]),
+        LiftedAtom(BoardClear, [board]),
+    }
+    add_effects = {
+        LiftedAtom(OnBoard, [ing, board]),
+        LiftedAtom(Clear, [ing]),
+        LiftedAtom(GripperOpen, [robot])
+    }
+    delete_effects = {
+        LiftedAtom(Holding, [ing, robot]),
+        LiftedAtom(BoardClear, [board]),
+    }
+
+    putonboard_nsrt = NSRT("PutOnBoard", parameters, preconditions,
+                           add_effects, delete_effects, set(), option,
+                           option_vars, null_sampler)
+    nsrts.add(putonboard_nsrt)
 
     return nsrts

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -105,7 +105,7 @@ class GlobalSettings:
     # sandwich env parameters
     sandwich_ingredients_train = {
         "bread": [2],
-        "burger": [1],
+        "patty": [1],
         "ham": [1],
         "egg": [1],
         "cheese": [1],
@@ -115,7 +115,7 @@ class GlobalSettings:
     }
     sandwich_ingredients_test = {
         "bread": [2],
-        "burger": [1],
+        "patty": [1],
         "ham": [1],
         "egg": [1],
         "cheese": [1],

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -102,6 +102,28 @@ class GlobalSettings:
     tools_num_contraptions_train = [2]
     tools_num_contraptions_test = [3]
 
+    # sandwich env parameters
+    sandwich_ingredients_train = {
+        "bread": [2],
+        "burger": [1],
+        "ham": [1],
+        "egg": [1],
+        "cheese": [1],
+        "lettuce": [1],
+        "tomato": [1],
+        "green_pepper": [1],
+    }
+    sandwich_ingredients_test = {
+        "bread": [2],
+        "burger": [1],
+        "ham": [1],
+        "egg": [1],
+        "cheese": [1],
+        "lettuce": [1],
+        "tomato": [1],
+        "green_pepper": [1],
+    }
+
     # general pybullet parameters
     pybullet_draw_debug = False  # useful for annotating in the GUI
     pybullet_camera_width = 335  # for high quality, use 1674

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -1556,3 +1556,4 @@ MaxTrainIters = Union[int, Callable[[int], int]]
 ExplorationStrategy = Tuple[Callable[[State], Action], Callable[[State], bool]]
 AbstractPolicy = Callable[[Set[GroundAtom], Set[Object], Set[GroundAtom]],
                           Optional[_GroundNSRT]]
+RGBA = Tuple[float, float, float, float]

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -24,6 +24,7 @@ from predicators.envs.pybullet_blocks import PyBulletBlocksEnv
 from predicators.envs.repeated_nextto import RepeatedNextToAmbiguousEnv, \
     RepeatedNextToEnv, RepeatedNextToSingleOptionEnv
 from predicators.envs.repeated_nextto_painting import RepeatedNextToPaintingEnv
+from predicators.envs.sandwich import SandwichEnv
 from predicators.envs.satellites import SatellitesEnv, SatellitesSimpleEnv
 from predicators.envs.screws import ScrewsEnv
 from predicators.envs.stick_button import StickButtonEnv
@@ -42,7 +43,7 @@ ENV_NAME_AND_CLS = [
     ("cluttered_table", ClutteredTableEnv),
     ("cluttered_table_place", ClutteredTablePlaceEnv), ("blocks", BlocksEnv),
     ("narrow_passage", NarrowPassageEnv), ("painting", PaintingEnv),
-    ("tools", ToolsEnv), ("playroom", PlayroomEnv),
+    ("sandwich", SandwichEnv), ("tools", ToolsEnv), ("playroom", PlayroomEnv),
     ("repeated_nextto", RepeatedNextToEnv),
     ("repeated_nextto_single_option", RepeatedNextToSingleOptionEnv),
     ("repeated_nextto_ambiguous", RepeatedNextToAmbiguousEnv),

--- a/tests/envs/test_sandwich.py
+++ b/tests/envs/test_sandwich.py
@@ -1,0 +1,54 @@
+"""Test cases for the sandwich env."""
+
+import numpy as np
+
+from predicators import utils
+from predicators.envs.sandwich import SandwichEnv
+from predicators.structs import Action, GroundAtom, Task
+
+
+def test_sandwich_properties():
+    """Test env object initialization and properties."""
+    utils.reset_config({"env": "sandwich"})
+    env = SandwichEnv()
+    for task in env.get_train_tasks():
+        for obj in task.init:
+            assert len(obj.type.feature_names) == len(task.init[obj])
+    for task in env.get_test_tasks():
+        for obj in task.init:
+            assert len(obj.type.feature_names) == len(task.init[obj])
+    assert len(env.predicates) == 15
+    BoardClear, Clear, GripperOpen, Holding, InHolder, IsBread, IsBurger, \
+        IsCheese, IsEgg, IsGreenPepper, IsHam, IsLettuce, IsTomato, On, \
+        OnBoard = sorted(env.predicates)
+    assert BoardClear.name == "BoardClear"
+    assert Clear.name == "Clear"
+    assert GripperOpen.name == "GripperOpen"
+    assert Holding.name == "Holding"
+    assert InHolder.name == "InHolder"
+    assert IsBread.name == "IsBread"
+    assert IsBurger.name == "IsBurger"
+    assert IsCheese.name == "IsCheese"
+    assert IsEgg.name == "IsEgg"
+    assert IsGreenPepper.name == "IsGreenPepper"
+    assert IsHam.name == "IsHam"
+    assert IsLettuce.name == "IsLettuce"
+    assert IsTomato.name == "IsTomato"
+    assert On.name == "On"
+    assert OnBoard.name == "OnBoard"
+    assert env.goal_predicates == {
+        IsBread, IsBurger, IsCheese, IsEgg, IsGreenPepper, IsHam, IsLettuce,
+        IsTomato, On, OnBoard
+    }
+    assert len(env.options) == 3
+    Pick, PutOnBoard, Stack = sorted(env.options)
+    assert Pick.name == "Pick"
+    assert PutOnBoard.name == "PutOnBoard"
+    assert Stack.name == "Stack"
+    assert len(env.types) == 4
+    board_type, holder_type, ingredient_type, robot_type = sorted(env.types)
+    assert board_type.name == "board"
+    assert holder_type.name == "holder"
+    assert ingredient_type.name == "ingredient"
+    assert robot_type.name == "robot"
+    assert env.action_space.shape == (4, )

--- a/tests/envs/test_sandwich.py
+++ b/tests/envs/test_sandwich.py
@@ -18,8 +18,8 @@ def test_sandwich_properties():
         for obj in task.init:
             assert len(obj.type.feature_names) == len(task.init[obj])
     assert len(env.predicates) == 15
-    BoardClear, Clear, GripperOpen, Holding, InHolder, IsBread, IsBurger, \
-        IsCheese, IsEgg, IsGreenPepper, IsHam, IsLettuce, IsTomato, On, \
+    BoardClear, Clear, GripperOpen, Holding, InHolder, IsBread, IsCheese, \
+        IsEgg, IsGreenPepper, IsHam, IsLettuce, IsPatty, IsTomato, On, \
         OnBoard = sorted(env.predicates)
     assert BoardClear.name == "BoardClear"
     assert Clear.name == "Clear"
@@ -27,7 +27,7 @@ def test_sandwich_properties():
     assert Holding.name == "Holding"
     assert InHolder.name == "InHolder"
     assert IsBread.name == "IsBread"
-    assert IsBurger.name == "IsBurger"
+    assert IsPatty.name == "IsPatty"
     assert IsCheese.name == "IsCheese"
     assert IsEgg.name == "IsEgg"
     assert IsGreenPepper.name == "IsGreenPepper"
@@ -37,7 +37,7 @@ def test_sandwich_properties():
     assert On.name == "On"
     assert OnBoard.name == "OnBoard"
     assert env.goal_predicates == {
-        IsBread, IsBurger, IsCheese, IsEgg, IsGreenPepper, IsHam, IsLettuce,
+        IsBread, IsPatty, IsCheese, IsEgg, IsGreenPepper, IsHam, IsLettuce,
         IsTomato, On, OnBoard
     }
     assert len(env.options) == 3

--- a/tests/envs/test_sandwich.py
+++ b/tests/envs/test_sandwich.py
@@ -116,10 +116,11 @@ def test_sandwich_options():
     assert not GroundAtom(OnBoard, [ing0, board]).holds(state0)
     assert GroundAtom(OnBoard, [ing0, board]).holds(state4)
     assert not GroundAtom(Clear, [ing1]).holds(state0)
+    assert not GroundAtom(Clear, [ing0]).holds(state1)
     assert GroundAtom(Clear, [ing1]).holds(state4)
     assert not GroundAtom(Clear, [ing0]).holds(state4)
 
-    # Cover option failure cases.
+    # Cover simulate "failure" cases.
 
     # Can only pick if fingers are open.
     state = state1
@@ -129,9 +130,11 @@ def test_sandwich_options():
     assert state.allclose(next_state)
 
     # No ingredient at this pose.
-    state = state0
-    x, y, z = env.x_ub, env.y_ub, env.z_lb
-    action = Action(np.array([x, y, z, 1.0], dtype=np.float32))
+    state = state2
+    x = state0.get(ing0, "pose_x")
+    y = state0.get(ing0, "pose_y")
+    z = state0.get(ing0, "pose_z")
+    action = Action(np.array([x, y, z, 0.0], dtype=np.float32))
     next_state = env.simulate(state, action)
     assert state.allclose(next_state)
 


### PR DESCRIPTION
new environment where a fixed-base robot makes sandwiches.

* the main motivation for this environment is to work towards a real robot demo with the panda (cc @williamshen-nz ).
* the objects are inspired by [this sandwich making play set](https://a.co/d/gM2CzjS), which I'm hoping we can buy and use with the panda
* the environment may also be useful for active predicate learning (@amburger66 )

here are some renderings:
* https://user-images.githubusercontent.com/2816502/216854567-dcb3f030-c635-441d-9227-c029ec51d876.mp4
* https://user-images.githubusercontent.com/2816502/216854572-307aae9a-58a1-4b6d-aa3b-aabeb718bc73.mp4
* https://user-images.githubusercontent.com/2816502/216854578-ebf1a4ad-3113-4a7d-80d8-fdd98687acac.mp4

notes about the renderings:
* the left is a side view and the right is a top-down view
* the ingredients are initially upright to allow for easy grasping
* the robot will grasp an ingredient lengthwise so that it can subsequently place onto the board or table without one of its fingers getting stuck underneath. hopefully the gripper is wide enough and the ingredients are small enough to allow this

after merging this PR, I'm planning to:
1. implement pybullet version.
2. extend the environment to make it more interesting. for example, add squirt bottles (mayo, ketchup, etc.). maybe add tools, like a spatula. maybe require the robot to move the board after the sandwich is made.
3. play with our new LLM interface for goal specification (e.g., "make me a reuben sandwich with ketchup" or something)

