### PR TITLE
Add TouchOpenEnv toy domain for testing nsrt rl approach.

### DIFF
--- a/predicators/envs/touch_point.py
+++ b/predicators/envs/touch_point.py
@@ -208,14 +208,7 @@ class TouchPointEnvParam(TouchPointEnv):
     def __init__(self, use_gui: bool = True) -> None:
         super().__init__(use_gui)
 
-        # Types
-        self._robot_type = Type("robot", ["x", "y"])
-        self._target_type = Type("target", ["x", "y"])
-        # Predicates
-        self._Touched = Predicate("Touched",
-                                  [self._robot_type, self._target_type],
-                                  self._Touched_holds)
-        # Options
+        # Override option.
         self._MoveTo = ParameterizedOption(
             "MoveTo",
             types=[self._robot_type, self._target_type],
@@ -224,9 +217,6 @@ class TouchPointEnvParam(TouchPointEnv):
             policy=self._MoveTo_policy,
             initiable=lambda s, m, o, p: True,
             terminal=self._MoveTo_terminal)
-        # Static objects (always exist no matter the settings).
-        self._robot = Object("robby", self._robot_type)
-        self._target = Object("target", self._target_type)
 
     @classmethod
     def get_name(cls) -> str:
@@ -256,5 +246,228 @@ class TouchPointEnvParam(TouchPointEnv):
     @staticmethod
     def _MoveTo_policy(state: State, memory: Dict, objects: Sequence[Object],
                        params: Array) -> Action:
-        del state, memory, objects  # unused
         return Action(params)
+
+
+class TouchOpenEnv(TouchPointEnvParam):
+    """TouchPointEnvParam but where the target is a door from DoorsEnv that
+    needs to be opened."""
+
+    open_door_threshold: ClassVar[float] = 1e-2
+
+    def __init__(self, use_gui: bool = True) -> None:
+        super().__init__()
+
+        # Add door type.
+        self._door_type = Type(
+            "door", ["x", "y", "mass", "friction", "rot", "flex", "open"])
+
+        # Add predicates.
+        del self._Touched
+        self._TouchingDoor = Predicate("TouchingDoor",
+                                       [self._robot_type, self._door_type],
+                                       self._TouchingDoor_holds)
+        self._DoorIsOpen = Predicate("DoorIsOpen", [self._door_type],
+                                     self._DoorIsOpen_holds)
+        # Add options.
+        # Note that the parameter spaces are designed to match what would be
+        # learned by the neural option learners, in that they correspond to
+        # only the dimensions that change when the option is run.
+        del self._MoveTo
+        self._MoveToDoor = ParameterizedOption(
+            "MoveToDoor",
+            types=[self._robot_type, self._door_type],
+            params_space=Box(self.action_limits[0], self.action_limits[1],
+                             (2, )),
+            policy=self._MoveToDoor_policy,
+            initiable=lambda s, m, o, p: True,
+            terminal=self._MoveToDoor_terminal)
+        self._OpenDoor = ParameterizedOption(
+            "OpenDoor",
+            types=[self._door_type, self._robot_type],
+            params_space=Box(-np.inf, np.inf, (2, )),
+            policy=self._OpenDoor_policy,
+            initiable=self._OpenDoor_initiable,
+            terminal=self._OpenDoor_terminal)
+        # Add static object.
+        self._door = Object("door", self._door_type)
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "touch_open"
+
+    @property
+    def action_space(self) -> Box:
+        # The action space is (dx, dy, drot).
+        lb, ub = self.action_limits
+        return Box(np.array([lb, lb, lb], dtype=np.float32),
+                   np.array([ub, ub, ub], dtype=np.float32))
+
+    def simulate(self, state: State, action: Action) -> State:
+        assert self.action_space.contains(action.arr)
+        dx, dy, drot = action.arr
+        x = state.get(self._robot, "x")
+        y = state.get(self._robot, "y")
+        rot = state.get(self._door, "rot")
+
+        new_x = x + (dx * self.action_magnitude)
+        new_y = y + (dy * self.action_magnitude)
+        new_x = np.clip(new_x, self.x_lb, self.x_ub)
+        new_y = np.clip(new_y, self.y_lb, self.y_ub)
+        new_rot = rot + drot
+        next_state = state.copy()
+        next_state.set(self._robot, "x", new_x)
+        next_state.set(self._robot, "y", new_y)
+
+        # If touching the door, change its value based on the action.
+        for door in state.get_objects(self._door_type):
+            if self._TouchingDoor_holds(state, [self._robot, door]):
+                # Rotate the door handle.
+                next_state.set(door, "rot", new_rot)
+                # Check if we should open the door.
+                target = self._get_open_door_target_value(
+                    mass=state.get(door, "mass"),
+                    friction=state.get(door, "friction"),
+                    flex=state.get(door, "flex"),
+                )
+                if abs(new_rot - target) < self.open_door_threshold:
+                    next_state.set(door, "open", 1.0)
+                else:
+                    next_state.set(door, "open", 0.0)
+        return next_state
+
+    @property
+    def predicates(self) -> Set[Predicate]:
+        return {self._TouchingDoor, self._DoorIsOpen}
+
+    @property
+    def goal_predicates(self) -> Set[Predicate]:
+        return {self._DoorIsOpen}
+
+    @property
+    def types(self) -> Set[Type]:
+        return {self._robot_type, self._door_type}
+
+    @property
+    def options(self) -> Set[ParameterizedOption]:
+        return {self._MoveToDoor, self._OpenDoor}
+
+    def render_state_plt(
+            self,
+            state: State,
+            task: Task,
+            action: Optional[Action] = None,
+            caption: Optional[str] = None) -> matplotlib.figure.Figure:
+        fig, ax = plt.subplots(1, 1, figsize=(5, 5))
+        robot_color = "gray"
+        robot_x = state.get(self._robot, "x")
+        robot_y = state.get(self._robot, "y")
+        door_x = state.get(self._door, "x")
+        door_y = state.get(self._door, "y")
+        door_open = state.get(self._door, "open")
+        if door_open:
+            door_color = "yellow"
+        else:
+            door_color = "brown"
+        rad = (self.touch_multiplier * self.action_magnitude) / 2
+        robot_circ = plt.Circle((robot_x, robot_y), rad / 2, color=robot_color)
+        door_circ = plt.Circle((door_x, door_y),
+                               rad,
+                               color=door_color,
+                               alpha=0.5)
+        ax.add_patch(robot_circ)
+        ax.add_patch(door_circ)
+        ax.set_xlim(self.x_lb - rad, self.x_ub + rad)
+        ax.set_ylim(self.y_lb - rad, self.y_ub + rad)
+        title = f"{robot_color} = robot, {door_color} = door"
+        if caption is not None:
+            title += f";\n{caption}"
+        plt.suptitle(title, wrap=True)
+        plt.tight_layout()
+        return fig
+
+    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[Task]:
+        goal_atom1 = GroundAtom(self._TouchingDoor, [self._robot, self._door])
+        goal_atom2 = GroundAtom(self._DoorIsOpen, [self._door])
+        goal1 = {goal_atom1, goal_atom2}
+        # The initial positions of the robot and door vary. The only constraint
+        # is that the initial positions should be far enough away that the goal
+        # is not initially satisfied.
+        tasks: List[Task] = []
+        while len(tasks) < num:
+            flex = rng.uniform(0.0, 1.0)
+            rot = rng.uniform(0.0, 1.0)
+            state = utils.create_state_from_dict({
+                self._robot: {
+                    "x": rng.uniform(self.x_lb, self.x_ub),
+                    "y": rng.uniform(self.y_lb, self.y_ub),
+                },
+                self._door: {
+                    "x": rng.uniform(self.x_lb, self.x_ub),
+                    "y": rng.uniform(self.y_lb, self.y_ub),
+                    "mass": rng.uniform(0.0, 1.0),
+                    "friction": rng.uniform(0.0, 1.0),
+                    "rot": rot,
+                    "flex": flex,
+                    "open": 0.0  # start out closed
+                },
+            })
+            # Make sure the goal is not satisfied.
+            if not goal_atom1.holds(state) and not goal_atom2.holds(state):
+                tasks.append(Task(state, goal1))
+        return tasks
+
+    @staticmethod
+    def _MoveToDoor_policy(state: State, memory: Dict,
+                           objects: Sequence[Object], params: Array) -> Action:
+        del state, memory, objects  # unused
+        dx, dy = params
+        return Action(np.array([dx, dy, 0.0], dtype=np.float32))
+
+    def _MoveToDoor_terminal(self, state: State, memory: Dict,
+                             objects: Sequence[Object], params: Array) -> bool:
+        del memory, params  # unused
+        return self._TouchingDoor_holds(state, objects)
+
+    def _OpenDoor_initiable(self, state: State, memory: Dict,
+                            objects: Sequence[Object], params: Array) -> bool:
+        del memory, params  # unused
+        # You can only open the door if touching it.
+        door, robot = objects
+        return self._TouchingDoor_holds(state, [robot, door])
+
+    @staticmethod
+    def _OpenDoor_policy(state: State, memory: Dict, objects: Sequence[Object],
+                         params: Array) -> Action:
+        del state, memory, objects  # unused
+        delta_rot, _ = params
+        return Action(np.array([0.0, 0.0, delta_rot], dtype=np.float32))
+
+    def _OpenDoor_terminal(self, state: State, memory: Dict,
+                           objects: Sequence[Object], params: Array) -> bool:
+        del memory, params  # unused
+        door, _ = objects
+        return self._DoorIsOpen_holds(state, [door])
+
+    def _TouchingDoor_holds(self, state: State,
+                            objects: Sequence[Object]) -> bool:
+        robot, door = objects
+        rx = state.get(robot, "x")
+        ry = state.get(robot, "y")
+        tx = state.get(door, "x")
+        ty = state.get(door, "y")
+        dist = np.sqrt((rx - tx)**2 + (ry - ty)**2)
+        return dist < self.action_magnitude * self.touch_multiplier
+
+    @staticmethod
+    def _DoorIsOpen_holds(state: State, objects: Sequence[Object]) -> bool:
+        door, = objects
+        return state.get(door, "open") > 0.5
+
+    @staticmethod
+    def _get_open_door_target_value(mass: float, friction: float,
+                                    flex: float) -> float:
+        # A made up complicated function.
+        # Want to be able to swap this out based on CFG.
+        return np.tanh(flex) * (np.sin(mass) +
+                                np.cos(friction) * np.sqrt(mass))

--- a/predicators/ground_truth_nsrts.py
+++ b/predicators/ground_truth_nsrts.py
@@ -12,6 +12,7 @@ from predicators.envs.playroom import PlayroomEnv
 from predicators.envs.repeated_nextto_painting import RepeatedNextToPaintingEnv
 from predicators.envs.satellites import SatellitesEnv
 from predicators.envs.tools import ToolsEnv
+from predicators.envs.touch_point import TouchOpenEnv
 from predicators.settings import CFG
 from predicators.structs import NSRT, Array, GroundAtom, LiftedAtom, Object, \
     ParameterizedOption, Predicate, State, Type, Variable
@@ -47,6 +48,8 @@ def get_gt_nsrts(env_name: str, predicates: Set[Predicate],
         nsrts = _get_pddl_env_gt_nsrts(env_name)
     elif env_name in ("touch_point", "touch_point_param"):
         nsrts = _get_touch_point_gt_nsrts(env_name)
+    elif env_name == "touch_open":
+        nsrts = _get_touch_open_gt_nsrts(env_name)
     elif env_name == "stick_button":
         nsrts = _get_stick_button_gt_nsrts(env_name)
     elif env_name == "doors":
@@ -2091,6 +2094,88 @@ def _get_touch_point_gt_nsrts(env_name: str) -> Set[NSRT]:
                      delete_effects, ignore_effects, option, option_vars,
                      moveto_sampler)
     nsrts.add(move_nsrt)
+
+    return nsrts
+
+
+def _get_touch_open_gt_nsrts(env_name: str) -> Set[NSRT]:
+    """Create ground truth NSRTs for TouchOpenEnv."""
+    robot_type, door_type = _get_types_by_names(env_name, ["robot", "door"])
+    TouchingDoor, DoorIsOpen = _get_predicates_by_names(
+        CFG.env, ["TouchingDoor", "DoorIsOpen"])
+    MoveToDoor, OpenDoor = _get_options_by_names(CFG.env,
+                                                 ["MoveToDoor", "OpenDoor"])
+    robot = Variable("?robot", robot_type)
+    door = Variable("?door", door_type)
+
+    nsrts = set()
+
+    # MoveToDoor
+    parameters = [robot, door]
+    option_vars = [robot, door]
+    option = MoveToDoor
+    preconditions: Set[LiftedAtom] = set()
+    add_effects = {LiftedAtom(TouchingDoor, [robot, door])}
+    delete_effects: Set[LiftedAtom] = set()
+    side_predicates: Set[Predicate] = set()
+
+    def move_to_door_sampler(state: State, goal: Set[GroundAtom],
+                             rng: np.random.Generator,
+                             objs: Sequence[Object]) -> Array:
+        del goal, rng  # unused
+        robot, door = objs
+        assert robot.is_instance(robot_type)
+        assert door.is_instance(door_type)
+        r_x = state.get(robot, "x")
+        r_y = state.get(robot, "y")
+        d_x = state.get(door, "x")
+        d_y = state.get(door, "y")
+        delta_x = d_x - r_x
+        delta_y = d_y - r_y
+        return np.array([delta_x, delta_y], dtype=np.float32)
+
+    move_to_door_nsrt = NSRT("MoveToDoor", parameters, preconditions,
+                             add_effects, delete_effects, side_predicates,
+                             option, option_vars, move_to_door_sampler)
+    nsrts.add(move_to_door_nsrt)
+
+    # OpenDoor
+    parameters = [door, robot]
+    option_vars = [door, robot]
+    option = OpenDoor
+    preconditions = {LiftedAtom(TouchingDoor, [robot, door])}
+    add_effects = {LiftedAtom(DoorIsOpen, [door])}
+    delete_effects = set()
+    side_predicates = set()
+
+    # Allow protected access because this is an oracle. Used in the sampler.
+    env = get_or_create_env(CFG.env)
+    assert isinstance(env, TouchOpenEnv)
+    get_open_door_target_value = env._get_open_door_target_value  # pylint: disable=protected-access
+
+    def open_door_sampler(state: State, goal: Set[GroundAtom],
+                          rng: np.random.Generator,
+                          objs: Sequence[Object]) -> Array:
+        del goal, rng
+        door, _ = objs
+        assert door.is_instance(door_type)
+        # Calculate the desired change in the doors "rotation" feature.
+        mass = state.get(door, "mass")
+        friction = state.get(door, "friction")
+        flex = state.get(door, "flex")
+        target_rot = get_open_door_target_value(mass=mass,
+                                                friction=friction,
+                                                flex=flex)
+        current_rot = state.get(door, "rot")
+        # The door always changes from closed to open.
+        delta_open = 1.0
+        return np.array([target_rot - current_rot, delta_open],
+                        dtype=np.float32)
+
+    open_door_nsrt = NSRT("OpenDoor", parameters, preconditions, add_effects,
+                          delete_effects, side_predicates, option, option_vars,
+                          open_door_sampler)
+    nsrts.add(open_door_nsrt)
 
     return nsrts
 

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -29,7 +29,8 @@ from predicators.envs.satellites import SatellitesEnv, SatellitesSimpleEnv
 from predicators.envs.screws import ScrewsEnv
 from predicators.envs.stick_button import StickButtonEnv
 from predicators.envs.tools import ToolsEnv
-from predicators.envs.touch_point import TouchPointEnv, TouchPointEnvParam
+from predicators.envs.touch_point import TouchOpenEnv, TouchPointEnv, \
+    TouchPointEnvParam
 from predicators.ground_truth_nsrts import get_gt_nsrts
 from predicators.option_model import _OracleOptionModel
 from predicators.settings import CFG
@@ -55,10 +56,9 @@ ENV_NAME_AND_CLS = [
     ("pddl_delivery_procedural_tasks", ProceduralTasksDeliveryPDDLEnv),
     ("pddl_easy_delivery_procedural_tasks",
      ProceduralTasksEasyDeliveryPDDLEnv), ("touch_point", TouchPointEnv),
-    ("touch_point_param", TouchPointEnvParam), ("stick_button",
-                                                StickButtonEnv),
-    ("doors", DoorsEnv), ("coffee", CoffeeEnv),
-    ("pybullet_blocks", PyBulletBlocksEnv)
+    ("touch_point_param", TouchPointEnvParam), ("touch_open", TouchOpenEnv),
+    ("stick_button", StickButtonEnv), ("doors", DoorsEnv),
+    ("coffee", CoffeeEnv), ("pybullet_blocks", PyBulletBlocksEnv)
 ]
 
 # For each environment name in ENV_NAME_AND_CLS, a list of additional

--- a/tests/envs/test_touch_point.py
+++ b/tests/envs/test_touch_point.py
@@ -6,7 +6,8 @@ import numpy as np
 import pytest
 
 from predicators import utils
-from predicators.envs.touch_point import TouchPointEnv, TouchPointEnvParam
+from predicators.envs.touch_point import TouchOpenEnv, TouchPointEnv, \
+    TouchPointEnvParam
 from predicators.structs import Action
 
 
@@ -104,3 +105,56 @@ def test_touch_point_param():
     state = env.simulate(state, action)
     state = env.simulate(state, action)
     assert goal_atom.holds(state)
+
+
+def test_touch_open():
+    """Tests for TouchPointEnv class."""
+    utils.reset_config({"env": "touch_point"})
+    env = TouchOpenEnv()
+    assert len(env.predicates) == 2
+    assert len(env.goal_predicates) == 1
+    assert {pred.name for pred in env.goal_predicates} == {"DoorIsOpen"}
+    assert len(env.options) == 2
+    assert len(env.types) == 2
+    assert env.action_space.shape == (3, )
+    task = env.get_train_tasks()[0]
+    state = task.init
+    env.render_state(state, task, caption="caption")
+    door, robot = sorted(state, key=lambda o: o.name)
+    assert robot.name == "robby"
+    assert door.name == "door"
+    state = utils.create_state_from_dict({
+        robot: {
+            "x": 0.4,
+            "y": 0.3,
+        },
+        door: {
+            "x": 0.5,
+            "y": 0.5,
+            "mass": 0.93,
+            "friction": 0.75,
+            "rot": 0,
+            "flex": 0.32,
+            "open": 0.0
+        }
+    })
+    assert len(task.goal) == 2
+    goal_atom = list(task.goal)[0]
+    assert goal_atom.objects == [door]
+    # Try to turn the door handle from far away.
+    action = Action(np.array([0.0, 0.0, 0.466], dtype=np.float32))
+    assert not goal_atom.holds(state)
+    action = Action(np.array([1.0, 1.0, 0.0], dtype=np.float32))
+    state = env.simulate(state, action)
+    act_mag = TouchPointEnv.action_magnitude
+    assert abs(state.get(robot, "x") - (0.4 + act_mag)) < 1e-7
+    assert abs(state.get(robot, "y") - (0.3 + act_mag)) < 1e-7
+    action = Action(np.array([0.0, 1.0, 0.0], dtype=np.float32))
+    state = env.simulate(state, action)
+    action = Action(np.array([0.0, 0.0, 0.466], dtype=np.float32))
+    state = env.simulate(state, action)
+    assert goal_atom.holds(state)
+    env.render_state(state, task, caption="caption")
+    action = Action(np.array([0.0, 0.0, -1.0], dtype=np.float32))
+    state = env.simulate(state, action)
+    assert not goal_atom.holds(state)


### PR DESCRIPTION
Adds a toy environment involving two options for testing the nsrt RL approach, one for moving to a door (just like moving to a point in TouchPointEnv), and another for opening a door (just like opening a door in DoorsEnv). 