### PR TITLE
implements FD task planning

### DIFF
--- a/predicators/approaches/bilevel_planning_approach.py
+++ b/predicators/approaches/bilevel_planning_approach.py
@@ -135,7 +135,7 @@ class BilevelPlanningApproach(BaseApproach):
                               max_skeletons_optimized=1,
                               use_visited_state_set=True,
                               **kwargs))
-            elif "fd" in CFG.sesame_task_planner: # pragma: no cover
+            elif "fd" in CFG.sesame_task_planner:  # pragma: no cover
                 fd_exec_path = os.environ["FD_EXEC_PATH"]
                 exec_str = os.path.join(fd_exec_path, "fast-downward.py")
                 timeout_cmd = "gtimeout" if sys.platform == "darwin" \

--- a/predicators/approaches/bilevel_planning_approach.py
+++ b/predicators/approaches/bilevel_planning_approach.py
@@ -135,7 +135,7 @@ class BilevelPlanningApproach(BaseApproach):
                               max_skeletons_optimized=1,
                               use_visited_state_set=True,
                               **kwargs))
-            elif "fd" in CFG.sesame_task_planner:
+            elif "fd" in CFG.sesame_task_planner: # pragma: no cover
                 fd_exec_path = os.environ["FD_EXEC_PATH"]
                 exec_str = os.path.join(fd_exec_path, "fast-downward.py")
                 timeout_cmd = "gtimeout" if sys.platform == "darwin" \
@@ -144,9 +144,6 @@ class BilevelPlanningApproach(BaseApproach):
                 assert "FD_EXEC_PATH" in os.environ, \
                     "Please follow instructions in the docstring of the" +\
                     "_sesame_plan_with_fast_downward method in planning.py"
-                
-                import ipdb; ipdb.set_trace()
-
                 if CFG.sesame_task_planner == "fdopt":
                     alias_flag = "--alias seq-opt-lmcut"
                 elif CFG.sesame_task_planner == "fdsat":
@@ -157,16 +154,15 @@ class BilevelPlanningApproach(BaseApproach):
 
                 sas_file = generate_sas_file_for_fd(task, nsrts, preds,
                                                     self._types, timeout,
-                                                    timeout_cmd, alias_flag,
-                                                    exec_str, list(objects),
-                                                    init_atoms)
+                                                    timeout_cmd,
+                                                    alias_flag, exec_str,
+                                                    list(objects), init_atoms)
                 plan, _, metrics = fd_plan_from_sas_file(
                     sas_file, timeout_cmd, timeout, exec_str, alias_flag,
                     start_time, list(objects), init_atoms, nsrts, CFG.horizon)
             else:
                 raise ValueError("Unrecognized sesame_task_planner: "
                                  f"{CFG.sesame_task_planner}")
-
         except PlanningFailure as e:
             raise ApproachFailure(e.args[0], e.info)
         except PlanningTimeout as e:

--- a/predicators/approaches/bilevel_planning_approach.py
+++ b/predicators/approaches/bilevel_planning_approach.py
@@ -111,9 +111,11 @@ class BilevelPlanningApproach(BaseApproach):
     def _run_task_plan(self, task: Task, nsrts: Set[NSRT],
                        preds: Set[Predicate], timeout: float, seed: int,
                        **kwargs: Any) -> Tuple[List[_GroundNSRT], Metrics]:
+
         init_atoms = utils.abstract(task.init, preds)
         goal = task.goal
         objects = set(task.init)
+
         try:
             start_time = time.perf_counter()
             ground_nsrts, reachable_atoms = task_plan_grounding(
@@ -123,6 +125,7 @@ class BilevelPlanningApproach(BaseApproach):
                 preds, objects)
             duration = time.perf_counter() - start_time
             timeout -= duration
+
             if CFG.sesame_task_planner == "astar":
                 plan, _, metrics = next(
                     task_plan(init_atoms,
@@ -163,6 +166,7 @@ class BilevelPlanningApproach(BaseApproach):
             else:
                 raise ValueError("Unrecognized sesame_task_planner: "
                                  f"{CFG.sesame_task_planner}")
+
         except PlanningFailure as e:
             raise ApproachFailure(e.args[0], e.info)
         except PlanningTimeout as e:

--- a/predicators/approaches/bilevel_planning_approach.py
+++ b/predicators/approaches/bilevel_planning_approach.py
@@ -5,6 +5,8 @@ then Execution.
 """
 
 import abc
+import os
+import sys
 import time
 from typing import Any, Callable, List, Optional, Sequence, Set, Tuple
 
@@ -15,7 +17,8 @@ from predicators.approaches import ApproachFailure, ApproachTimeout, \
     BaseApproach
 from predicators.option_model import _OptionModelBase, create_option_model
 from predicators.planning import PlanningFailure, PlanningTimeout, \
-    sesame_plan, task_plan, task_plan_grounding
+    fd_plan_from_sas_file, generate_sas_file_for_fd, sesame_plan, task_plan, \
+    task_plan_grounding
 from predicators.settings import CFG
 from predicators.structs import NSRT, Action, DummyOption, GroundAtom, \
     Metrics, ParameterizedOption, Predicate, State, Task, Type, _GroundNSRT, \
@@ -108,11 +111,9 @@ class BilevelPlanningApproach(BaseApproach):
     def _run_task_plan(self, task: Task, nsrts: Set[NSRT],
                        preds: Set[Predicate], timeout: float, seed: int,
                        **kwargs: Any) -> Tuple[List[_GroundNSRT], Metrics]:
-
         init_atoms = utils.abstract(task.init, preds)
         goal = task.goal
         objects = set(task.init)
-
         try:
             start_time = time.perf_counter()
             ground_nsrts, reachable_atoms = task_plan_grounding(
@@ -122,18 +123,49 @@ class BilevelPlanningApproach(BaseApproach):
                 preds, objects)
             duration = time.perf_counter() - start_time
             timeout -= duration
+            if CFG.sesame_task_planner == "astar":
+                plan, _, metrics = next(
+                    task_plan(init_atoms,
+                              goal,
+                              ground_nsrts,
+                              reachable_atoms,
+                              heuristic,
+                              seed,
+                              timeout,
+                              max_skeletons_optimized=1,
+                              use_visited_state_set=True,
+                              **kwargs))
+            elif "fd" in CFG.sesame_task_planner:
+                fd_exec_path = os.environ["FD_EXEC_PATH"]
+                exec_str = os.path.join(fd_exec_path, "fast-downward.py")
+                timeout_cmd = "gtimeout" if sys.platform == "darwin" \
+                    else "timeout"
+                # Run Fast Downward followed by cleanup. Capture the output.
+                assert "FD_EXEC_PATH" in os.environ, \
+                    "Please follow instructions in the docstring of the" +\
+                    "_sesame_plan_with_fast_downward method in planning.py"
+                
+                import ipdb; ipdb.set_trace()
 
-            plan, _, metrics = next(
-                task_plan(init_atoms,
-                          goal,
-                          ground_nsrts,
-                          reachable_atoms,
-                          heuristic,
-                          seed,
-                          timeout,
-                          max_skeletons_optimized=1,
-                          use_visited_state_set=True,
-                          **kwargs))
+                if CFG.sesame_task_planner == "fdopt":
+                    alias_flag = "--alias seq-opt-lmcut"
+                elif CFG.sesame_task_planner == "fdsat":
+                    alias_flag = "--alias lama-first"
+                else:
+                    raise ValueError("Unrecognized sesame_task_planner: "
+                                     f"{CFG.sesame_task_planner}")
+
+                sas_file = generate_sas_file_for_fd(task, nsrts, preds,
+                                                    self._types, timeout,
+                                                    timeout_cmd, alias_flag,
+                                                    exec_str, list(objects),
+                                                    init_atoms)
+                plan, _, metrics = fd_plan_from_sas_file(
+                    sas_file, timeout_cmd, timeout, exec_str, alias_flag,
+                    start_time, list(objects), init_atoms, nsrts, CFG.horizon)
+            else:
+                raise ValueError("Unrecognized sesame_task_planner: "
+                                 f"{CFG.sesame_task_planner}")
 
         except PlanningFailure as e:
             raise ApproachFailure(e.args[0], e.info)

--- a/predicators/approaches/bilevel_planning_approach.py
+++ b/predicators/approaches/bilevel_planning_approach.py
@@ -118,15 +118,15 @@ class BilevelPlanningApproach(BaseApproach):
 
         try:
             start_time = time.perf_counter()
-            ground_nsrts, reachable_atoms = task_plan_grounding(
-                init_atoms, objects, nsrts)
-            heuristic = utils.create_task_planning_heuristic(
-                self._task_planning_heuristic, init_atoms, goal, ground_nsrts,
-                preds, objects)
-            duration = time.perf_counter() - start_time
-            timeout -= duration
 
             if CFG.sesame_task_planner == "astar":
+                ground_nsrts, reachable_atoms = task_plan_grounding(
+                    init_atoms, objects, nsrts)
+                heuristic = utils.create_task_planning_heuristic(
+                    self._task_planning_heuristic, init_atoms, goal,
+                    ground_nsrts, preds, objects)
+                duration = time.perf_counter() - start_time
+                timeout -= duration
                 plan, _, metrics = next(
                     task_plan(init_atoms,
                               goal,

--- a/predicators/planning.py
+++ b/predicators/planning.py
@@ -966,7 +966,8 @@ def fd_plan_from_sas_file(
     sas_file: str, timeout_cmd: str, timeout: float, exec_str: str,
     alias_flag: str, start_time: float, objects: List[Object],
     init_atoms: Set[GroundAtom], nsrts: Set[NSRT], max_horizon: int
-) -> Tuple[List[_GroundNSRT], List[Set[GroundAtom]], Metrics]: # pragma: no cover
+) -> Tuple[List[_GroundNSRT], List[Set[GroundAtom]],
+           Metrics]:  # pragma: no cover
     """Given a SAS file, runs search on it to generate a plan."""
     cmd_str = (f"{timeout_cmd} {timeout} {exec_str} {alias_flag} {sas_file}")
     output = subprocess.getoutput(cmd_str)

--- a/predicators/planning.py
+++ b/predicators/planning.py
@@ -936,7 +936,7 @@ def generate_sas_file_for_fd(
         task: Task, nsrts: Set[NSRT], predicates: Set[Predicate],
         types: Set[Type], timeout: float, timeout_cmd: str, alias_flag: str,
         exec_str: str, objects: List[Object],
-        init_atoms: Set[GroundAtom]) -> str: # pragma: no cover
+        init_atoms: Set[GroundAtom]) -> str:  # pragma: no cover
     """Generates a SAS file for a particular PDDL planning problem so that FD
     can be used for search."""
     # Create the domain and problem strings, then write them to tempfiles.

--- a/predicators/planning.py
+++ b/predicators/planning.py
@@ -932,11 +932,11 @@ def task_plan_with_option_plan_constraint(
     return action_seq
 
 
-def generate_sas_file_for_fd(task: Task, nsrts: Set[NSRT],
-                             predicates: Set[Predicate], types: Set[Type],
-                             timeout: float, timeout_cmd: str, alias_flag: str,
-                             exec_str: str, objects: List[Object],
-                             init_atoms: Set[GroundAtom]) -> str:
+def generate_sas_file_for_fd(
+        task: Task, nsrts: Set[NSRT], predicates: Set[Predicate],
+        types: Set[Type], timeout: float, timeout_cmd: str, alias_flag: str,
+        exec_str: str, objects: List[Object],
+        init_atoms: Set[GroundAtom]) -> str: # pragma: no cover
     """Generates a SAS file for a particular PDDL planning problem so that FD
     can be used for search."""
     # Create the domain and problem strings, then write them to tempfiles.

--- a/predicators/planning.py
+++ b/predicators/planning.py
@@ -966,7 +966,7 @@ def fd_plan_from_sas_file(
     sas_file: str, timeout_cmd: str, timeout: float, exec_str: str,
     alias_flag: str, start_time: float, objects: List[Object],
     init_atoms: Set[GroundAtom], nsrts: Set[NSRT], max_horizon: int
-) -> Tuple[List[_GroundNSRT], List[Set[GroundAtom]], Metrics]:
+) -> Tuple[List[_GroundNSRT], List[Set[GroundAtom]], Metrics]: # pragma: no cover
     """Given a SAS file, runs search on it to generate a plan."""
     cmd_str = (f"{timeout_cmd} {timeout} {exec_str} {alias_flag} {sas_file}")
     output = subprocess.getoutput(cmd_str)

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -376,7 +376,6 @@ def test_planning_without_sim():
     assert "Greedy option not initiable." in str(e)
 
 
-
 def test_get_gt_nsrts():
     """Test get_gt_nsrts alone."""
     with pytest.raises(NotImplementedError):

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -298,7 +298,24 @@ def test_planning_without_sim():
         _policy_solves_task(policy, task, env.simulate)
     assert "Greedy option plan exhausted." in str(e)
 
+    # Cover case where unknown task planner is used.
+    utils.reset_config({
+        "env": "cover",
+        "num_train_tasks": 0,
+        "num_test_tasks": 1,
+        "bilevel_plan_without_sim": True,
+        "sesame_task_planner": "not-a-real-planner"
+    })
+    with pytest.raises(ValueError):
+        policy = approach.solve(task, timeout=500)
+
     # Test timeout.
+    utils.reset_config({
+        "env": "pddl_blocks_procedural_tasks",
+        "num_train_tasks": 0,
+        "num_test_tasks": 2,
+        "bilevel_plan_without_sim": True,
+    })
     with pytest.raises(ApproachTimeout) as e:
         approach.solve(task, timeout=0)
 
@@ -357,6 +374,7 @@ def test_planning_without_sim():
     with pytest.raises(ApproachFailure) as e:
         policy(task.init)
     assert "Greedy option not initiable." in str(e)
+
 
 
 def test_get_gt_nsrts():

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -657,7 +657,7 @@ def test_sesame_plan_fast_downward():
         })
         env = ClutteredTableEnv()
         nsrts = get_gt_nsrts(env.get_name(), env.predicates,
-                            get_gt_options(env.get_name()))
+                             get_gt_options(env.get_name()))
         task = env.get_test_tasks()[0]
         option_model = create_option_model(CFG.option_model_name)
         try:
@@ -675,7 +675,7 @@ def test_sesame_plan_fast_downward():
             )
             # We only get to these lines if FD is installed.
             assert all(isinstance(act, _Option)
-                    for act in plan)  # pragma: no cover
+                       for act in plan)  # pragma: no cover
             assert metrics["num_nodes_created"] >= \
                 metrics["num_nodes_expanded"]  # pragma: no cover
         except AssertionError as e:

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -655,11 +655,9 @@ def test_sesame_plan_fast_downward():
             "num_test_tasks": 50,
             "sesame_task_planner": sesame_task_planner,
         })
-        # Test on the repeated_nextto_single_option env, which requires ignore
-        # effects.
         env = ClutteredTableEnv()
         nsrts = get_gt_nsrts(env.get_name(), env.predicates,
-                             get_gt_options(env.get_name()))
+                            get_gt_options(env.get_name()))
         task = env.get_test_tasks()[0]
         option_model = create_option_model(CFG.option_model_name)
         try:
@@ -677,7 +675,7 @@ def test_sesame_plan_fast_downward():
             )
             # We only get to these lines if FD is installed.
             assert all(isinstance(act, _Option)
-                       for act in plan)  # pragma: no cover
+                    for act in plan)  # pragma: no cover
             assert metrics["num_nodes_created"] >= \
                 metrics["num_nodes_expanded"]  # pragma: no cover
         except AssertionError as e:


### PR DESCRIPTION
Enables use of FD with the `--bilevel_plan_without_sim` flag set to `True`. Will be useful for environments like sokoban (#1426 ) that are challenging for task planning.

Example command:
```
python predicators/main.py --seed 0 --env pddl_blocks_procedural_tasks --approach oracle --num_train_tasks 0 --num_test_tasks 5 --bilevel_plan_without_sim True --sesame_task_planner fdopt
```