### PR TITLE
`SandwichEnvClear`

### DIFF
--- a/predicators/envs/sandwich.py
+++ b/predicators/envs/sandwich.py
@@ -874,8 +874,8 @@ class SandwichEnvClear(SandwichEnv):
     indicating whether it is clear, and (2) the board has a feature indicating
     whether it is clear.
 
-    This allows us to learn all the predicates with the assumption that the
-    predicates are a function of only their argument's states.
+    This allows us to learn all the predicates with the assumption that
+    the predicates are a function of only their argument's states.
     """
 
     def __init__(self, use_gui: bool = True) -> None:
@@ -946,11 +946,6 @@ class SandwichEnvClear(SandwichEnv):
     @classmethod
     def get_name(cls) -> str:
         return "sandwich_clear"
-
-    # TODO: need this?
-    # def _Clear_holds(self, state: State, objects: Sequence[Object]) -> bool:
-    #     obj, = objects
-    #     return self._object_is_clear(state, obj)
 
     def _BoardClear_holds(self, state: State,
                           objects: Sequence[Object]) -> bool:

--- a/predicators/ground_truth_nsrts.py
+++ b/predicators/ground_truth_nsrts.py
@@ -60,7 +60,7 @@ def get_gt_nsrts(env_name: str, predicates: Set[Predicate],
         nsrts = _get_coffee_gt_nsrts(env_name)
     elif env_name in ("satellites", "satellites_simple"):
         nsrts = _get_satellites_gt_nsrts(env_name)
-    elif env_name == "sandwich":
+    elif env_name in ("sandwich", "sandwich_clear"):
         nsrts = _get_sandwich_gt_nsrts(env_name)
     else:
         raise NotImplementedError("Ground truth NSRTs not implemented")

--- a/tests/envs/test_sandwich.py
+++ b/tests/envs/test_sandwich.py
@@ -1,8 +1,10 @@
 """Test cases for the sandwich env."""
 
 import numpy as np
+import pytest
 
 from predicators import utils
+from predicators.envs import create_new_env
 from predicators.envs.sandwich import SandwichEnv
 from predicators.structs import Action, GroundAtom
 
@@ -54,14 +56,15 @@ def test_sandwich_properties():
     assert env.action_space.shape == (4, )
 
 
-def test_sandwich_options():
+@pytest.mark.parametrize("env_name", ["sandwich", "sandwich_clear"])
+def test_sandwich_options(env_name):
     """Tests for sandwich parameterized options, predicates, and rendering."""
     # Set up environment
     utils.reset_config({
-        "env": "sandwich",
+        "env": env_name,
         # "render_state_dpi": 150,  # uncomment for higher-res test videos
     })
-    env = SandwichEnv()
+    env = create_new_env(env_name)
     BoardClear, Clear, GripperOpen, _, InHolder, _, _, _, _, _, _, _, _, On, \
         OnBoard = sorted(env.predicates)
     Pick, PutOnBoard, Stack = sorted(env.options)


### PR DESCRIPTION
Gives each ingredient obj and the board a "clear" feature so that all predicates can be learned with the assumption that they are a function of only their argument's states