### PR TITLE
[ml_models] Added a CNNRegressor

### DIFF
--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -769,9 +769,8 @@ class CNNRegressor(PyTorchRegressor):
         self._linears = nn.ModuleList()
 
     def forward(self, tensor_X: Tensor) -> Tensor:
-        for _, conv in enumerate(self._convs[:-1]):
-            tensor_X = self._max_pool(conv(tensor_X))
-        tensor_X = self._convs[-1](tensor_X)
+        for _, conv in enumerate(self._convs):
+            tensor_X = self._max_pool(F.relu(conv(tensor_X)))
         tensor_X = torch.flatten(tensor_X, 1)
         for _, linear in enumerate(self._linears[:-1]):
             tensor_X = F.relu(linear(tensor_X))
@@ -789,14 +788,10 @@ class CNNRegressor(PyTorchRegressor):
             kernel_size = self._conv_kernel_sizes[i]
             self._convs.append(
                 nn.Conv2d(c_dim, self._conv_channel_nums[i], kernel_size))
-            # Calculate size after Conv2d
+            # Calculate size after Conv2d + MaxPool2d
             c_dim = self._conv_channel_nums[i]
-            h_dim = h_dim - kernel_size + 1
-            w_dim = w_dim - kernel_size + 1
-            if i < len(self._conv_channel_nums) - 1:
-                # Calculate size after MaxPool2d
-                h_dim = h_dim // 2
-                w_dim = w_dim // 2
+            h_dim = (h_dim - kernel_size + 1) // 2
+            w_dim = (w_dim - kernel_size + 1) // 2
 
         flattened_size = c_dim * h_dim * w_dim
         self._linears = nn.ModuleList()

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -109,7 +109,7 @@ class _NormalizingRegressor(Regressor):
     def predict(self, x: Array) -> Array:
         assert self._x_dim != -1 or len(self._x_shape), \
             "Fit must be called before predict."
-        assert x.shape == (self._x_dim, ) or x.shape == self._x_shape
+        assert x.shape in ((self._x_dim, ), self._x_shape)
         # Normalize.
         x = (x - self._input_shift) / self._input_scale
         # Make prediction.

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -795,8 +795,8 @@ class CNNRegressor(PyTorchRegressor):
             w_dim = w_dim - kernel_size + 1
             if i < len(self._conv_channel_nums) - 1:
                 # Calculate size after MaxPool2d
-                h_dim = (h_dim + 1) // 2
-                w_dim = (w_dim + 1) // 2
+                h_dim = h_dim // 2
+                w_dim = w_dim // 2
 
         flattened_size = c_dim * h_dim * w_dim
         self._linears = nn.ModuleList()

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -81,8 +81,7 @@ class _NormalizingRegressor(Regressor):
     def __init__(self, seed: int) -> None:
         super().__init__(seed)
         # Set in fit().
-        self._x_dim = -1
-        self._x_shape: Tuple[int, ...] = tuple()
+        self._x_dims: Tuple[int, ...] = tuple()
         self._y_dim = -1
         self._input_shift = np.zeros(1, dtype=np.float32)
         self._input_scale = np.zeros(1, dtype=np.float32)
@@ -90,14 +89,8 @@ class _NormalizingRegressor(Regressor):
         self._output_scale = np.zeros(1, dtype=np.float32)
 
     def fit(self, X: Array, Y: Array) -> None:
-        if len(X.shape) == 2:
-            # Inputs are vectors
-            num_data, self._x_dim = X.shape
-        else:
-            # Inputs are arrays with at least 2 dimensions
-            # Set self._x_dim to a tuple
-            num_data = X.shape[0]
-            self._x_shape = tuple(X.shape[1:])
+        num_data = X.shape[0]
+        self._x_dims = tuple(X.shape[1:])
         _, self._y_dim = Y.shape
         assert Y.shape[0] == num_data
         logging.info(f"Training {self.__class__.__name__} on {num_data} "
@@ -107,9 +100,8 @@ class _NormalizingRegressor(Regressor):
         self._fit(X, Y)
 
     def predict(self, x: Array) -> Array:
-        assert self._x_dim != -1 or len(self._x_shape), \
-            "Fit must be called before predict."
-        assert x.shape in ((self._x_dim, ), self._x_shape)
+        assert len(self._x_dims), "Fit must be called before predict."
+        assert x.shape == self._x_dims
         # Normalize.
         x = (x - self._input_shift) / self._input_scale
         # Make prediction.
@@ -282,7 +274,7 @@ class _NormalizingBinaryClassifier(BinaryClassifier):
         super().__init__(seed)
         self._balance_data = balance_data
         # Set in fit().
-        self._x_dim = -1
+        self._x_dims: Tuple[int, ...] = tuple()
         self._input_shift = np.zeros(1, dtype=np.float32)
         self._input_scale = np.zeros(1, dtype=np.float32)
         self._do_single_class_prediction = False
@@ -293,7 +285,8 @@ class _NormalizingBinaryClassifier(BinaryClassifier):
 
         X is two-dimensional, y is one-dimensional.
         """
-        num_data, self._x_dim = X.shape
+        num_data = X.shape[0]
+        self._x_dims = tuple(X.shape[1:])
         assert y.shape == (num_data, )
         logging.info(f"Training {self.__class__.__name__} on {num_data} "
                      "datapoints")
@@ -321,8 +314,8 @@ class _NormalizingBinaryClassifier(BinaryClassifier):
 
         x is single-dimensional.
         """
-        assert self._x_dim > -1, "Fit must be called before classify."
-        assert x.shape == (self._x_dim, )
+        assert len(self._x_dims), "Fit must be called before classify."
+        assert x.shape == self._x_dims
         if self._do_single_class_prediction:
             return self._predicted_single_class
         # Normalize.
@@ -434,7 +427,7 @@ class PyTorchBinaryClassifier(_NormalizingBinaryClassifier, nn.Module):
 
     def _forward_single_input_np(self, x: Array) -> float:
         """Helper for _classify() and predict_proba()."""
-        assert x.shape == (self._x_dim, )
+        assert x.shape == self._x_dims
         tensor_x = torch.from_numpy(np.array(x, dtype=np.float32))
         tensor_X = tensor_x.unsqueeze(dim=0)
         tensor_Y = self(tensor_X)
@@ -470,8 +463,9 @@ class MLPRegressor(PyTorchRegressor):
         return tensor_X
 
     def _initialize_net(self) -> None:
+        assert len(self._x_dims) == 1, "X should be two-dimensional"
         self._linears = nn.ModuleList()
-        self._linears.append(nn.Linear(self._x_dim, self._hid_sizes[0]))
+        self._linears.append(nn.Linear(self._x_dims[0], self._hid_sizes[0]))
         for i in range(len(self._hid_sizes) - 1):
             self._linears.append(
                 nn.Linear(self._hid_sizes[i], self._hid_sizes[i + 1]))
@@ -562,9 +556,10 @@ class ImplicitMLPRegressor(PyTorchRegressor):
         return tensor_X.squeeze(dim=-1)
 
     def _initialize_net(self) -> None:
+        assert len(self._x_dims) == 1, "X must be two-dimensional"
         self._linears = nn.ModuleList()
         self._linears.append(
-            nn.Linear(self._x_dim + self._y_dim, self._hid_sizes[0]))
+            nn.Linear(self._x_dims[0] + self._y_dim, self._hid_sizes[0]))
         for i in range(len(self._hid_sizes) - 1):
             self._linears.append(
                 nn.Linear(self._hid_sizes[i], self._hid_sizes[i + 1]))
@@ -596,7 +591,7 @@ class ImplicitMLPRegressor(PyTorchRegressor):
         # Cast to torch first.
         tensor_X = torch.from_numpy(np.array(X, dtype=np.float32))
         tensor_Y = torch.from_numpy(np.array(Y, dtype=np.float32))
-        assert tensor_X.shape == (num_samples, self._x_dim)
+        assert tensor_X.shape == (num_samples, *self._x_dims)
         assert tensor_Y.shape == (num_samples, self._y_dim)
         # Expand tensor_Y in preparation for concat in the loop below.
         tensor_Y = tensor_Y[:, None, :]
@@ -606,10 +601,10 @@ class ImplicitMLPRegressor(PyTorchRegressor):
         # the num_negatives outputs, and the 1 positive output, have a
         # corresponding input.
         tiled_X = tensor_X.unsqueeze(1).repeat(1, num_negatives + 1, 1)
-        assert tiled_X.shape == (num_samples, num_negatives + 1, self._x_dim)
+        assert tiled_X.shape == (num_samples, num_negatives + 1, *self._x_dims)
         extended_X = tiled_X.reshape([-1, tensor_X.shape[-1]])
         assert extended_X.shape == (num_samples * (num_negatives + 1),
-                                    self._x_dim)
+                                    *self._x_dims)
         while True:
             # Resample negative examples on each iteration.
             neg_Y = torch.rand(size=(num_samples, num_negatives, self._y_dim),
@@ -620,7 +615,7 @@ class ImplicitMLPRegressor(PyTorchRegressor):
             # Concatenate to create the final input to the network.
             XY = torch.cat([extended_X, combined_Y], axis=1)  # type: ignore
             assert XY.shape == (num_samples * (num_negatives + 1),
-                                self._x_dim + self._y_dim)
+                                self._x_dims[0] + self._y_dim)
             # Create labels for multiclass loss. Note that the true inputs
             # are first, so the target labels are all zeros (see docstring).
             idxs = torch.zeros([num_samples], dtype=torch.int64)
@@ -655,7 +650,7 @@ class ImplicitMLPRegressor(PyTorchRegressor):
                              clip_value=self._clip_value)
 
     def _predict(self, x: Array) -> Array:
-        assert x.shape == (self._x_dim, )
+        assert x.shape == self._x_dims
         if self._inference_method == "sample_once":
             return self._predict_sample_once(x)
         if self._inference_method == "derivative_free":
@@ -673,7 +668,7 @@ class ImplicitMLPRegressor(PyTorchRegressor):
         # Concatenate the x and ys.
         concat_xy = np.array([np.hstack([x, y]) for y in sample_ys],
                              dtype=np.float32)
-        assert concat_xy.shape == (num_samples, self._x_dim + self._y_dim)
+        assert concat_xy.shape == (num_samples, self._x_dims[0] + self._y_dim)
         # Pass through network.
         scores = self(torch.from_numpy(concat_xy))
         # Find the highest probability sample.
@@ -735,7 +730,7 @@ class ImplicitMLPRegressor(PyTorchRegressor):
         # Concatenate the x and ys.
         concat_xy = np.array([np.hstack([x, y]) for y in candidate_ys],
                              dtype=np.float32)
-        assert concat_xy.shape == (num_samples, self._x_dim + self._y_dim)
+        assert concat_xy.shape == (num_samples, self._x_dims[0] + self._y_dim)
         # Pass through network.
         scores = self(torch.from_numpy(concat_xy))
         # Find the highest probability sample.
@@ -782,8 +777,8 @@ class CNNRegressor(PyTorchRegressor):
 
         # We need to calculate the size of the tensor outputted from the Conv2d
         # layers to use as the input dim for the linear layers post-flatten.
-        assert len(self._x_shape) == 3  # expect (C, H, W)
-        c_dim, h_dim, w_dim = self._x_shape
+        assert len(self._x_dims) == 3, "X should be 4-dimensional (N, C, H, W)"
+        c_dim, h_dim, w_dim = self._x_dims
         for i in range(len(self._conv_channel_nums)):
             kernel_size = self._conv_kernel_sizes[i]
             self._convs.append(
@@ -836,8 +831,9 @@ class NeuralGaussianRegressor(PyTorchRegressor, DistributionRegressor):
         # Versus MLPRegressor, the only difference here is that the output
         # size is 2 * self._y_dim, rather than self._y_dim, because we are
         # predicting both mean and diagonal variance.
+        assert len(self._x_dims) == 1, "X should be two-dimensional"
         self._linears = nn.ModuleList()
-        self._linears.append(nn.Linear(self._x_dim, self._hid_sizes[0]))
+        self._linears.append(nn.Linear(self._x_dims[0], self._hid_sizes[0]))
         for i in range(len(self._hid_sizes) - 1):
             self._linears.append(
                 nn.Linear(self._hid_sizes[i], self._hid_sizes[i + 1]))
@@ -878,7 +874,7 @@ class NeuralGaussianRegressor(PyTorchRegressor, DistributionRegressor):
         # Note: we need to use _predict(), rather than predict(), because
         # we need to apply normalization separately to the mean and variance
         # components of the prediction (see below).
-        assert x.shape == (self._x_dim, )
+        assert x.shape == self._x_dims
         # Normalize.
         norm_x = (x - self._input_shift) / self._input_scale
         norm_y = self._predict(norm_x)
@@ -931,7 +927,8 @@ class MLPBinaryClassifier(PyTorchBinaryClassifier):
         self._linears = nn.ModuleList()
 
     def _initialize_net(self) -> None:
-        self._linears.append(nn.Linear(self._x_dim, self._hid_sizes[0]))
+        assert len(self._x_dims) == 1, "X should be two-dimensional"
+        self._linears.append(nn.Linear(self._x_dims[0], self._hid_sizes[0]))
         for i in range(len(self._hid_sizes) - 1):
             self._linears.append(
                 nn.Linear(self._hid_sizes[i], self._hid_sizes[i + 1]))

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -9,7 +9,7 @@ from predicators import utils
 from predicators.ml_models import BinaryClassifierEnsemble, \
     DegenerateMLPDistributionRegressor, ImplicitMLPRegressor, \
     KNeighborsClassifier, KNeighborsRegressor, MLPBinaryClassifier, \
-    MLPRegressor, NeuralGaussianRegressor
+    MLPRegressor, CNNRegressor, NeuralGaussianRegressor
 
 
 def test_basic_mlp_regressor():
@@ -90,6 +90,38 @@ def test_implicit_mlp_regressor():
     model._inference_method = "not a real inference method"  # pylint: disable=protected-access
     with pytest.raises(NotImplementedError):
         model.predict(x)
+
+
+def test_basic_cnn_regressor():
+    """Tests for CNNRegressor."""
+    utils.reset_config()
+    input_size = (3, 5, 3)
+    output_size = 2
+    num_samples = 5
+    model = CNNRegressor(seed=123,
+                         conv_channel_nums=[1],
+                         conv_kernel_sizes=[3],
+                         linear_hid_sizes=[32, 32],
+                         max_train_iters=100,
+                         clip_gradients=True,
+                         clip_value=5,
+                         learning_rate=1e-3)
+    X = np.ones((num_samples, *input_size))
+    Y = np.zeros((num_samples, output_size))
+    model.fit(X, Y)
+    x = np.ones(input_size)
+    predicted_y = model.predict(x)
+    expected_y = np.zeros(output_size)
+    assert predicted_y.shape == expected_y.shape
+    assert np.allclose(predicted_y, expected_y, atol=1e-2)
+    # Test with nonzero outputs.
+    Y = 75 * np.ones((num_samples, output_size))
+    model.fit(X, Y)
+    x = np.ones(input_size)
+    predicted_y = model.predict(x)
+    expected_y = 75 * np.ones(output_size)
+    assert predicted_y.shape == expected_y.shape
+    assert np.allclose(predicted_y, expected_y, atol=1e-2)
 
 
 def test_neural_gaussian_regressor():

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -6,10 +6,10 @@ import numpy as np
 import pytest
 
 from predicators import utils
-from predicators.ml_models import BinaryClassifierEnsemble, \
+from predicators.ml_models import BinaryClassifierEnsemble, CNNRegressor, \
     DegenerateMLPDistributionRegressor, ImplicitMLPRegressor, \
     KNeighborsClassifier, KNeighborsRegressor, MLPBinaryClassifier, \
-    MLPRegressor, CNNRegressor, NeuralGaussianRegressor
+    MLPRegressor, NeuralGaussianRegressor
 
 
 def test_basic_mlp_regressor():

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -95,7 +95,7 @@ def test_implicit_mlp_regressor():
 def test_basic_cnn_regressor():
     """Tests for CNNRegressor."""
     utils.reset_config()
-    input_size = (3, 6, 4)
+    input_size = (3, 9, 6)
     output_size = 2
     num_samples = 5
     model = CNNRegressor(seed=123,

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -95,12 +95,12 @@ def test_implicit_mlp_regressor():
 def test_basic_cnn_regressor():
     """Tests for CNNRegressor."""
     utils.reset_config()
-    input_size = (3, 5, 3)
+    input_size = (3, 6, 4)
     output_size = 2
     num_samples = 5
     model = CNNRegressor(seed=123,
-                         conv_channel_nums=[1],
-                         conv_kernel_sizes=[3],
+                         conv_channel_nums=[1, 1],
+                         conv_kernel_sizes=[3, 1],
                          linear_hid_sizes=[32, 32],
                          max_train_iters=100,
                          clip_gradients=True,


### PR DESCRIPTION
**Summary of Changes:**
- Added a `CNNRegressor` class modeled off of `MLPRegressor`, which is a regression model composed of CNN-ReLU-MaxPool blocks, a flatten layer, and then linear-ReLU layers.
- Added tests for `CNNRegressor`
- Refactored `ml_models.py` so that all instances of `self._x_dim` are now tuples instead of single integers, to make it more flexible for inputs with more than 2 dimensions. Added some assertions in other model definitions that X is 2D in cases where it seemed necessary.