### PR TITLE
add `bilevel_plan_without_sim` setting

### DIFF
--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -372,6 +372,12 @@ class GlobalSettings:
     sesame_check_static_object_changes = False
     # Warning: making this tolerance any lower breaks pybullet_blocks.
     sesame_static_object_change_tol = 1e-3
+    # If True, then bilevel planning approaches will run task planning only,
+    # and then greedily sample and execute in the environment. This avoids the
+    # need for a simulator. In the future, we could check to see if the
+    # observed states match (at the abstract level) the expected states, and
+    # replan if not. But for now, we just execute each step without checking.
+    bilevel_plan_without_sim = False
 
     # evaluation parameters
     log_dir = "logs"

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -1,10 +1,13 @@
 """Test cases for the oracle approach class."""
 from typing import Any, Dict, List, Set
+from unittest.mock import patch
 
 import numpy as np
 import pytest
 
+import predicators.envs.pddl_env
 from predicators import utils
+from predicators.approaches.base_approach import ApproachFailure
 from predicators.approaches.oracle_approach import OracleApproach
 from predicators.envs.blocks import BlocksEnv
 from predicators.envs.cluttered_table import ClutteredTableEnv, \
@@ -33,7 +36,9 @@ from predicators.envs.touch_point import TouchOpenEnv, TouchPointEnv, \
 from predicators.ground_truth_models import get_gt_nsrts, get_gt_options
 from predicators.option_model import _OracleOptionModel
 from predicators.settings import CFG
-from predicators.structs import Action, Variable
+from predicators.structs import NSRT, Action, ParameterizedOption, Variable
+
+_PDDL_ENV_MODULE_PATH = predicators.envs.pddl_env.__name__
 
 ENV_NAME_AND_CLS = [
     ("cover", CoverEnv), ("cover_typed_options", CoverEnvTypedOptions),
@@ -259,6 +264,81 @@ def test_oracle_approach(env_name, env_cls):
             assert _policy_solves_task(policy, task, env.simulate)
     # Tests if OracleApproach can load _OracleOptionModel
     assert isinstance(approach.get_option_model(), _OracleOptionModel)
+
+
+def test_planning_without_sim():
+    """Tests the oracle approach in an environment with no simulator."""
+    # Test planning in a PDDL environment, which should succeed without
+    # simulation.
+    utils.reset_config({
+        "env": "pddl_blocks_procedural_tasks",
+        "num_train_tasks": 0,
+        "num_test_tasks": 2,
+        "bilevel_plan_without_sim": True,
+    })
+    simulate_path_str = \
+        f"{_PDDL_ENV_MODULE_PATH}.ProceduralTasksBlocksPDDLEnv.simulate"
+    with patch(simulate_path_str) as mock_simulate:
+        # Raise an error (and fail the test) if simulate is called.
+        mock_simulate.side_effect = AssertionError("Simulate called.")
+        env = ProceduralTasksBlocksPDDLEnv(use_gui=False)
+        train_tasks = env.get_train_tasks()
+        approach = OracleApproach(env.predicates,
+                                  get_gt_options(env.get_name()), env.types,
+                                  env.action_space, train_tasks)
+    # Test the policy outside of patch() because _policy_solves_task uses the
+    # simulator.
+    task = env.get_test_tasks()[0]
+    policy = approach.solve(task, timeout=500)
+    assert _policy_solves_task(policy, task, env.simulate)
+    # Running the policy again should fail because the plan is empty.
+    with pytest.raises(ApproachFailure) as e:
+        _policy_solves_task(policy, task, env.simulate)
+    assert "Greedy option plan exhausted." in str(e)
+    # Cover case where the option is not initiable.
+    utils.reset_config({
+        "env": "cover",
+        "num_train_tasks": 0,
+        "num_test_tasks": 1,
+        "bilevel_plan_without_sim": True,
+    })
+    env = CoverEnv(use_gui=False)
+    train_tasks = env.get_train_tasks()
+
+    # Force options to be non-initiable.
+    options = get_gt_options(env.get_name())
+    approach = OracleApproach(env.predicates, options, env.types,
+                              env.action_space, train_tasks)
+
+    assert len(options) == 1
+    option = next(iter(options))
+    new_option = ParameterizedOption(option.name, option.types,
+                                     option.params_space, option.policy,
+                                     lambda _1, _2, _3, _4: False,
+                                     option.terminal)
+    nsrts = approach._nsrts  # pylint: disable=protected-access
+    new_nsrts = set()
+    for nsrt in nsrts:
+        new_nsrt = NSRT(
+            nsrt.name,
+            nsrt.parameters,
+            nsrt.preconditions,
+            nsrt.add_effects,
+            nsrt.delete_effects,
+            nsrt.ignore_effects,
+            new_option,
+            nsrt.option_vars,
+            nsrt._sampler,  # pylint: disable=protected-access
+        )
+        new_nsrts.add(new_nsrt)
+    approach._nsrts = new_nsrts  # pylint: disable=protected-access
+
+    task = env.get_test_tasks()[0]
+
+    policy = approach.solve(task, timeout=500)
+    with pytest.raises(ApproachFailure) as e:
+        policy(task.init)
+    assert "Greedy option not initiable." in str(e)
 
 
 def test_get_gt_nsrts():


### PR DESCRIPTION
with `--bilevel_plan_without_sim True`, it will now be possible to run bilevel planning-based approaches but with only task planning run, to avoid the need for a `simulate()` function in the environment.

this flag will only work in environments that are not "TAMP-interesting" in that the first skeleton is assumed to work and all samples are assumed to work.

it's useful for getting simpler environments off the ground (e.g., forthcoming sokoban environment, cozmo environment.)

closes #1420