### PR TITLE
[narrow_passage] Randomly vary narrow_passage door/passage widths between task initializations

### DIFF
--- a/predicators/envs/narrow_passage.py
+++ b/predicators/envs/narrow_passage.py
@@ -198,25 +198,26 @@ class NarrowPassageEnv(BaseEnv):
         goal = {goal_atom}
 
         # The initial positions of the robot and target vary, while wall and
-        # door positions are fixed. The robot should be above the walls, while
+        # door y positions are fixed. The robot should be above the walls, while
         # the dot should be below the walls (y coordinate)
         y_mid = (self.y_ub - self.y_lb) / 2 + self.y_lb
         margin = self.wall_thickness_half + self.init_pos_margin
-        # Door width is generated randomly
-        door_width_padding = rng.uniform(
-            CFG.narrow_passage_door_width_padding_lb,
-            CFG.narrow_passage_door_width_padding_ub,
-        )
-        door_width = (self.robot_radius + door_width_padding) * 2
-        # Passage width is generated randomly
-        passage_width_padding = rng.uniform(
-            CFG.narrow_passage_passage_width_padding_lb,
-            CFG.narrow_passage_passage_width_padding_ub,
-        )
-        passage_width = (self.robot_radius + passage_width_padding) * 2
 
         tasks: List[Task] = []
         while len(tasks) < num:
+            # Door width is generated randomly per task
+            door_width_padding = rng.uniform(
+                CFG.narrow_passage_door_width_padding_lb,
+                CFG.narrow_passage_door_width_padding_ub,
+            )
+            door_width = (self.robot_radius + door_width_padding) * 2
+            # Passage width is generated randomly per task
+            passage_width_padding = rng.uniform(
+                CFG.narrow_passage_passage_width_padding_lb,
+                CFG.narrow_passage_passage_width_padding_ub,
+            )
+            passage_width = (self.robot_radius + passage_width_padding) * 2
+
             state = utils.create_state_from_dict({
                 self._robot: {
                     "x":

--- a/predicators/envs/narrow_passage.py
+++ b/predicators/envs/narrow_passage.py
@@ -462,9 +462,8 @@ class NarrowPassageEnv(BaseEnv):
         else:
             assert obj.is_instance(self._door_type)
             y = self.y_lb + (
-                self.y_ub - self.y_lb
-            ) / 2 - self.wall_thickness_half + self.doorway_depth
+                self.y_ub -
+                self.y_lb) / 2 - self.wall_thickness_half + self.doorway_depth
             width = state.get(obj, "width")
-            height = (self.wall_thickness_half -
-                      self.doorway_depth) * 2
+            height = (self.wall_thickness_half - self.doorway_depth) * 2
         return utils.Rectangle(x=x, y=y, width=width, height=height, theta=0)

--- a/predicators/envs/narrow_passage.py
+++ b/predicators/envs/narrow_passage.py
@@ -87,9 +87,6 @@ class NarrowPassageEnv(BaseEnv):
         self._door = Object("door", self._door_type)
         self._door_sensor = Object("door_sensor", self._door_sensor_type)
 
-        # Cache for _Geom2D objects
-        self._static_geom_cache: Dict[Object, _Geom2D] = {}
-
     @classmethod
     def get_name(cls) -> str:
         return "narrow_passage"
@@ -454,29 +451,20 @@ class NarrowPassageEnv(BaseEnv):
                 or obj.is_instance(self._target_type)):
             y = state.get(obj, "y")
             return utils.Circle(x, y, self.robot_radius)
-        # Cache static objects such as door and walls
-        if obj not in self._static_geom_cache:
-            if obj.is_instance(self._door_sensor_type):
-                y = self.y_lb + (self.y_ub - self.y_lb) / 2
-                self._static_geom_cache[obj] = utils.Circle(
-                    x, y, self.door_sensor_radius)
-            else:
-                if obj.is_instance(self._wall_type):
-                    y = self.y_lb + (self.y_ub -
-                                     self.y_lb) / 2 - self.wall_thickness_half
-                    width = state.get(obj, "width")
-                    height = self.wall_thickness_half * 2
-                else:
-                    assert obj.is_instance(self._door_type)
-                    y = self.y_lb + (
-                        self.y_ub - self.y_lb
-                    ) / 2 - self.wall_thickness_half + self.doorway_depth
-                    width = state.get(obj, "width")
-                    height = (self.wall_thickness_half -
-                              self.doorway_depth) * 2
-                self._static_geom_cache[obj] = utils.Rectangle(x=x,
-                                                               y=y,
-                                                               width=width,
-                                                               height=height,
-                                                               theta=0)
-        return self._static_geom_cache[obj]
+        if obj.is_instance(self._door_sensor_type):
+            y = self.y_lb + (self.y_ub - self.y_lb) / 2
+            return utils.Circle(x, y, self.door_sensor_radius)
+        if obj.is_instance(self._wall_type):
+            y = self.y_lb + (self.y_ub -
+                             self.y_lb) / 2 - self.wall_thickness_half
+            width = state.get(obj, "width")
+            height = self.wall_thickness_half * 2
+        else:
+            assert obj.is_instance(self._door_type)
+            y = self.y_lb + (
+                self.y_ub - self.y_lb
+            ) / 2 - self.wall_thickness_half + self.doorway_depth
+            width = state.get(obj, "width")
+            height = (self.wall_thickness_half -
+                      self.doorway_depth) * 2
+        return utils.Rectangle(x=x, y=y, width=width, height=height, theta=0)

--- a/predicators/envs/narrow_passage.py
+++ b/predicators/envs/narrow_passage.py
@@ -51,7 +51,7 @@ class NarrowPassageEnv(BaseEnv):
         self._robot_type = Type("robot", ["x", "y"])
         self._target_type = Type("target", ["x", "y"])
         self._wall_type = Type("wall", ["x", "width"])
-        self._door_type = Type("door", ["x", "open"])
+        self._door_type = Type("door", ["x", "width", "open"])
         # Type for the region within which the robot must be located
         # in order for the door-opening action to work.
         self._door_sensor_type = Type("door_sensor", ["x"])
@@ -205,10 +205,18 @@ class NarrowPassageEnv(BaseEnv):
         # the dot should be below the walls (y coordinate)
         y_mid = (self.y_ub - self.y_lb) / 2 + self.y_lb
         margin = self.wall_thickness_half + self.init_pos_margin
-        door_width = (self.robot_radius +
-                      CFG.narrow_passage_door_width_padding) * 2
-        passage_width = (self.robot_radius +
-                         CFG.narrow_passage_passage_width_padding) * 2
+        # Door width is generated randomly
+        door_width_padding = rng.uniform(
+            CFG.narrow_passage_door_width_padding_lb,
+            CFG.narrow_passage_door_width_padding_ub,
+        )
+        door_width = (self.robot_radius + door_width_padding) * 2
+        # Passage width is generated randomly
+        passage_width_padding = rng.uniform(
+            CFG.narrow_passage_passage_width_padding_lb,
+            CFG.narrow_passage_passage_width_padding_ub,
+        )
+        passage_width = (self.robot_radius + passage_width_padding) * 2
 
         tasks: List[Task] = []
         while len(tasks) < num:
@@ -244,6 +252,7 @@ class NarrowPassageEnv(BaseEnv):
                 },
                 self._door: {
                     "x": self.door_x_pos,
+                    "width": door_width,
                     "open": 0,  # door starts closed
                 },
                 self._door_sensor: {
@@ -462,8 +471,7 @@ class NarrowPassageEnv(BaseEnv):
                     y = self.y_lb + (
                         self.y_ub - self.y_lb
                     ) / 2 - self.wall_thickness_half + self.doorway_depth
-                    width = (self.robot_radius +
-                             CFG.narrow_passage_door_width_padding) * 2
+                    width = state.get(obj, "width")
                     height = (self.wall_thickness_half -
                               self.doorway_depth) * 2
                 self._static_geom_cache[obj] = utils.Rectangle(x=x,

--- a/predicators/refinement_estimators/oracle_refinement_estimator.py
+++ b/predicators/refinement_estimators/oracle_refinement_estimator.py
@@ -2,6 +2,7 @@
 
 from typing import List, Set
 
+from predicators.envs.narrow_passage import NarrowPassageEnv
 from predicators.refinement_estimators import BaseRefinementEstimator
 from predicators.settings import CFG
 from predicators.structs import GroundAtom, State, _GroundNSRT
@@ -23,7 +24,8 @@ class OracleRefinementEstimator(BaseRefinementEstimator):
                  atoms_sequence: List[Set[GroundAtom]]) -> float:
         env_name = CFG.env
         if env_name == "narrow_passage":
-            return narrow_passage_oracle_estimator(skeleton, atoms_sequence)
+            return narrow_passage_oracle_estimator(initial_state, skeleton,
+                                                   atoms_sequence)
 
         # Given environment doesn't have an implemented oracle estimator
         raise NotImplementedError(
@@ -31,24 +33,32 @@ class OracleRefinementEstimator(BaseRefinementEstimator):
 
 
 def narrow_passage_oracle_estimator(
+    initial_state: State,
     skeleton: List[_GroundNSRT],
     atoms_sequence: List[Set[GroundAtom]],
 ) -> float:
     """Oracle refinement estimation function for narrow_passage env."""
     del atoms_sequence  # unused
 
-    # Hard-coded estimated num_samples needed to refine different operators
-    move_and_open_door = 1
-    move_through_door = 1
-    move_through_passage = 3
+    # Extract door and passage widths from the state
+    env = NarrowPassageEnv()
+    door_type, _, _, _, wall_type = sorted(env.types)
+    door, = initial_state.get_objects(door_type)
+    door_width = initial_state.get(door, "width")
+    _, middle_wall, right_wall = sorted(initial_state.get_objects(wall_type))
+    passage_x = initial_state.get(middle_wall, "x") + \
+                initial_state.get(middle_wall, "width")
+    passage_width = initial_state.get(right_wall, "x") - passage_x
+
+    # If the door is wider than the passage, then opening the door is
+    # beneficial. Otherwise, opening the door should be costly.
+    cost_of_open_door = -1 if door_width > passage_width else 1
 
     # Sum metric of difficulty over skeleton
     cost = 0
-    door_open = False
     for ground_nsrt in skeleton:
         if ground_nsrt.name == "MoveAndOpenDoor":
-            cost += move_and_open_door
-            door_open = True
+            cost += cost_of_open_door
         elif ground_nsrt.name == "MoveToTarget":
-            cost += move_through_door if door_open else move_through_passage
+            cost += 1
     return cost

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -276,8 +276,10 @@ class GlobalSettings:
     doors_draw_debug = False
 
     # narrow_passage env parameters
-    narrow_passage_door_width_padding = 0.075
-    narrow_passage_passage_width_padding = 2e-4
+    narrow_passage_door_width_padding_lb = 1e-3
+    narrow_passage_door_width_padding_ub = 1e-2
+    narrow_passage_passage_width_padding_lb = 2e-4
+    narrow_passage_passage_width_padding_ub = 2e-3
     narrow_passage_birrt_num_attempts = 10
     narrow_passage_birrt_num_iters = 100
     narrow_passage_birrt_smooth_amt = 50

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -276,10 +276,10 @@ class GlobalSettings:
     doors_draw_debug = False
 
     # narrow_passage env parameters
-    narrow_passage_door_width_padding_lb = 1e-3
-    narrow_passage_door_width_padding_ub = 1e-2
-    narrow_passage_passage_width_padding_lb = 2e-4
-    narrow_passage_passage_width_padding_ub = 2e-3
+    narrow_passage_door_width_padding_lb = 1e-4
+    narrow_passage_door_width_padding_ub = 5e-3
+    narrow_passage_passage_width_padding_lb = 5e-4
+    narrow_passage_passage_width_padding_ub = 2e-2
     narrow_passage_birrt_num_attempts = 10
     narrow_passage_birrt_num_iters = 100
     narrow_passage_birrt_smooth_amt = 50

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -150,7 +150,13 @@ EXTRA_ARGS_ORACLE_APPROACH["doors"] = [{
     "doors_max_obstacles_per_room": 1,
 }]
 EXTRA_ARGS_ORACLE_APPROACH["narrow_passage"] = [{
-    "narrow_passage_passage_width_padding":
+    "narrow_passage_door_width_padding_lb":
+    0.075,
+    "narrow_passage_door_width_padding_ub":
+    0.075,
+    "narrow_passage_passage_width_padding_lb":
+    0.075,
+    "narrow_passage_passage_width_padding_ub":
     0.075,
 }]
 EXTRA_ARGS_ORACLE_APPROACH["pddl_delivery_procedural_tasks"] = [

--- a/tests/approaches/test_refinement_estimation_approach.py
+++ b/tests/approaches/test_refinement_estimation_approach.py
@@ -22,6 +22,10 @@ def test_refinement_estimation_approach():
     args = {
         "env": "narrow_passage",
         "refinement_estimator": "oracle",
+        "narrow_passage_door_width_padding_lb": 0.05,
+        "narrow_passage_door_width_padding_ub": 0.05,
+        "narrow_passage_passage_width_padding_lb": 0.05,
+        "narrow_passage_passage_width_padding_ub": 0.05,
     }
     # Default to 2 train and test tasks, but allow them to be specified in
     # the extra args too.

--- a/tests/envs/test_narrow_passage.py
+++ b/tests/envs/test_narrow_passage.py
@@ -41,7 +41,11 @@ def test_narrow_passage_properties():
 def test_narrow_passage_actions():
     """Test to check that basic actions and rendering works, especially door
     opening."""
-    utils.reset_config({"env": "narrow_passage"})
+    utils.reset_config({
+        "env": "narrow_passage",
+        "narrow_passage_door_width_padding_lb": 0.075,
+        "narrow_passage_door_width_padding_ub": 0.075,
+    })
     env = NarrowPassageEnv()
     DoorIsClosed, DoorIsOpen, TouchedGoal = sorted(env.predicates)
     door_type, _, robot_type, target_type, _ = sorted(env.types)
@@ -116,7 +120,11 @@ def test_narrow_passage_actions():
 def test_narrow_passage_collisions():
     """Test that the robot can't go through walls or closed door."""
     # Set up environment
-    utils.reset_config({"env": "narrow_passage"})
+    utils.reset_config({
+        "env": "narrow_passage",
+        "narrow_passage_door_width_padding_lb": 0.075,
+        "narrow_passage_door_width_padding_ub": 0.075,
+    })
     env = NarrowPassageEnv()
     door_type, _, robot_type, _, _ = sorted(env.types)
 

--- a/tests/envs/test_narrow_passage.py
+++ b/tests/envs/test_narrow_passage.py
@@ -156,7 +156,10 @@ def test_narrow_passage_options():
     # Set up environment
     utils.reset_config({
         "env": "narrow_passage",
-        "narrow_passage_passage_width_padding": 0.02,
+        "narrow_passage_door_width_padding_lb": 0.02,
+        "narrow_passage_door_width_padding_ub": 0.02,
+        "narrow_passage_passage_width_padding_lb": 0.02,
+        "narrow_passage_passage_width_padding_ub": 0.02,
         # "render_state_dpi": 150,  # uncomment for higher-res test videos
     })
     env = NarrowPassageEnv()

--- a/tests/test_train_refinement_estimator.py
+++ b/tests/test_train_refinement_estimator.py
@@ -22,7 +22,10 @@ def test_train_refinement_estimator():
     utils.reset_config_with_parser(
         parser, {
             "env": "narrow_passage",
-            "narrow_passage_passage_width_padding": 0.02,
+            "narrow_passage_door_width_padding_lb": 0.05,
+            "narrow_passage_door_width_padding_ub": 0.05,
+            "narrow_passage_passage_width_padding_lb": 0.05,
+            "narrow_passage_passage_width_padding_ub": 0.05,
             "num_train_tasks": 1,
         })
     sys.argv = [


### PR DESCRIPTION
**Summary of changes:**
 - `narrow_passage` environment randomly initializes the widths of the door and narrow passage for each task, as opposed to using a fixed width based on CFG parameters
 - `narrow_passage` environment can no longer maintain a static geom cache
 - CFG settings changed to take lower bounds and upper bounds for the door and passage width paddings