### PR TITLE
Added online_learning_lifelong Flag

### DIFF
--- a/predicators/envs/base_env.py
+++ b/predicators/envs/base_env.py
@@ -345,4 +345,4 @@ class BaseEnv(abc.ABC):
 
     def get_state(self) -> State:
         """Get the current state of this environment."""
-        return self._current_state
+        return self._current_state.copy()

--- a/predicators/envs/base_env.py
+++ b/predicators/envs/base_env.py
@@ -342,3 +342,7 @@ class BaseEnv(abc.ABC):
         """
         raise NotImplementedError("This environment did not implement an "
                                   "interface for human demonstrations!")
+
+    def get_state(self) -> State:
+        """Get the current state of this environment."""
+        return self._current_state

--- a/predicators/main.py
+++ b/predicators/main.py
@@ -222,6 +222,7 @@ def _generate_interaction_results(
                                "if allow_interaction_in_demo_tasks is False.")
         monitor = TeacherInteractionMonitorWithVideo(env.render, request,
                                                      teacher)
+        init_state = last_state if CFG.online_learning_lifelong else None
         traj, _ = utils.run_policy(
             request.act_policy,
             env,
@@ -229,14 +230,13 @@ def _generate_interaction_results(
             request.train_task_idx,
             request.termination_function,
             max_num_steps=CFG.max_num_steps_interaction_request,
-            init_state=last_state
-            if CFG.online_learning_use_last_state else None,
+            init_state=init_state,
             exceptions_to_break_on={
                 utils.EnvironmentFailure, utils.OptionExecutionFailure,
                 utils.RequestActPolicyFailure
             },
             monitor=monitor)
-        if CFG.online_learning_use_last_state:
+        if CFG.online_learning_lifelong:
             last_state = traj.states[-1]
         request_responses = monitor.get_responses()
         query_cost += monitor.get_query_cost()

--- a/predicators/main.py
+++ b/predicators/main.py
@@ -212,7 +212,6 @@ def _generate_interaction_results(
     logging.info("Generating interaction results...")
     results = []
     query_cost = 0.0
-    do_state_reset = True
     if CFG.make_interaction_videos:
         video = []
     for request in requests:
@@ -229,14 +228,12 @@ def _generate_interaction_results(
             request.train_task_idx,
             request.termination_function,
             max_num_steps=CFG.max_num_steps_interaction_request,
-            do_state_reset=do_state_reset,
+            do_state_reset=(not CFG.online_learning_lifelong),
             exceptions_to_break_on={
                 utils.EnvironmentFailure, utils.OptionExecutionFailure,
                 utils.RequestActPolicyFailure
             },
             monitor=monitor)
-        if CFG.online_learning_lifelong:
-            do_state_reset = False
         request_responses = monitor.get_responses()
         query_cost += monitor.get_query_cost()
         result = InteractionResult(traj.states, traj.actions,

--- a/predicators/main.py
+++ b/predicators/main.py
@@ -212,6 +212,7 @@ def _generate_interaction_results(
     logging.info("Generating interaction results...")
     results = []
     query_cost = 0.0
+    last_state = None
     if CFG.make_interaction_videos:
         video = []
     for request in requests:
@@ -228,11 +229,15 @@ def _generate_interaction_results(
             request.train_task_idx,
             request.termination_function,
             max_num_steps=CFG.max_num_steps_interaction_request,
+            init_state=last_state
+            if CFG.online_learning_use_last_state else None,
             exceptions_to_break_on={
                 utils.EnvironmentFailure, utils.OptionExecutionFailure,
                 utils.RequestActPolicyFailure
             },
             monitor=monitor)
+        if CFG.online_learning_use_last_state:
+            last_state = traj.states[-1]
         request_responses = monitor.get_responses()
         query_cost += monitor.get_query_cost()
         result = InteractionResult(traj.states, traj.actions,

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -469,6 +469,7 @@ class GlobalSettings:
     # online NSRT learning parameters
     online_nsrt_learning_requests_per_cycle = 10
     online_learning_max_novelty_count = 0
+    online_learning_use_last_state = False
 
     # refinement cost estimation parameters
     refinement_estimator = "oracle"  # default refinement cost estimator

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -469,7 +469,7 @@ class GlobalSettings:
     # online NSRT learning parameters
     online_nsrt_learning_requests_per_cycle = 10
     online_learning_max_novelty_count = 0
-    online_learning_use_last_state = False
+    online_learning_lifelong = False
 
     # refinement cost estimation parameters
     refinement_estimator = "oracle"  # default refinement cost estimator

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -905,6 +905,7 @@ def run_policy(
         task_idx: int,
         termination_function: Callable[[State], bool],
         max_num_steps: int,
+        init_state: State = None,
         exceptions_to_break_on: Optional[Set[TypingType[Exception]]] = None,
         monitor: Optional[Monitor] = None
 ) -> Tuple[LowLevelTrajectory, Metrics]:
@@ -922,7 +923,8 @@ def run_policy(
     last action from the returned trajectory to maintain the invariant that
     the trajectory states are of length one greater than the actions.
     """
-    state = env.reset(train_or_test, task_idx)
+    state = init_state if init_state is not None else env.reset(
+        train_or_test, task_idx)
     states = [state]
     actions: List[Action] = []
     metrics: Metrics = defaultdict(float)

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -905,7 +905,7 @@ def run_policy(
         task_idx: int,
         termination_function: Callable[[State], bool],
         max_num_steps: int,
-        init_state: State = None,
+        init_state: Optional[State] = None,
         exceptions_to_break_on: Optional[Set[TypingType[Exception]]] = None,
         monitor: Optional[Monitor] = None
 ) -> Tuple[LowLevelTrajectory, Metrics]:
@@ -925,6 +925,7 @@ def run_policy(
     """
     state = init_state if init_state is not None else env.reset(
         train_or_test, task_idx)
+    assert env.get_state().allclose(state)
     states = [state]
     actions: List[Action] = []
     metrics: Metrics = defaultdict(float)

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -905,7 +905,7 @@ def run_policy(
         task_idx: int,
         termination_function: Callable[[State], bool],
         max_num_steps: int,
-        init_state: Optional[State] = None,
+        do_state_reset: bool = True,
         exceptions_to_break_on: Optional[Set[TypingType[Exception]]] = None,
         monitor: Optional[Monitor] = None
 ) -> Tuple[LowLevelTrajectory, Metrics]:
@@ -923,8 +923,10 @@ def run_policy(
     last action from the returned trajectory to maintain the invariant that
     the trajectory states are of length one greater than the actions.
     """
-    state = init_state if init_state is not None else env.reset(
-        train_or_test, task_idx)
+    if not do_state_reset:
+        state = env.get_state()
+    else:
+        state = env.reset(train_or_test, task_idx)
     assert env.get_state().allclose(state)
     states = [state]
     actions: List[Action] = []

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -923,9 +923,8 @@ def run_policy(
     last action from the returned trajectory to maintain the invariant that
     the trajectory states are of length one greater than the actions.
     """
-    if not do_state_reset:
-        state = env.get_state()
-    else:
+    state = env.get_state()
+    if do_state_reset:
         state = env.reset(train_or_test, task_idx)
     assert env.get_state().allclose(state)
     states = [state]

--- a/tests/approaches/test_online_nsrt_learning_approach.py
+++ b/tests/approaches/test_online_nsrt_learning_approach.py
@@ -29,7 +29,7 @@ def test_online_nsrt_learning_approach():
         "num_test_tasks": 3,
         "explorer": "random_options",
         "online_learning_max_novelty_count": float("inf"),
-        "online_learning_use_last_state": True
+        "online_learning_use_lifelong": True
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()

--- a/tests/approaches/test_online_nsrt_learning_approach.py
+++ b/tests/approaches/test_online_nsrt_learning_approach.py
@@ -29,7 +29,7 @@ def test_online_nsrt_learning_approach():
         "num_test_tasks": 3,
         "explorer": "random_options",
         "online_learning_max_novelty_count": float("inf"),
-        "online_learning_use_lifelong": True
+        "online_learning_lifelong": True
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()

--- a/tests/approaches/test_online_nsrt_learning_approach.py
+++ b/tests/approaches/test_online_nsrt_learning_approach.py
@@ -29,6 +29,7 @@ def test_online_nsrt_learning_approach():
         "num_test_tasks": 3,
         "explorer": "random_options",
         "online_learning_max_novelty_count": float("inf"),
+        "online_learning_use_last_state": True
     })
     env = CoverEnv()
     train_tasks = env.get_train_tasks()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -604,6 +604,7 @@ def test_run_policy():
             raise utils.EnvironmentFailure("mock failure")
 
         def get_state(self):
+            """Gets currrent state in mock environment."""
             return DefaultState
 
     mock_env = _MockEnv()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -603,6 +603,9 @@ def test_run_policy():
             del action  # unused
             raise utils.EnvironmentFailure("mock failure")
 
+        def get_state(self):
+            return DefaultState
+
     mock_env = _MockEnv()
     policy = lambda _: Action(np.zeros(1, dtype=np.float32))
     monitor = _CountingMonitor()


### PR DESCRIPTION
This PR adds an online_learning_use_last_state, to load the last_state during online exploration instead of sampling a random state. Try with command:

```python predicators/main.py --approach online_nsrt_learning --seed 0  --env cover --explorer glib --max_initial_demos 1 --num_train_tasks 1 --num_test_tasks 10 --max_num_steps_interaction_request 10000 --min_data_for_nsrt 10 --num_online_learning_cycles 1 --online_learning_lifelong True```