### PR TITLE
fix pybullet cover

### DIFF
--- a/predicators/envs/pybullet_cover.py
+++ b/predicators/envs/pybullet_cover.py
@@ -1,6 +1,6 @@
 """A PyBullet version of Cover."""
 
-from typing import ClassVar, Dict, List, Sequence, Tuple
+from typing import ClassVar, Dict, List, Sequence, Set, Tuple
 
 import numpy as np
 import pybullet as p
@@ -83,6 +83,10 @@ class PyBulletCoverEnv(PyBulletEnv, CoverEnv):
                 ])
         self._block_id_to_block: Dict[int, Object] = {}
         self._target_id_to_target: Dict[int, Object] = {}
+
+    @property
+    def options(self) -> Set[ParameterizedOption]:
+        return {self._PickPlace}
 
     def simulate(self, state: State, action: Action) -> State:
         # To implement this, need to handle resetting to states where the

--- a/tests/envs/test_pybullet_cover.py
+++ b/tests/envs/test_pybullet_cover.py
@@ -105,6 +105,14 @@ def test_pybullet_cover_reset(env):
         env.render_state(state, task, action)
 
 
+def test_pybullet_cover_options(env):
+    """Tests for PyBulletCoverEnv.options."""
+    options = env.options
+    assert len(options) == 1
+    option = next(iter(options))
+    assert option.name == "PickPlace"
+
+
 def test_pybullet_cover_step(env):
     """Tests for taking actions in PyBulletCoverEnv."""
     block = Object("block0", env.block_type)


### PR DESCRIPTION
closes #1400

I wanted to add a more direct test of the oracle approach, but it's not completely straightforward because our oracle approach tests currently use `env.simulate`, which is not implemented for pybullet cover. we could change that, but that's a much bigger change than I have the stomach for at the moment