### PR TITLE
separate `Task` from `EnvironmentTask`

### DIFF
--- a/predicators/envs/base_env.py
+++ b/predicators/envs/base_env.py
@@ -13,8 +13,8 @@ from gym.spaces import Box
 from predicators import utils
 from predicators.llm_interface import OpenAILLM
 from predicators.settings import CFG
-from predicators.structs import Action, DefaultState, DefaultEnvironmentTask, \
-    GroundAtom, Object, Predicate, State, EnvironmentTask, Type, Video
+from predicators.structs import Action, DefaultEnvironmentTask, DefaultState, \
+    EnvironmentTask, GroundAtom, Object, Predicate, State, Type, Video
 
 
 class BaseEnv(abc.ABC):

--- a/predicators/envs/base_env.py
+++ b/predicators/envs/base_env.py
@@ -306,7 +306,7 @@ class BaseEnv(abc.ABC):
         """Resets the current state to the train or test task initial state."""
         self._current_task = self.get_task(train_or_test, task_idx)
         # NOTE: current_state will be deprecated soon in favor of current_obs.
-        self._current_state = self._current_task.task.init
+        self._current_state = self._current_task.init
         # Copy to prevent external changes to the environment's state.
         return self._current_state.copy()
 

--- a/predicators/envs/blocks.py
+++ b/predicators/envs/blocks.py
@@ -23,7 +23,7 @@ from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
 from predicators.structs import Action, Array, GroundAtom, Object, Predicate, \
-    State, Task, Type
+    State, EnvironmentTask, Type
 
 
 class BlocksEnv(BaseEnv):
@@ -178,12 +178,12 @@ class BlocksEnv(BaseEnv):
             next_state.set(other_block, "clear", 0)
         return next_state
 
-    def _generate_train_tasks(self) -> List[Task]:
+    def _generate_train_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num_tasks=CFG.num_train_tasks,
                                possible_num_blocks=self._num_blocks_train,
                                rng=self._train_rng)
 
-    def _generate_test_tasks(self) -> List[Task]:
+    def _generate_test_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num_tasks=CFG.num_test_tasks,
                                possible_num_blocks=self._num_blocks_test,
                                rng=self._test_rng)
@@ -215,7 +215,7 @@ class BlocksEnv(BaseEnv):
     def render_state_plt(
             self,
             state: State,
-            task: Task,
+            task: EnvironmentTask,
             action: Optional[Action] = None,
             caption: Optional[str] = None) -> matplotlib.figure.Figure:
         r = self._block_size * 0.5  # block radius
@@ -282,7 +282,7 @@ class BlocksEnv(BaseEnv):
         return fig
 
     def _get_tasks(self, num_tasks: int, possible_num_blocks: List[int],
-                   rng: np.random.Generator) -> List[Task]:
+                   rng: np.random.Generator) -> List[EnvironmentTask]:
         tasks = []
         for _ in range(num_tasks):
             num_blocks = rng.choice(possible_num_blocks)
@@ -292,7 +292,7 @@ class BlocksEnv(BaseEnv):
                 goal = self._sample_goal_from_piles(num_blocks, piles, rng)
                 if not all(goal_atom.holds(init_state) for goal_atom in goal):
                     break
-            tasks.append(Task(init_state, goal))
+            tasks.append(EnvironmentTask(init_state, goal))
         return tasks
 
     def _sample_initial_piles(self, num_blocks: int,
@@ -479,7 +479,7 @@ class BlocksEnv(BaseEnv):
             return None
         return max(blocks_here, key=lambda x: x[1])[0]  # highest z
 
-    def _load_task_from_json(self, json_file: Path) -> Task:
+    def _load_task_from_json(self, json_file: Path) -> EnvironmentTask:
         with open(json_file, "r", encoding="utf-8") as f:
             task_spec = json.load(f)
         # Create the initial state from the task spec.
@@ -526,8 +526,8 @@ class BlocksEnv(BaseEnv):
                 task_spec["language_goal"], id_to_obj)
         else:
             raise ValueError("JSON task spec must include 'goal'.")
-        task = Task(init_state, goal)
-        assert not task.goal_holds(init_state)
+        task = EnvironmentTask(init_state, goal)
+        assert not task.task.goal_holds(init_state)
         return task
 
     def _get_language_goal_prompt_prefix(self,

--- a/predicators/envs/blocks.py
+++ b/predicators/envs/blocks.py
@@ -526,9 +526,9 @@ class BlocksEnv(BaseEnv):
                 task_spec["language_goal"], id_to_obj)
         else:
             raise ValueError("JSON task spec must include 'goal'.")
-        task = EnvironmentTask(init_state, goal)
-        assert not task.task.goal_holds(init_state)
-        return task
+        env_task = EnvironmentTask(init_state, goal)
+        assert not env_task.task.goal_holds(init_state)
+        return env_task
 
     def _get_language_goal_prompt_prefix(self,
                                          object_names: Collection[str]) -> str:

--- a/predicators/envs/blocks.py
+++ b/predicators/envs/blocks.py
@@ -22,8 +22,8 @@ from matplotlib import patches
 from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
-from predicators.structs import Action, Array, GroundAtom, Object, Predicate, \
-    State, EnvironmentTask, Type
+from predicators.structs import Action, Array, EnvironmentTask, GroundAtom, \
+    Object, Predicate, State, Type
 
 
 class BlocksEnv(BaseEnv):

--- a/predicators/envs/cluttered_table.py
+++ b/predicators/envs/cluttered_table.py
@@ -111,8 +111,8 @@ class ClutteredTableEnv(BaseEnv):
             caption: Optional[str] = None) -> matplotlib.figure.Figure:
         fig, ax = plt.subplots(1, 1)
         ax.set_aspect('equal')
-        assert len(task.task.goal) == 1
-        goal_atom = next(iter(task.task.goal))
+        assert len(task.goal) == 1
+        goal_atom = next(iter(task.goal))
         assert goal_atom.predicate == self._Holding
         assert len(goal_atom.objects) == 1
         goal_can = goal_atom.objects[0]

--- a/predicators/envs/cluttered_table.py
+++ b/predicators/envs/cluttered_table.py
@@ -14,8 +14,8 @@ from gym.spaces import Box
 from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
-from predicators.structs import Action, Array, GroundAtom, Object, Predicate, \
-    State, EnvironmentTask, Type
+from predicators.structs import Action, Array, EnvironmentTask, GroundAtom, \
+    Object, Predicate, State, Type
 
 
 class ClutteredTableEnv(BaseEnv):
@@ -155,7 +155,8 @@ class ClutteredTableEnv(BaseEnv):
         plt.tight_layout()
         return fig
 
-    def _get_tasks(self, num: int, train_or_test: str) -> List[EnvironmentTask]:
+    def _get_tasks(self, num: int,
+                   train_or_test: str) -> List[EnvironmentTask]:
         tasks = []
         cans = []
         for i in range(
@@ -165,7 +166,8 @@ class ClutteredTableEnv(BaseEnv):
         goal = {GroundAtom(self._Holding, [cans[0]])}
         for _ in range(num):
             tasks.append(
-                EnvironmentTask(self._create_initial_state(cans, train_or_test), goal))
+                EnvironmentTask(
+                    self._create_initial_state(cans, train_or_test), goal))
         return tasks
 
     def _create_initial_state(self, cans: List[Object],

--- a/predicators/envs/cluttered_table.py
+++ b/predicators/envs/cluttered_table.py
@@ -15,7 +15,7 @@ from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
 from predicators.structs import Action, Array, GroundAtom, Object, Predicate, \
-    State, Task, Type
+    State, EnvironmentTask, Type
 
 
 class ClutteredTableEnv(BaseEnv):
@@ -77,10 +77,10 @@ class ClutteredTableEnv(BaseEnv):
         next_state.set(desired_can, "is_grasped", 1.0)
         return next_state
 
-    def _generate_train_tasks(self) -> List[Task]:
+    def _generate_train_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num=CFG.num_train_tasks, train_or_test="train")
 
-    def _generate_test_tasks(self) -> List[Task]:
+    def _generate_test_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num=CFG.num_test_tasks, train_or_test="test")
 
     @property
@@ -106,13 +106,13 @@ class ClutteredTableEnv(BaseEnv):
     def render_state_plt(
             self,
             state: State,
-            task: Task,
+            task: EnvironmentTask,
             action: Optional[Action] = None,
             caption: Optional[str] = None) -> matplotlib.figure.Figure:
         fig, ax = plt.subplots(1, 1)
         ax.set_aspect('equal')
-        assert len(task.goal) == 1
-        goal_atom = next(iter(task.goal))
+        assert len(task.task.goal) == 1
+        goal_atom = next(iter(task.task.goal))
         assert goal_atom.predicate == self._Holding
         assert len(goal_atom.objects) == 1
         goal_can = goal_atom.objects[0]
@@ -155,7 +155,7 @@ class ClutteredTableEnv(BaseEnv):
         plt.tight_layout()
         return fig
 
-    def _get_tasks(self, num: int, train_or_test: str) -> List[Task]:
+    def _get_tasks(self, num: int, train_or_test: str) -> List[EnvironmentTask]:
         tasks = []
         cans = []
         for i in range(
@@ -165,7 +165,7 @@ class ClutteredTableEnv(BaseEnv):
         goal = {GroundAtom(self._Holding, [cans[0]])}
         for _ in range(num):
             tasks.append(
-                Task(self._create_initial_state(cans, train_or_test), goal))
+                EnvironmentTask(self._create_initial_state(cans, train_or_test), goal))
         return tasks
 
     def _create_initial_state(self, cans: List[Object],

--- a/predicators/envs/coffee.py
+++ b/predicators/envs/coffee.py
@@ -10,8 +10,8 @@ from gym.spaces import Box
 from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
-from predicators.structs import Action, GroundAtom, Object, Predicate, State, \
-    EnvironmentTask, Type
+from predicators.structs import Action, EnvironmentTask, GroundAtom, Object, \
+    Predicate, State, Type
 
 
 class CoffeeEnv(BaseEnv):

--- a/predicators/envs/coffee.py
+++ b/predicators/envs/coffee.py
@@ -11,7 +11,7 @@ from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
 from predicators.structs import Action, GroundAtom, Object, Predicate, State, \
-    Task, Type
+    EnvironmentTask, Type
 
 
 class CoffeeEnv(BaseEnv):
@@ -269,12 +269,12 @@ class CoffeeEnv(BaseEnv):
             next_state.set(self._jug, "is_filled", 1.0)
         return next_state
 
-    def _generate_train_tasks(self) -> List[Task]:
+    def _generate_train_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num=CFG.num_train_tasks,
                                num_cups_lst=CFG.coffee_num_cups_train,
                                rng=self._train_rng)
 
-    def _generate_test_tasks(self) -> List[Task]:
+    def _generate_test_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num=CFG.num_test_tasks,
                                num_cups_lst=CFG.coffee_num_cups_test,
                                rng=self._test_rng)
@@ -307,7 +307,7 @@ class CoffeeEnv(BaseEnv):
     def render_state_plt(
             self,
             state: State,
-            task: Task,
+            task: EnvironmentTask,
             action: Optional[Action] = None,
             caption: Optional[str] = None) -> matplotlib.figure.Figure:
         del caption  # unused
@@ -438,7 +438,7 @@ class CoffeeEnv(BaseEnv):
         return fig
 
     def _get_tasks(self, num: int, num_cups_lst: List[int],
-                   rng: np.random.Generator) -> List[Task]:
+                   rng: np.random.Generator) -> List[EnvironmentTask]:
         tasks = []
         # Create the parts of the initial state that do not change between
         # tasks, which includes the robot and the machine.
@@ -519,7 +519,7 @@ class CoffeeEnv(BaseEnv):
                 "is_filled": 0.0  # jug starts off empty
             }
             init_state = utils.create_state_from_dict(state_dict)
-            task = Task(init_state, goal)
+            task = EnvironmentTask(init_state, goal)
             tasks.append(task)
         return tasks
 

--- a/predicators/envs/cover.py
+++ b/predicators/envs/cover.py
@@ -15,7 +15,7 @@ from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
 from predicators.structs import Action, Array, GroundAtom, Object, Predicate, \
-    State, Task, Type
+    State, EnvironmentTask, Type
 
 
 class CoverEnv(BaseEnv):
@@ -112,10 +112,10 @@ class CoverEnv(BaseEnv):
                 next_state.set(held_block, "grasp", -1)
         return next_state
 
-    def _generate_train_tasks(self) -> List[Task]:
+    def _generate_train_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num=CFG.num_train_tasks, rng=self._train_rng)
 
-    def _generate_test_tasks(self) -> List[Task]:
+    def _generate_test_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num=CFG.num_test_tasks, rng=self._test_rng)
 
     @property
@@ -140,7 +140,7 @@ class CoverEnv(BaseEnv):
     def render_state_plt(
             self,
             state: State,
-            task: Task,
+            task: EnvironmentTask,
             action: Optional[Action] = None,
             caption: Optional[str] = None) -> matplotlib.figure.Figure:
         fig, ax = plt.subplots(1, 1)
@@ -238,7 +238,7 @@ class CoverEnv(BaseEnv):
             targets.append(Object(f"target{i}", self._target_type))
         return blocks, targets
 
-    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[Task]:
+    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[EnvironmentTask]:
         tasks = []
         # Create blocks and targets.
         blocks, targets = self._create_blocks_and_targets()
@@ -257,7 +257,7 @@ class CoverEnv(BaseEnv):
             init = self._create_initial_state(blocks, targets, rng)
             assert init.get_objects(self._block_type) == blocks
             assert init.get_objects(self._target_type) == targets
-            tasks.append(Task(init, goals[i % len(goals)]))
+            tasks.append(EnvironmentTask(init, goals[i % len(goals)]))
         return tasks
 
     def _create_initial_state(self, blocks: List[Object],
@@ -712,7 +712,7 @@ class CoverMultistepOptions(CoverEnvTypedOptions):
     def render_state_plt(
             self,
             state: State,
-            task: Task,
+            task: EnvironmentTask,
             action: Optional[Action] = None,
             caption: Optional[str] = None) -> matplotlib.figure.Figure:
         # Need to override rendering to account for new state features.

--- a/predicators/envs/cover.py
+++ b/predicators/envs/cover.py
@@ -14,8 +14,8 @@ from gym.spaces import Box
 from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
-from predicators.structs import Action, Array, GroundAtom, Object, Predicate, \
-    State, EnvironmentTask, Type
+from predicators.structs import Action, Array, EnvironmentTask, GroundAtom, \
+    Object, Predicate, State, Type
 
 
 class CoverEnv(BaseEnv):
@@ -238,7 +238,8 @@ class CoverEnv(BaseEnv):
             targets.append(Object(f"target{i}", self._target_type))
         return blocks, targets
 
-    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[EnvironmentTask]:
+    def _get_tasks(self, num: int,
+                   rng: np.random.Generator) -> List[EnvironmentTask]:
         tasks = []
         # Create blocks and targets.
         blocks, targets = self._create_blocks_and_targets()

--- a/predicators/envs/doors.py
+++ b/predicators/envs/doors.py
@@ -14,7 +14,7 @@ from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
 from predicators.structs import Action, GroundAtom, Object, Predicate, State, \
-    Task, Type
+    EnvironmentTask, Type
 from predicators.utils import Rectangle, StateWithCache, _Geom2D
 
 
@@ -111,10 +111,10 @@ class DoorsEnv(BaseEnv):
                     next_state.set(door, "open", 1.0)
         return next_state
 
-    def _generate_train_tasks(self) -> List[Task]:
+    def _generate_train_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num=CFG.num_train_tasks, rng=self._train_rng)
 
-    def _generate_test_tasks(self) -> List[Task]:
+    def _generate_test_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num=CFG.num_test_tasks, rng=self._test_rng)
 
     @property
@@ -153,7 +153,7 @@ class DoorsEnv(BaseEnv):
     def render_state_plt(
             self,
             state: State,
-            task: Task,
+            task: EnvironmentTask,
             action: Optional[Action] = None,
             caption: Optional[str] = None) -> matplotlib.figure.Figure:
         del caption  # unused
@@ -164,7 +164,7 @@ class DoorsEnv(BaseEnv):
         default_room_color = "lightgray"
         in_room_color = "lightsteelblue"
         goal_room_color = "khaki"
-        goal_room = next(iter(task.goal)).objects[1]
+        goal_room = next(iter(task.task.goal)).objects[1]
         for room in state.get_objects(self._room_type):
             room_geom = self.object_to_geom(room, state)
             if room == goal_room:
@@ -217,8 +217,8 @@ class DoorsEnv(BaseEnv):
         plt.tight_layout()
         return fig
 
-    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[Task]:
-        tasks: List[Task] = []
+    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[EnvironmentTask]:
+        tasks: List[EnvironmentTask] = []
         for _ in range(num):
             # Sample a room map.
             room_map = self._sample_room_map(rng)
@@ -234,7 +234,7 @@ class DoorsEnv(BaseEnv):
             goal_atom = GroundAtom(self._InRoom, [self._robot, goal_room])
             goal = {goal_atom}
             assert not goal_atom.holds(state)
-            tasks.append(Task(state, goal))
+            tasks.append(EnvironmentTask(state, goal))
         return tasks
 
     def _sample_initial_state_from_map(self, room_map: NDArray,

--- a/predicators/envs/doors.py
+++ b/predicators/envs/doors.py
@@ -13,8 +13,8 @@ from numpy.typing import NDArray
 from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
-from predicators.structs import Action, GroundAtom, Object, Predicate, State, \
-    EnvironmentTask, Type
+from predicators.structs import Action, EnvironmentTask, GroundAtom, Object, \
+    Predicate, State, Type
 from predicators.utils import Rectangle, StateWithCache, _Geom2D
 
 
@@ -217,7 +217,8 @@ class DoorsEnv(BaseEnv):
         plt.tight_layout()
         return fig
 
-    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[EnvironmentTask]:
+    def _get_tasks(self, num: int,
+                   rng: np.random.Generator) -> List[EnvironmentTask]:
         tasks: List[EnvironmentTask] = []
         for _ in range(num):
             # Sample a room map.

--- a/predicators/envs/doors.py
+++ b/predicators/envs/doors.py
@@ -164,7 +164,7 @@ class DoorsEnv(BaseEnv):
         default_room_color = "lightgray"
         in_room_color = "lightsteelblue"
         goal_room_color = "khaki"
-        goal_room = next(iter(task.task.goal)).objects[1]
+        goal_room = next(iter(task.goal)).objects[1]
         for room in state.get_objects(self._room_type):
             room_geom = self.object_to_geom(room, state)
             if room == goal_room:

--- a/predicators/envs/narrow_passage.py
+++ b/predicators/envs/narrow_passage.py
@@ -10,8 +10,8 @@ from gym.spaces import Box
 from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
-from predicators.structs import Action, GroundAtom, Object, Predicate, State, \
-    EnvironmentTask, Type
+from predicators.structs import Action, EnvironmentTask, GroundAtom, Object, \
+    Predicate, State, Type
 from predicators.utils import _Geom2D
 
 
@@ -172,7 +172,8 @@ class NarrowPassageEnv(BaseEnv):
         plt.tight_layout()
         return fig
 
-    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[EnvironmentTask]:
+    def _get_tasks(self, num: int,
+                   rng: np.random.Generator) -> List[EnvironmentTask]:
         # There is only one goal in this environment.
         goal_atom = GroundAtom(self._TouchedGoal, [self._robot, self._target])
         goal = {goal_atom}

--- a/predicators/envs/narrow_passage.py
+++ b/predicators/envs/narrow_passage.py
@@ -11,7 +11,7 @@ from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
 from predicators.structs import Action, GroundAtom, Object, Predicate, State, \
-    Task, Type
+    EnvironmentTask, Type
 from predicators.utils import _Geom2D
 
 
@@ -98,10 +98,10 @@ class NarrowPassageEnv(BaseEnv):
             next_state.set(self._robot, "y", y)
         return next_state
 
-    def _generate_train_tasks(self) -> List[Task]:
+    def _generate_train_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num=CFG.num_train_tasks, rng=self._train_rng)
 
-    def _generate_test_tasks(self) -> List[Task]:
+    def _generate_test_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num=CFG.num_test_tasks, rng=self._test_rng)
 
     @property
@@ -133,7 +133,7 @@ class NarrowPassageEnv(BaseEnv):
     def render_state_plt(
             self,
             state: State,
-            task: Task,
+            task: EnvironmentTask,
             action: Optional[Action] = None,
             caption: Optional[str] = None) -> matplotlib.figure.Figure:
         fig, ax = plt.subplots(1, 1, figsize=(5, 5))
@@ -172,7 +172,7 @@ class NarrowPassageEnv(BaseEnv):
         plt.tight_layout()
         return fig
 
-    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[Task]:
+    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[EnvironmentTask]:
         # There is only one goal in this environment.
         goal_atom = GroundAtom(self._TouchedGoal, [self._robot, self._target])
         goal = {goal_atom}
@@ -183,7 +183,7 @@ class NarrowPassageEnv(BaseEnv):
         y_mid = (self.y_ub - self.y_lb) / 2 + self.y_lb
         margin = self.wall_thickness_half + self.init_pos_margin
 
-        tasks: List[Task] = []
+        tasks: List[EnvironmentTask] = []
         while len(tasks) < num:
             # Door width is generated randomly per task
             door_width_padding = rng.uniform(
@@ -241,7 +241,7 @@ class NarrowPassageEnv(BaseEnv):
             assert not goal_atom.holds(
                 state
             ), "Error: goal is already satisfied in this state initialization"
-            tasks.append(Task(state, goal))
+            tasks.append(EnvironmentTask(state, goal))
         return tasks
 
     def _TouchedGoal_holds(self, state: State,

--- a/predicators/envs/painting.py
+++ b/predicators/envs/painting.py
@@ -17,8 +17,8 @@ from matplotlib import patches
 from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
-from predicators.structs import Action, GroundAtom, Object, Predicate, State, \
-    EnvironmentTask, Type
+from predicators.structs import Action, EnvironmentTask, GroundAtom, Object, \
+    Predicate, State, Type
 
 
 class PaintingEnv(BaseEnv):

--- a/predicators/envs/painting.py
+++ b/predicators/envs/painting.py
@@ -18,7 +18,7 @@ from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
 from predicators.structs import Action, GroundAtom, Object, Predicate, State, \
-    Task, Type
+    EnvironmentTask, Type
 
 
 class PaintingEnv(BaseEnv):
@@ -263,12 +263,12 @@ class PaintingEnv(BaseEnv):
     def _num_objects_test(self) -> List[int]:
         return CFG.painting_num_objs_test
 
-    def _generate_train_tasks(self) -> List[Task]:
+    def _generate_train_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num_tasks=CFG.num_train_tasks,
                                num_objs_lst=self._num_objects_train,
                                rng=self._train_rng)
 
-    def _generate_test_tasks(self) -> List[Task]:
+    def _generate_test_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num_tasks=CFG.num_test_tasks,
                                num_objs_lst=self._num_objects_test,
                                rng=self._test_rng)
@@ -317,7 +317,7 @@ class PaintingEnv(BaseEnv):
     def render_state_plt(
             self,
             state: State,
-            task: Task,
+            task: EnvironmentTask,
             action: Optional[Action] = None,
             caption: Optional[str] = None) -> matplotlib.figure.Figure:
         fig, ax = plt.subplots(1, 1)
@@ -417,7 +417,7 @@ class PaintingEnv(BaseEnv):
         return False
 
     def _get_tasks(self, num_tasks: int, num_objs_lst: List[int],
-                   rng: np.random.Generator) -> List[Task]:
+                   rng: np.random.Generator) -> List[EnvironmentTask]:
         tasks = []
         for i in range(num_tasks):
             num_objs = num_objs_lst[i % len(num_objs_lst)]
@@ -505,7 +505,7 @@ class PaintingEnv(BaseEnv):
                 if self._update_z_poses:
                     state.set(target_obj, "pose_z",
                               state.get(target_obj, "pose_z") + 1.0)
-            tasks.append(Task(state, goal))
+            tasks.append(EnvironmentTask(state, goal))
         return tasks
 
     def _sample_initial_object_pose(

--- a/predicators/envs/pddl_env.py
+++ b/predicators/envs/pddl_env.py
@@ -27,9 +27,9 @@ from predicators.envs.pddl_procedural_generation import \
     create_gripper_pddl_generator, create_miconic_pddl_generator, \
     create_spanner_pddl_generator
 from predicators.settings import CFG
-from predicators.structs import Action, GroundAtom, LiftedAtom, Object, \
-    PDDLProblemGenerator, Predicate, State, STRIPSOperator, EnvironmentTask, Type, \
-    Variable, Video, _GroundSTRIPSOperator
+from predicators.structs import Action, EnvironmentTask, GroundAtom, \
+    LiftedAtom, Object, PDDLProblemGenerator, Predicate, State, \
+    STRIPSOperator, Type, Variable, Video, _GroundSTRIPSOperator
 
 ###############################################################################
 #                                Base Classes                                 #
@@ -100,7 +100,10 @@ class _PDDLEnv(BaseEnv):
             self._test_rng)
         # Determine the goal predicates from the tasks.
         tasks = self._pregenerated_train_tasks + self._pregenerated_test_tasks
-        self._goal_predicates = {a.predicate for t in tasks for a in t.task.goal}
+        self._goal_predicates = {
+            a.predicate
+            for t in tasks for a in t.task.goal
+        }
 
     @classmethod
     @abc.abstractmethod

--- a/predicators/envs/pddl_env.py
+++ b/predicators/envs/pddl_env.py
@@ -28,7 +28,7 @@ from predicators.envs.pddl_procedural_generation import \
     create_spanner_pddl_generator
 from predicators.settings import CFG
 from predicators.structs import Action, GroundAtom, LiftedAtom, Object, \
-    PDDLProblemGenerator, Predicate, State, STRIPSOperator, Task, Type, \
+    PDDLProblemGenerator, Predicate, State, STRIPSOperator, EnvironmentTask, Type, \
     Variable, Video, _GroundSTRIPSOperator
 
 ###############################################################################
@@ -100,7 +100,7 @@ class _PDDLEnv(BaseEnv):
             self._test_rng)
         # Determine the goal predicates from the tasks.
         tasks = self._pregenerated_train_tasks + self._pregenerated_test_tasks
-        self._goal_predicates = {a.predicate for t in tasks for a in t.goal}
+        self._goal_predicates = {a.predicate for t in tasks for a in t.task.goal}
 
     @classmethod
     @abc.abstractmethod
@@ -148,15 +148,15 @@ class _PDDLEnv(BaseEnv):
                                                      ordered_objs)
         return next_state
 
-    def _generate_train_tasks(self) -> List[Task]:
+    def _generate_train_tasks(self) -> List[EnvironmentTask]:
         return self._pregenerated_train_tasks
 
-    def _generate_test_tasks(self) -> List[Task]:
+    def _generate_test_tasks(self) -> List[EnvironmentTask]:
         return self._pregenerated_test_tasks
 
     def _generate_tasks(self, num_tasks: int,
                         problem_gen: PDDLProblemGenerator,
-                        rng: np.random.Generator) -> List[Task]:
+                        rng: np.random.Generator) -> List[EnvironmentTask]:
         tasks = []
         domain_str = self.get_domain_str()
         for pddl_problem_str in problem_gen(num_tasks, rng):
@@ -190,14 +190,14 @@ class _PDDLEnv(BaseEnv):
     def render_state_plt(
             self,
             state: State,
-            task: Task,
+            task: EnvironmentTask,
             action: Optional[Action] = None,
             caption: Optional[str] = None) -> matplotlib.figure.Figure:
         raise NotImplementedError("This env does not use Matplotlib")
 
     def render_state(self,
                      state: State,
-                     task: Task,
+                     task: EnvironmentTask,
                      action: Optional[Action] = None,
                      caption: Optional[str] = None) -> Video:
         raise NotImplementedError("Render not implemented for PDDLEnv.")
@@ -741,7 +741,7 @@ def _parse_pddl_domain(
 
 def _pddl_problem_str_to_task(pddl_problem_str: str, pddl_domain_str: str,
                               types: Set[Type],
-                              predicates: Set[Predicate]) -> Task:
+                              predicates: Set[Predicate]) -> EnvironmentTask:
     # Let pyperplan do most of the heavy lifting.
     # Pyperplan needs the domain to parse the problem. Note that this is
     # cached by lru_cache.
@@ -774,7 +774,7 @@ def _pddl_problem_str_to_task(pddl_problem_str: str, pddl_domain_str: str,
         for a in pyperplan_problem.goal
     }
     # Finalize the task.
-    task = Task(init, goal)
+    task = EnvironmentTask(init, goal)
     return task
 
 

--- a/predicators/envs/playroom.py
+++ b/predicators/envs/playroom.py
@@ -12,7 +12,7 @@ from predicators import utils
 from predicators.envs.blocks import BlocksEnv, BlocksEnvClear
 from predicators.settings import CFG
 from predicators.structs import Action, Array, GroundAtom, Object, Predicate, \
-    State, Task, Type
+    State, EnvironmentTask, Type
 
 
 class PlayroomSimpleEnv(BlocksEnv):
@@ -161,7 +161,7 @@ class PlayroomSimpleEnv(BlocksEnv):
     def render_state_plt(
             self,
             state: State,
-            task: Task,
+            task: EnvironmentTask,
             action: Optional[Action] = None,
             caption: Optional[str] = None) -> matplotlib.figure.Figure:
         r = self._block_size * 0.5  # block radius
@@ -348,7 +348,7 @@ class PlayroomSimpleEnv(BlocksEnv):
         return fig
 
     def _get_tasks(self, num_tasks: int, possible_num_blocks: List[int],
-                   rng: np.random.Generator) -> List[Task]:
+                   rng: np.random.Generator) -> List[EnvironmentTask]:
         # Initial states vary by block placement, and light is randomly on/off.
         # Goals involve goal piles and light different from the initial state.
         tasks = []
@@ -361,7 +361,7 @@ class PlayroomSimpleEnv(BlocksEnv):
                 goal = self._sample_goal(num_blocks, piles, light_is_on, rng)
                 if not all(goal_atom.holds(init_state) for goal_atom in goal):
                     break
-            tasks.append(Task(init_state, goal))
+            tasks.append(EnvironmentTask(init_state, goal))
         return tasks
 
     def _sample_state_from_piles(self, piles: List[List[Object]],

--- a/predicators/envs/playroom.py
+++ b/predicators/envs/playroom.py
@@ -11,8 +11,8 @@ from matplotlib import patches
 from predicators import utils
 from predicators.envs.blocks import BlocksEnv, BlocksEnvClear
 from predicators.settings import CFG
-from predicators.structs import Action, Array, GroundAtom, Object, Predicate, \
-    State, EnvironmentTask, Type
+from predicators.structs import Action, Array, EnvironmentTask, GroundAtom, \
+    Object, Predicate, State, Type
 
 
 class PlayroomSimpleEnv(BlocksEnv):

--- a/predicators/envs/pybullet_blocks.py
+++ b/predicators/envs/pybullet_blocks.py
@@ -14,7 +14,7 @@ from predicators.pybullet_helpers.geometry import Pose, Pose3D, Quaternion
 from predicators.pybullet_helpers.robots import SingleArmPyBulletRobot, \
     create_single_arm_pybullet_robot
 from predicators.settings import CFG
-from predicators.structs import Array, Object, State, Task
+from predicators.structs import Array, Object, State, EnvironmentTask
 
 
 class PyBulletBlocksEnv(PyBulletEnv, BlocksEnv):
@@ -227,11 +227,11 @@ class PyBulletBlocksEnv(PyBulletEnv, BlocksEnv):
         return state
 
     def _get_tasks(self, num_tasks: int, possible_num_blocks: List[int],
-                   rng: np.random.Generator) -> List[Task]:
+                   rng: np.random.Generator) -> List[EnvironmentTask]:
         tasks = super()._get_tasks(num_tasks, possible_num_blocks, rng)
         return self._add_pybullet_state_to_tasks(tasks)
 
-    def _load_task_from_json(self, json_file: Path) -> Task:
+    def _load_task_from_json(self, json_file: Path) -> EnvironmentTask:
         task = super()._load_task_from_json(json_file)
         return self._add_pybullet_state_to_tasks([task])[0]
 

--- a/predicators/envs/pybullet_blocks.py
+++ b/predicators/envs/pybullet_blocks.py
@@ -14,7 +14,7 @@ from predicators.pybullet_helpers.geometry import Pose, Pose3D, Quaternion
 from predicators.pybullet_helpers.robots import SingleArmPyBulletRobot, \
     create_single_arm_pybullet_robot
 from predicators.settings import CFG
-from predicators.structs import Array, Object, State, EnvironmentTask
+from predicators.structs import Array, EnvironmentTask, Object, State
 
 
 class PyBulletBlocksEnv(PyBulletEnv, BlocksEnv):

--- a/predicators/envs/pybullet_cover.py
+++ b/predicators/envs/pybullet_cover.py
@@ -12,7 +12,7 @@ from predicators.pybullet_helpers.geometry import Pose, Pose3D, Quaternion
 from predicators.pybullet_helpers.robots import SingleArmPyBulletRobot, \
     create_single_arm_pybullet_robot
 from predicators.settings import CFG
-from predicators.structs import Action, Array, Object, State, Task
+from predicators.structs import Action, Array, Object, State, EnvironmentTask
 
 
 class PyBulletCoverEnv(PyBulletEnv, CoverEnv):
@@ -297,6 +297,6 @@ class PyBulletCoverEnv(PyBulletEnv, CoverEnv):
     def get_name(cls) -> str:
         return "pybullet_cover"
 
-    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[Task]:
+    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[EnvironmentTask]:
         tasks = super()._get_tasks(num, rng)
         return self._add_pybullet_state_to_tasks(tasks)

--- a/predicators/envs/pybullet_cover.py
+++ b/predicators/envs/pybullet_cover.py
@@ -12,7 +12,7 @@ from predicators.pybullet_helpers.geometry import Pose, Pose3D, Quaternion
 from predicators.pybullet_helpers.robots import SingleArmPyBulletRobot, \
     create_single_arm_pybullet_robot
 from predicators.settings import CFG
-from predicators.structs import Action, Array, Object, State, EnvironmentTask
+from predicators.structs import Action, Array, EnvironmentTask, Object, State
 
 
 class PyBulletCoverEnv(PyBulletEnv, CoverEnv):
@@ -297,6 +297,7 @@ class PyBulletCoverEnv(PyBulletEnv, CoverEnv):
     def get_name(cls) -> str:
         return "pybullet_cover"
 
-    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[EnvironmentTask]:
+    def _get_tasks(self, num: int,
+                   rng: np.random.Generator) -> List[EnvironmentTask]:
         tasks = super()._get_tasks(num, rng)
         return self._add_pybullet_state_to_tasks(tasks)

--- a/predicators/envs/pybullet_env.py
+++ b/predicators/envs/pybullet_env.py
@@ -391,13 +391,13 @@ class PyBulletEnv(BaseEnv):
         pybullet_tasks = []
         for task in tasks:
             # Reset the robot.
-            init = task.task.init
+            init = task.init
             self._pybullet_robot.reset_state(self._extract_robot_state(init))
             # Extract the joints.
             joint_positions = self._pybullet_robot.get_joints()
             pybullet_init = utils.PyBulletState(
                 init.data.copy(), simulator_state=joint_positions)
-            pybullet_task = EnvironmentTask(pybullet_init, task.task.goal)
+            pybullet_task = EnvironmentTask(pybullet_init, task.goal)
             pybullet_tasks.append(pybullet_task)
         return pybullet_tasks
 

--- a/predicators/envs/pybullet_env.py
+++ b/predicators/envs/pybullet_env.py
@@ -18,7 +18,7 @@ from predicators.pybullet_helpers.geometry import Pose3D, Quaternion
 from predicators.pybullet_helpers.link import get_link_state
 from predicators.pybullet_helpers.robots import SingleArmPyBulletRobot
 from predicators.settings import CFG
-from predicators.structs import Action, Array, State, EnvironmentTask, Video
+from predicators.structs import Action, Array, EnvironmentTask, State, Video
 
 
 class PyBulletEnv(BaseEnv):
@@ -386,7 +386,8 @@ class PyBulletEnv(BaseEnv):
         target = action.arr[-1]
         return target - finger_position
 
-    def _add_pybullet_state_to_tasks(self, tasks: List[EnvironmentTask]) -> List[EnvironmentTask]:
+    def _add_pybullet_state_to_tasks(
+            self, tasks: List[EnvironmentTask]) -> List[EnvironmentTask]:
         """Converts the task initial states into PyBulletStates."""
         pybullet_tasks = []
         for task in tasks:

--- a/predicators/envs/pybullet_env.py
+++ b/predicators/envs/pybullet_env.py
@@ -18,7 +18,7 @@ from predicators.pybullet_helpers.geometry import Pose3D, Quaternion
 from predicators.pybullet_helpers.link import get_link_state
 from predicators.pybullet_helpers.robots import SingleArmPyBulletRobot
 from predicators.settings import CFG
-from predicators.structs import Action, Array, State, Task, Video
+from predicators.structs import Action, Array, State, EnvironmentTask, Video
 
 
 class PyBulletEnv(BaseEnv):
@@ -168,14 +168,14 @@ class PyBulletEnv(BaseEnv):
     def render_state_plt(
             self,
             state: State,
-            task: Task,
+            task: EnvironmentTask,
             action: Optional[Action] = None,
             caption: Optional[str] = None) -> matplotlib.figure.Figure:
         raise NotImplementedError("This env does not use Matplotlib")
 
     def render_state(self,
                      state: State,
-                     task: Task,
+                     task: EnvironmentTask,
                      action: Optional[Action] = None,
                      caption: Optional[str] = None) -> Video:
         raise NotImplementedError("A PyBullet environment cannot render "
@@ -386,18 +386,18 @@ class PyBulletEnv(BaseEnv):
         target = action.arr[-1]
         return target - finger_position
 
-    def _add_pybullet_state_to_tasks(self, tasks: List[Task]) -> List[Task]:
+    def _add_pybullet_state_to_tasks(self, tasks: List[EnvironmentTask]) -> List[EnvironmentTask]:
         """Converts the task initial states into PyBulletStates."""
         pybullet_tasks = []
         for task in tasks:
             # Reset the robot.
-            init = task.init
+            init = task.task.init
             self._pybullet_robot.reset_state(self._extract_robot_state(init))
             # Extract the joints.
             joint_positions = self._pybullet_robot.get_joints()
             pybullet_init = utils.PyBulletState(
                 init.data.copy(), simulator_state=joint_positions)
-            pybullet_task = Task(pybullet_init, task.goal)
+            pybullet_task = EnvironmentTask(pybullet_init, task.task.goal)
             pybullet_tasks.append(pybullet_task)
         return pybullet_tasks
 

--- a/predicators/envs/repeated_nextto.py
+++ b/predicators/envs/repeated_nextto.py
@@ -13,8 +13,8 @@ from gym.spaces import Box
 
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
-from predicators.structs import Action, Array, GroundAtom, Object, Predicate, \
-    State, EnvironmentTask, Type
+from predicators.structs import Action, Array, EnvironmentTask, GroundAtom, \
+    Object, Predicate, State, Type
 
 
 class RepeatedNextToEnv(BaseEnv):
@@ -127,7 +127,8 @@ class RepeatedNextToEnv(BaseEnv):
         plt.tight_layout()
         return fig
 
-    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[EnvironmentTask]:
+    def _get_tasks(self, num: int,
+                   rng: np.random.Generator) -> List[EnvironmentTask]:
         tasks = []
         dots = []
         for i in range(CFG.repeated_nextto_num_dots):

--- a/predicators/envs/repeated_nextto.py
+++ b/predicators/envs/repeated_nextto.py
@@ -14,7 +14,7 @@ from gym.spaces import Box
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
 from predicators.structs import Action, Array, GroundAtom, Object, Predicate, \
-    State, Task, Type
+    State, EnvironmentTask, Type
 
 
 class RepeatedNextToEnv(BaseEnv):
@@ -73,10 +73,10 @@ class RepeatedNextToEnv(BaseEnv):
             next_state.set(dot_to_grasp, "grasped", 1.0)
         return next_state
 
-    def _generate_train_tasks(self) -> List[Task]:
+    def _generate_train_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num=CFG.num_train_tasks, rng=self._train_rng)
 
-    def _generate_test_tasks(self) -> List[Task]:
+    def _generate_test_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num=CFG.num_test_tasks, rng=self._test_rng)
 
     @property
@@ -102,7 +102,7 @@ class RepeatedNextToEnv(BaseEnv):
     def render_state_plt(
             self,
             state: State,
-            task: Task,
+            task: EnvironmentTask,
             action: Optional[Action] = None,
             caption: Optional[str] = None) -> matplotlib.figure.Figure:
         fig, ax = plt.subplots(1, 1)
@@ -127,7 +127,7 @@ class RepeatedNextToEnv(BaseEnv):
         plt.tight_layout()
         return fig
 
-    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[Task]:
+    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[EnvironmentTask]:
         tasks = []
         dots = []
         for i in range(CFG.repeated_nextto_num_dots):
@@ -150,7 +150,7 @@ class RepeatedNextToEnv(BaseEnv):
                 data[dot] = np.array([dot_x, 0.0])
             robot_x = rng.uniform(self.env_lb, self.env_ub)
             data[self._robot] = np.array([robot_x])
-            tasks.append(Task(State(data), goals[i % len(goals)]))
+            tasks.append(EnvironmentTask(State(data), goals[i % len(goals)]))
         return tasks
 
     def _NextTo_holds(self, state: State, objects: Sequence[Object]) -> bool:
@@ -192,18 +192,18 @@ class RepeatedNextToAmbiguousEnv(RepeatedNextToEnv):
     def get_name(cls) -> str:
         return "repeated_nextto_ambiguous"
 
-    def _generate_train_tasks(self) -> List[Task]:
+    def _generate_train_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks_ambiguous(num=CFG.num_train_tasks,
                                          rng=self._train_rng,
                                          are_train_tasks=True)
 
-    def _generate_test_tasks(self) -> List[Task]:
+    def _generate_test_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks_ambiguous(num=CFG.num_train_tasks,
                                          rng=self._train_rng,
                                          are_train_tasks=False)
 
     def _get_tasks_ambiguous(self, num: int, rng: np.random.Generator,
-                             are_train_tasks: bool) -> List[Task]:
+                             are_train_tasks: bool) -> List[EnvironmentTask]:
         assert self.env_ub - self.env_lb > self._nextto_thresh
         tasks = []
         dots = []
@@ -233,5 +233,5 @@ class RepeatedNextToAmbiguousEnv(RepeatedNextToEnv):
                 data[dot] = np.array([dot_x, 0.0])
             robot_x = self.env_lb
             data[self._robot] = np.array([robot_x])
-            tasks.append(Task(State(data), goals[i % len(goals)]))
+            tasks.append(EnvironmentTask(State(data), goals[i % len(goals)]))
         return tasks

--- a/predicators/envs/repeated_nextto_painting.py
+++ b/predicators/envs/repeated_nextto_painting.py
@@ -12,7 +12,8 @@ import matplotlib
 
 from predicators.envs.painting import PaintingEnv
 from predicators.settings import CFG
-from predicators.structs import Action, Object, Predicate, State, EnvironmentTask
+from predicators.structs import Action, EnvironmentTask, Object, Predicate, \
+    State
 
 
 class RepeatedNextToPaintingEnv(PaintingEnv):

--- a/predicators/envs/repeated_nextto_painting.py
+++ b/predicators/envs/repeated_nextto_painting.py
@@ -12,7 +12,7 @@ import matplotlib
 
 from predicators.envs.painting import PaintingEnv
 from predicators.settings import CFG
-from predicators.structs import Action, Object, Predicate, State, Task
+from predicators.structs import Action, Object, Predicate, State, EnvironmentTask
 
 
 class RepeatedNextToPaintingEnv(PaintingEnv):
@@ -111,7 +111,7 @@ class RepeatedNextToPaintingEnv(PaintingEnv):
     def render_state_plt(
             self,
             state: State,
-            task: Task,
+            task: EnvironmentTask,
             action: Optional[Action] = None,
             caption: Optional[str] = None) -> matplotlib.figure.Figure:
         # List of NextTo objects to render

--- a/predicators/envs/sandwich.py
+++ b/predicators/envs/sandwich.py
@@ -11,8 +11,8 @@ from gym.spaces import Box
 from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
-from predicators.structs import RGBA, Action, GroundAtom, Object, Predicate, \
-    State, EnvironmentTask, Type
+from predicators.structs import RGBA, Action, EnvironmentTask, GroundAtom, \
+    Object, Predicate, State, Type
 from predicators.utils import _Geom2D
 
 

--- a/predicators/envs/sandwich.py
+++ b/predicators/envs/sandwich.py
@@ -12,7 +12,7 @@ from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
 from predicators.structs import RGBA, Action, GroundAtom, Object, Predicate, \
-    State, Task, Type
+    State, EnvironmentTask, Type
 from predicators.utils import _Geom2D
 
 
@@ -241,12 +241,12 @@ class SandwichEnv(BaseEnv):
             next_state.set(ing, "clear", 1.0)
         return next_state
 
-    def _generate_train_tasks(self) -> List[Task]:
+    def _generate_train_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num_tasks=CFG.num_train_tasks,
                                num_ingredients=self._num_ingredients_train,
                                rng=self._train_rng)
 
-    def _generate_test_tasks(self) -> List[Task]:
+    def _generate_test_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num_tasks=CFG.num_test_tasks,
                                num_ingredients=self._num_ingredients_test,
                                rng=self._test_rng)
@@ -285,7 +285,7 @@ class SandwichEnv(BaseEnv):
     def render_state_plt(
             self,
             state: State,
-            task: Task,
+            task: EnvironmentTask,
             action: Optional[Action] = None,
             caption: Optional[str] = None) -> matplotlib.figure.Figure:
 
@@ -398,7 +398,7 @@ class SandwichEnv(BaseEnv):
         return fig
 
     def _get_tasks(self, num_tasks: int, num_ingredients: Dict[str, List[int]],
-                   rng: np.random.Generator) -> List[Task]:
+                   rng: np.random.Generator) -> List[EnvironmentTask]:
         tasks = []
         for _ in range(num_tasks):
             ing_to_num: Dict[str, int] = {}
@@ -409,7 +409,7 @@ class SandwichEnv(BaseEnv):
             goal = self._sample_goal(init_state, rng)
             goal_holds = all(goal_atom.holds(init_state) for goal_atom in goal)
             assert not goal_holds
-            tasks.append(Task(init_state, goal))
+            tasks.append(EnvironmentTask(init_state, goal))
         return tasks
 
     def _sample_initial_state(self, ingredient_to_num: Dict[str, int],

--- a/predicators/envs/satellites.py
+++ b/predicators/envs/satellites.py
@@ -29,8 +29,8 @@ from gym.spaces import Box
 from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
-from predicators.structs import Action, GroundAtom, Object, Predicate, State, \
-    EnvironmentTask, Type
+from predicators.structs import Action, EnvironmentTask, GroundAtom, Object, \
+    Predicate, State, Type
 
 
 class SatellitesEnv(BaseEnv):

--- a/predicators/envs/satellites.py
+++ b/predicators/envs/satellites.py
@@ -30,7 +30,7 @@ from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
 from predicators.structs import Action, GroundAtom, Object, Predicate, State, \
-    Task, Type
+    EnvironmentTask, Type
 
 
 class SatellitesEnv(BaseEnv):
@@ -167,13 +167,13 @@ class SatellitesEnv(BaseEnv):
             next_state.set(sat, "theta", theta)
         return next_state
 
-    def _generate_train_tasks(self) -> List[Task]:
+    def _generate_train_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num=CFG.num_train_tasks,
                                num_sat_lst=CFG.satellites_num_sat_train,
                                num_obj_lst=CFG.satellites_num_obj_train,
                                rng=self._train_rng)
 
-    def _generate_test_tasks(self) -> List[Task]:
+    def _generate_test_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num=CFG.num_test_tasks,
                                num_sat_lst=CFG.satellites_num_sat_test,
                                num_obj_lst=CFG.satellites_num_obj_test,
@@ -209,7 +209,7 @@ class SatellitesEnv(BaseEnv):
     def render_state_plt(
             self,
             state: State,
-            task: Task,
+            task: EnvironmentTask,
             action: Optional[Action] = None,
             caption: Optional[str] = None) -> matplotlib.figure.Figure:
         figsize = (1, 1)
@@ -257,7 +257,7 @@ class SatellitesEnv(BaseEnv):
 
     def _get_tasks(self, num: int, num_sat_lst: List[int],
                    num_obj_lst: List[int],
-                   rng: np.random.Generator) -> List[Task]:
+                   rng: np.random.Generator) -> List[EnvironmentTask]:
         tasks = []
         radius = self.radius + self.init_padding
         for _ in range(num):
@@ -343,7 +343,7 @@ class SatellitesEnv(BaseEnv):
                 elif self._HasGeiger_holds(init_state, [sat]):
                     goal_pred = self._GeigerReadingTaken
                 goal.add(GroundAtom(goal_pred, [sat, goal_obj_for_sat]))
-            task = Task(init_state, goal)
+            task = EnvironmentTask(init_state, goal)
             tasks.append(task)
         return tasks
 
@@ -481,13 +481,13 @@ class SatellitesSimpleEnv(SatellitesEnv):
     def get_name(cls) -> str:
         return "satellites_simple"
 
-    def _generate_train_tasks(self) -> List[Task]:
+    def _generate_train_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num=CFG.num_train_tasks,
                                num_sat_lst=CFG.satellites_num_sat_train,
                                num_obj_lst=[1],
                                rng=self._train_rng)
 
-    def _generate_test_tasks(self) -> List[Task]:
+    def _generate_test_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num=CFG.num_test_tasks,
                                num_sat_lst=CFG.satellites_num_sat_test,
                                num_obj_lst=[1],

--- a/predicators/envs/screws.py
+++ b/predicators/envs/screws.py
@@ -11,7 +11,7 @@ from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
 from predicators.structs import Action, GroundAtom, Object, Predicate, State, \
-    Task, Type
+    EnvironmentTask, Type
 
 
 class ScrewsEnv(BaseEnv):
@@ -67,12 +67,12 @@ class ScrewsEnv(BaseEnv):
         self._robot = Object("robby", self._gripper_type)
         self._receptacle = Object("receptacle", self._receptacle_type)
 
-    def _generate_train_tasks(self) -> List[Task]:
+    def _generate_train_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num_tasks=CFG.num_train_tasks,
                                possible_num_screws=self.num_screws_train,
                                rng=self._train_rng)
 
-    def _generate_test_tasks(self) -> List[Task]:
+    def _generate_test_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num_tasks=CFG.num_test_tasks,
                                possible_num_screws=self.num_screws_test,
                                rng=self._test_rng)
@@ -84,7 +84,7 @@ class ScrewsEnv(BaseEnv):
     def render_state_plt(
             self,
             state: State,
-            task: Task,
+            task: EnvironmentTask,
             action: Optional[Action] = None,
             caption: Optional[str] = None) -> matplotlib.figure.Figure:
         fig, ax = plt.subplots(1, 1)
@@ -120,8 +120,8 @@ class ScrewsEnv(BaseEnv):
                  color="black")
 
         # Find which object is the goal screw.
-        assert len(task.goal) == 1
-        goal_pred = list(task.goal)[0]
+        assert len(task.task.goal) == 1
+        goal_pred = list(task.task.goal)[0]
         goal_screw = goal_pred.objects[0]
 
         # Draw screws.
@@ -175,7 +175,7 @@ class ScrewsEnv(BaseEnv):
         return self._transition_demagnetize(state_after_move)
 
     def _get_tasks(self, num_tasks: int, possible_num_screws: List[int],
-                   rng: np.random.Generator) -> List[Task]:
+                   rng: np.random.Generator) -> List[EnvironmentTask]:
         tasks = []
 
         for _ in range(num_tasks):
@@ -206,7 +206,7 @@ class ScrewsEnv(BaseEnv):
 
     def _get_single_task(self, screw_name_to_pos: Dict[str, Tuple[float,
                                                                   float]],
-                         rng: np.random.Generator) -> Task:
+                         rng: np.random.Generator) -> EnvironmentTask:
         state_dict = {}
         goal_atoms: Set[GroundAtom] = set()
         # Select a random screw that needs to be in the receptacle as the goal
@@ -245,7 +245,7 @@ class ScrewsEnv(BaseEnv):
 
         init_state = utils.create_state_from_dict(state_dict)
         assert len(goal_atoms) == 1
-        task = Task(init_state, goal_atoms)
+        task = EnvironmentTask(init_state, goal_atoms)
         return task
 
     def _surface_xy_is_valid(self, x: float, y: float,

--- a/predicators/envs/screws.py
+++ b/predicators/envs/screws.py
@@ -120,8 +120,8 @@ class ScrewsEnv(BaseEnv):
                  color="black")
 
         # Find which object is the goal screw.
-        assert len(task.task.goal) == 1
-        goal_pred = list(task.task.goal)[0]
+        assert len(task.goal) == 1
+        goal_pred = list(task.goal)[0]
         goal_screw = goal_pred.objects[0]
 
         # Draw screws.

--- a/predicators/envs/screws.py
+++ b/predicators/envs/screws.py
@@ -10,8 +10,8 @@ from gym.spaces import Box
 from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
-from predicators.structs import Action, GroundAtom, Object, Predicate, State, \
-    EnvironmentTask, Type
+from predicators.structs import Action, EnvironmentTask, GroundAtom, Object, \
+    Predicate, State, Type
 
 
 class ScrewsEnv(BaseEnv):

--- a/predicators/envs/sokoban.py
+++ b/predicators/envs/sokoban.py
@@ -11,8 +11,8 @@ from numpy.typing import NDArray
 from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
-from predicators.structs import Action, GroundAtom, Object, Predicate, State, \
-    EnvironmentTask, Type, Video
+from predicators.structs import Action, EnvironmentTask, GroundAtom, Object, \
+    Predicate, State, Type, Video
 
 # Free, goals, boxes, player masks.
 _Observation = Tuple[NDArray[np.uint8], NDArray[np.uint8], NDArray[np.uint8],

--- a/predicators/envs/sokoban.py
+++ b/predicators/envs/sokoban.py
@@ -139,7 +139,7 @@ class SokobanEnv(BaseEnv):
         """Resets the current state to the train or test task initial state."""
         self._current_task = self.get_task(train_or_test, task_idx)
         # NOTE: current_state will be deprecated soon in favor of current_obs.
-        self._current_state = self._current_task.task.init
+        self._current_state = self._current_task.init
         # We now need to reset the underlying gym environment to the correct
         # state.
         seed_offset = CFG.seed

--- a/predicators/envs/stick_button.py
+++ b/predicators/envs/stick_button.py
@@ -12,7 +12,7 @@ from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
 from predicators.structs import Action, GroundAtom, Object, Predicate, State, \
-    Task, Type
+    EnvironmentTask, Type
 from predicators.utils import _Geom2D
 
 
@@ -161,13 +161,13 @@ class StickButtonEnv(BaseEnv):
 
         return next_state
 
-    def _generate_train_tasks(self) -> List[Task]:
+    def _generate_train_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(
             num=CFG.num_train_tasks,
             num_button_lst=CFG.stick_button_num_buttons_train,
             rng=self._train_rng)
 
-    def _generate_test_tasks(self) -> List[Task]:
+    def _generate_test_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(
             num=CFG.num_test_tasks,
             num_button_lst=CFG.stick_button_num_buttons_test,
@@ -199,7 +199,7 @@ class StickButtonEnv(BaseEnv):
     def render_state_plt(
             self,
             state: State,
-            task: Task,
+            task: EnvironmentTask,
             action: Optional[Action] = None,
             caption: Optional[str] = None) -> matplotlib.figure.Figure:
         figsize = (self.x_ub - self.x_lb, self.y_ub - self.y_lb)
@@ -252,7 +252,7 @@ class StickButtonEnv(BaseEnv):
         return fig
 
     def _get_tasks(self, num: int, num_button_lst: List[int],
-                   rng: np.random.Generator) -> List[Task]:
+                   rng: np.random.Generator) -> List[EnvironmentTask]:
         tasks = []
         for _ in range(num):
             state_dict = {}
@@ -362,7 +362,7 @@ class StickButtonEnv(BaseEnv):
                 "theta": holder_rect.theta,
             }
             init_state = utils.create_state_from_dict(state_dict)
-            task = Task(init_state, goal)
+            task = EnvironmentTask(init_state, goal)
             tasks.append(task)
         return tasks
 

--- a/predicators/envs/stick_button.py
+++ b/predicators/envs/stick_button.py
@@ -11,8 +11,8 @@ from gym.spaces import Box
 from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
-from predicators.structs import Action, GroundAtom, Object, Predicate, State, \
-    EnvironmentTask, Type
+from predicators.structs import Action, EnvironmentTask, GroundAtom, Object, \
+    Predicate, State, Type
 from predicators.utils import _Geom2D
 
 

--- a/predicators/envs/tools.py
+++ b/predicators/envs/tools.py
@@ -20,7 +20,7 @@ from gym.spaces import Box
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
 from predicators.structs import Action, GroundAtom, Object, Predicate, State, \
-    Task, Type
+    EnvironmentTask, Type
 
 
 class ToolsEnv(BaseEnv):
@@ -171,14 +171,14 @@ class ToolsEnv(BaseEnv):
         next_state.set(self._robot, "fingers", 0.0)
         return next_state
 
-    def _generate_train_tasks(self) -> List[Task]:
+    def _generate_train_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(
             num_tasks=CFG.num_train_tasks,
             num_items_lst=CFG.tools_num_items_train,
             num_contraptions_lst=CFG.tools_num_contraptions_train,
             rng=self._train_rng)
 
-    def _generate_test_tasks(self) -> List[Task]:
+    def _generate_test_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(
             num_tasks=CFG.num_test_tasks,
             num_items_lst=CFG.tools_num_items_test,
@@ -221,14 +221,14 @@ class ToolsEnv(BaseEnv):
     def render_state_plt(
             self,
             state: State,
-            task: Task,
+            task: EnvironmentTask,
             action: Optional[Action] = None,
             caption: Optional[str] = None) -> matplotlib.figure.Figure:
         raise NotImplementedError
 
     def _get_tasks(self, num_tasks: int, num_items_lst: List[int],
                    num_contraptions_lst: List[int],
-                   rng: np.random.Generator) -> List[Task]:
+                   rng: np.random.Generator) -> List[EnvironmentTask]:
         tasks = []
         for i in range(num_tasks):
             num_items = num_items_lst[i % len(num_items_lst)]
@@ -366,7 +366,7 @@ class ToolsEnv(BaseEnv):
                 tools.append(tool)
                 data[tool] = np.array(feats, dtype=np.float32)
             state = State(data)
-            tasks.append(Task(state, goal))
+            tasks.append(EnvironmentTask(state, goal))
         return tasks
 
     @staticmethod

--- a/predicators/envs/tools.py
+++ b/predicators/envs/tools.py
@@ -19,8 +19,8 @@ from gym.spaces import Box
 
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
-from predicators.structs import Action, GroundAtom, Object, Predicate, State, \
-    EnvironmentTask, Type
+from predicators.structs import Action, EnvironmentTask, GroundAtom, Object, \
+    Predicate, State, Type
 
 
 class ToolsEnv(BaseEnv):

--- a/predicators/envs/touch_point.py
+++ b/predicators/envs/touch_point.py
@@ -12,7 +12,7 @@ from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
 from predicators.structs import Action, GroundAtom, Object, Predicate, State, \
-    Task, Type
+    EnvironmentTask, Type
 
 
 class TouchPointEnv(BaseEnv):
@@ -65,10 +65,10 @@ class TouchPointEnv(BaseEnv):
         next_state.set(self._robot, "y", new_y)
         return next_state
 
-    def _generate_train_tasks(self) -> List[Task]:
+    def _generate_train_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num=CFG.num_train_tasks, rng=self._train_rng)
 
-    def _generate_test_tasks(self) -> List[Task]:
+    def _generate_test_tasks(self) -> List[EnvironmentTask]:
         return self._get_tasks(num=CFG.num_test_tasks, rng=self._test_rng)
 
     @property
@@ -91,7 +91,7 @@ class TouchPointEnv(BaseEnv):
     def render_state_plt(
             self,
             state: State,
-            task: Task,
+            task: EnvironmentTask,
             action: Optional[Action] = None,
             caption: Optional[str] = None) -> matplotlib.figure.Figure:
         fig, ax = plt.subplots(1, 1, figsize=(5, 5))
@@ -115,14 +115,14 @@ class TouchPointEnv(BaseEnv):
         plt.tight_layout()
         return fig
 
-    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[Task]:
+    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[EnvironmentTask]:
         # There is only one goal in this environment.
         goal_atom = GroundAtom(self._Touched, [self._robot, self._target])
         goal = {goal_atom}
         # The initial positions of the robot and dot vary. The only constraint
         # is that the initial positions should be far enough away that the goal
         # is not initially satisfied.
-        tasks: List[Task] = []
+        tasks: List[EnvironmentTask] = []
         while len(tasks) < num:
             state = utils.create_state_from_dict({
                 self._robot: {
@@ -136,7 +136,7 @@ class TouchPointEnv(BaseEnv):
             })
             # Make sure goal is not satisfied.
             if not goal_atom.holds(state):
-                tasks.append(Task(state, goal))
+                tasks.append(EnvironmentTask(state, goal))
         return tasks
 
     def _Touched_holds(self, state: State, objects: Sequence[Object]) -> bool:
@@ -281,7 +281,7 @@ class TouchOpenEnv(TouchPointEnvParam):
     def render_state_plt(
             self,
             state: State,
-            task: Task,
+            task: EnvironmentTask,
             action: Optional[Action] = None,
             caption: Optional[str] = None) -> matplotlib.figure.Figure:
         fig, ax = plt.subplots(1, 1, figsize=(5, 5))
@@ -312,14 +312,14 @@ class TouchOpenEnv(TouchPointEnvParam):
         plt.tight_layout()
         return fig
 
-    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[Task]:
+    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[EnvironmentTask]:
         goal_atom1 = GroundAtom(self._TouchingDoor, [self._robot, self._door])
         goal_atom2 = GroundAtom(self._DoorIsOpen, [self._door])
         goal1 = {goal_atom1, goal_atom2}
         # The initial positions of the robot and door vary. The only constraint
         # is that the initial positions should be far enough away that the goal
         # is not initially satisfied.
-        tasks: List[Task] = []
+        tasks: List[EnvironmentTask] = []
         while len(tasks) < num:
             flex = rng.uniform(0.0, 1.0)
             rot = rng.uniform(0.0, 1.0)
@@ -340,7 +340,7 @@ class TouchOpenEnv(TouchPointEnvParam):
             })
             # Make sure the goal is not satisfied.
             if not goal_atom1.holds(state) and not goal_atom2.holds(state):
-                tasks.append(Task(state, goal1))
+                tasks.append(EnvironmentTask(state, goal1))
         return tasks
 
     def _TouchingDoor_holds(self, state: State,

--- a/predicators/envs/touch_point.py
+++ b/predicators/envs/touch_point.py
@@ -11,8 +11,8 @@ from gym.spaces import Box
 from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
-from predicators.structs import Action, GroundAtom, Object, Predicate, State, \
-    EnvironmentTask, Type
+from predicators.structs import Action, EnvironmentTask, GroundAtom, Object, \
+    Predicate, State, Type
 
 
 class TouchPointEnv(BaseEnv):
@@ -115,7 +115,8 @@ class TouchPointEnv(BaseEnv):
         plt.tight_layout()
         return fig
 
-    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[EnvironmentTask]:
+    def _get_tasks(self, num: int,
+                   rng: np.random.Generator) -> List[EnvironmentTask]:
         # There is only one goal in this environment.
         goal_atom = GroundAtom(self._Touched, [self._robot, self._target])
         goal = {goal_atom}
@@ -312,7 +313,8 @@ class TouchOpenEnv(TouchPointEnvParam):
         plt.tight_layout()
         return fig
 
-    def _get_tasks(self, num: int, rng: np.random.Generator) -> List[EnvironmentTask]:
+    def _get_tasks(self, num: int,
+                   rng: np.random.Generator) -> List[EnvironmentTask]:
         goal_atom1 = GroundAtom(self._TouchingDoor, [self._robot, self._door])
         goal_atom2 = GroundAtom(self._DoorIsOpen, [self._door])
         goal1 = {goal_atom1, goal_atom2}

--- a/predicators/main.py
+++ b/predicators/main.py
@@ -92,7 +92,14 @@ def main() -> None:
     assert env.goal_predicates.issubset(env.predicates)
     preds, _ = utils.parse_config_excluded_predicates(env)
     # Create the train tasks.
-    train_tasks = env.get_train_tasks()
+    env_train_tasks = env.get_train_tasks()
+    # This is a placeholder for a forthcoming perception API. However, we will
+    # make the assumption for the foreseeable future that a train Task can be
+    # constructed from a train EnvironmentTask. In other words, the initial obs
+    # is assumed to contain enough information to determine all of the objects
+    # and their initial states. We only make this assumption for the training
+    # tasks, we don't need to make it for the test tasks.
+    train_tasks = [t.task for t in env_train_tasks]
     # If train tasks have goals that involve excluded predicates, strip those
     # predicate classifiers to prevent leaking information to the approaches.
     stripped_train_tasks = [
@@ -263,10 +270,13 @@ def _run_testing(env: BaseEnv, approach: BaseApproach) -> Metrics:
     metrics: Metrics = defaultdict(float)
     curr_num_nodes_created = 0.0
     curr_num_nodes_expanded = 0.0
-    for test_task_idx, task in enumerate(test_tasks):
+    for test_task_idx, env_task in enumerate(test_tasks):
         # Run the approach's solve() method to get a policy for this task.
         solve_start = time.perf_counter()
         try:
+            # This conversion from EnvironmentTask to Task will be replaced
+            # by a more general perception API shortly.
+            task = env_task.task
             policy = approach.solve(task, timeout=CFG.timeout)
         except (ApproachTimeout, ApproachFailure) as e:
             logging.info(f"Task {test_task_idx+1} / {len(test_tasks)}: "

--- a/predicators/main.py
+++ b/predicators/main.py
@@ -98,7 +98,9 @@ def main() -> None:
     # constructed from a train EnvironmentTask. In other words, the initial obs
     # is assumed to contain enough information to determine all of the objects
     # and their initial states. We only make this assumption for the training
-    # tasks, we don't need to make it for the test tasks.
+    # tasks, we don't need to make it for the test tasks. We need to make it
+    # for training tasks because all of the data collection here is offline,
+    # so there would be no way for agent to gather information in training.
     train_tasks = [t.task for t in env_train_tasks]
     # If train tasks have goals that involve excluded predicates, strip those
     # predicate classifiers to prevent leaking information to the approaches.

--- a/predicators/refinement_estimators/cnn_refinement_estimator.py
+++ b/predicators/refinement_estimators/cnn_refinement_estimator.py
@@ -12,7 +12,8 @@ from predicators.ml_models import CNNRegressor
 from predicators.refinement_estimators.per_skeleton_estimator import \
     PerSkeletonRefinementEstimator
 from predicators.settings import CFG
-from predicators.structs import ImageInput, RefinementDatapoint, Task, EnvironmentTask
+from predicators.structs import EnvironmentTask, ImageInput, \
+    RefinementDatapoint, Task
 
 
 class CNNRefinementEstimator(PerSkeletonRefinementEstimator[CNNRegressor]):

--- a/predicators/refinement_estimators/cnn_refinement_estimator.py
+++ b/predicators/refinement_estimators/cnn_refinement_estimator.py
@@ -12,7 +12,7 @@ from predicators.ml_models import CNNRegressor
 from predicators.refinement_estimators.per_skeleton_estimator import \
     PerSkeletonRefinementEstimator
 from predicators.settings import CFG
-from predicators.structs import ImageInput, RefinementDatapoint, Task
+from predicators.structs import ImageInput, RefinementDatapoint, Task, EnvironmentTask
 
 
 class CNNRefinementEstimator(PerSkeletonRefinementEstimator[CNNRegressor]):
@@ -82,7 +82,11 @@ class CNNRefinementEstimator(PerSkeletonRefinementEstimator[CNNRegressor]):
         """Render the initial state of the task using the given environment's
         method, and pre-process image as necessary."""
         # Render initial state
-        img = self._env.render_state(task.init, task)[0]
+        # Wrapping the task in an environment task to hack around the fact that
+        # render_state() expects an EnvironmentTask. Assuming that for the envs
+        # that we're using, the EnvironmentTasks will effectively be Tasks.
+        env_task = EnvironmentTask(task.init, task.goal)
+        img = self._env.render_state(task.init, env_task)[0]
 
         # Crop and downsample the image if needed
         if CFG.cnn_refinement_estimator_crop:

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -416,6 +416,31 @@ DefaultTask = Task(DefaultState, set())
 
 
 @dataclass(frozen=True, eq=False)
+class EnvironmentTask:
+    """An initial observation and goal description.
+    
+    Environments produce environment tasks and agents produce and solve tasks.
+    
+    In fully observed settings, the init_obs will be a State and the
+    goal_description will be a Set[GroundAtom]. For convenience, we can convert
+    an EnvironmentTask into a Task in those cases.
+    """
+    init_obs: Observation
+    goal_description: GoalDescription
+
+    @cached_property
+    def task(self) -> Task:
+        assert isinstance(self.init_obs, State)
+        assert isinstance(self.goal_description, set)
+        assert not self.goal_description or isinstance(
+            next(iter(self.goal_description)), GroundAtom)
+        return Task(self.init_obs, self.goal_description)
+
+
+DefaultEnvironmentTask = EnvironmentTask(DefaultState, set())
+
+
+@dataclass(frozen=True, eq=False)
 class ParameterizedOption:
     """Struct defining a parameterized option, which has a parameter space and
     can be ground into an Option, given parameter values.
@@ -1548,6 +1573,8 @@ class LiftedDecisionList:
 
 
 # Convenience higher-order types useful throughout the code
+Observation = Any
+GoalDescription = Any
 OptionSpec = Tuple[ParameterizedOption, List[Variable]]
 GroundAtomTrajectory = Tuple[LowLevelTrajectory, List[Set[GroundAtom]]]
 Image = NDArray[np.uint8]

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -430,11 +430,22 @@ class EnvironmentTask:
 
     @cached_property
     def task(self) -> Task:
+        """Convenience method for environment tasks that are fully observed."""
+        return Task(self.init, self.goal)
+
+    @cached_property
+    def init(self) -> State:
+        """Convenience method for environment tasks that are fully observed."""
         assert isinstance(self.init_obs, State)
+        return self.init_obs
+
+    @cached_property
+    def goal(self) -> Set[GroundAtom]:
+        """Convenience method for environment tasks that are fully observed."""
         assert isinstance(self.goal_description, set)
         assert not self.goal_description or isinstance(
             next(iter(self.goal_description)), GroundAtom)
-        return Task(self.init_obs, self.goal_description)
+        return set(self.goal_description)
 
 
 DefaultEnvironmentTask = EnvironmentTask(DefaultState, set())

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -418,9 +418,9 @@ DefaultTask = Task(DefaultState, set())
 @dataclass(frozen=True, eq=False)
 class EnvironmentTask:
     """An initial observation and goal description.
-    
+
     Environments produce environment tasks and agents produce and solve tasks.
-    
+
     In fully observed settings, the init_obs will be a State and the
     goal_description will be a Set[GroundAtom]. For convenience, we can convert
     an EnvironmentTask into a Task in those cases.

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -445,7 +445,7 @@ class EnvironmentTask:
         assert isinstance(self.goal_description, set)
         assert not self.goal_description or isinstance(
             next(iter(self.goal_description)), GroundAtom)
-        return set(self.goal_description)
+        return self.goal_description
 
 
 DefaultEnvironmentTask = EnvironmentTask(DefaultState, set())

--- a/predicators/train_refinement_estimator.py
+++ b/predicators/train_refinement_estimator.py
@@ -84,7 +84,8 @@ def _train_refinement_estimation_approach() -> None:
     preds, _ = utils.parse_config_excluded_predicates(env)
 
     # Create the train tasks.
-    train_tasks = env.get_train_tasks()
+    env_train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env_train_tasks]
     # Assume we're not doing option learning, pass in all the environment's
     # oracle options.
     assert CFG.option_learner == "no_learning"

--- a/scripts/evaluate_interactive_approach_classifiers.py
+++ b/scripts/evaluate_interactive_approach_classifiers.py
@@ -95,7 +95,7 @@ def create_states_cover(
     target_poses = [0.375, 0.815]
     # State 0: no blocks overlap any targets
     env_task = env.get_test_tasks()[0]
-    state = env_task.task.init
+    state = env_task.init
     block0 = [b for b in state if b.name == "block0"][0]
     block1 = [b for b in state if b.name == "block1"][0]
     target0 = [b for b in state if b.name == "target0"][0]

--- a/scripts/evaluate_interactive_approach_classifiers.py
+++ b/scripts/evaluate_interactive_approach_classifiers.py
@@ -94,8 +94,8 @@ def create_states_cover(
     block_poses = [0.15, 0.605]
     target_poses = [0.375, 0.815]
     # State 0: no blocks overlap any targets
-    task = env.get_test_tasks()[0]
-    state = task.init
+    env_task = env.get_test_tasks()[0]
+    state = env_task.task.init
     block0 = [b for b in state if b.name == "block0"][0]
     block1 = [b for b in state if b.name == "block1"][0]
     target0 = [b for b in state if b.name == "target0"][0]

--- a/scripts/grammar_search_analysis.py
+++ b/scripts/grammar_search_analysis.py
@@ -177,8 +177,9 @@ def _run_proxy_analysis_for_env(args: Dict[str, Any], env_name: str,
     })
     env = create_new_env(env_name)
     options = get_gt_options(env.get_name())
-    train_tasks = env.get_train_tasks()
-    dataset = create_dataset(env, train_tasks, options)
+    env_train_tasks = env.get_train_tasks()
+    dataset = create_dataset(env, env_train_tasks, options)
+    train_tasks = [t.task for t in env_train_tasks]
     start_time = time.perf_counter()
 
     for non_goal_predicates in non_goal_predicate_sets:

--- a/scripts/grammar_search_analysis.py
+++ b/scripts/grammar_search_analysis.py
@@ -178,8 +178,8 @@ def _run_proxy_analysis_for_env(args: Dict[str, Any], env_name: str,
     env = create_new_env(env_name)
     options = get_gt_options(env.get_name())
     env_train_tasks = env.get_train_tasks()
-    dataset = create_dataset(env, env_train_tasks, options)
     train_tasks = [t.task for t in env_train_tasks]
+    dataset = create_dataset(env, train_tasks, options)
     start_time = time.perf_counter()
 
     for non_goal_predicates in non_goal_predicate_sets:

--- a/scripts/skeleton_score_analysis.py
+++ b/scripts/skeleton_score_analysis.py
@@ -56,8 +56,9 @@ def _setup_data_for_env(env_name: str,
     })
     env = create_new_env(env_name)
     options = get_gt_options(env.get_name())
-    train_tasks = env.get_train_tasks()
-    dataset = create_dataset(env, train_tasks, options)
+    env_train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env_train_tasks]
+    dataset = create_dataset(env, env_train_tasks, options)
     assert all(traj.is_demo for traj in dataset.trajectories)
     demo_skeleton_lengths = [
         utils.num_options_in_action_sequence(t.actions)

--- a/scripts/skeleton_score_analysis.py
+++ b/scripts/skeleton_score_analysis.py
@@ -58,7 +58,7 @@ def _setup_data_for_env(env_name: str,
     options = get_gt_options(env.get_name())
     env_train_tasks = env.get_train_tasks()
     train_tasks = [t.task for t in env_train_tasks]
-    dataset = create_dataset(env, env_train_tasks, options)
+    dataset = create_dataset(env, train_tasks, options)
     assert all(traj.is_demo for traj in dataset.trajectories)
     demo_skeleton_lengths = [
         utils.num_options_in_action_sequence(t.actions)

--- a/tests/approaches/test_base_approach.py
+++ b/tests/approaches/test_base_approach.py
@@ -84,7 +84,7 @@ def test_base_approach():
 def test_create_approach():
     """Tests for create_approach."""
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     for name in [
             "random_actions",
             "random_options",

--- a/tests/approaches/test_gnn_action_policy_approach.py
+++ b/tests/approaches/test_gnn_action_policy_approach.py
@@ -22,13 +22,13 @@ def test_gnn_action_policy_approach():
         "horizon": 10
     })
     env = create_new_env("cover")
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     approach = create_approach("gnn_action_policy", env.predicates,
                                get_gt_options(env.get_name()), env.types,
                                env.action_space, train_tasks)
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))
     assert approach.is_learning_based
-    task = env.get_test_tasks()[0]
+    task = env.get_test_tasks()[0].task
     with pytest.raises(AssertionError):  # haven't learned yet!
         approach.solve(task, timeout=CFG.timeout)
     approach.learn_from_offline_dataset(dataset)

--- a/tests/approaches/test_gnn_metacontroller_approach.py
+++ b/tests/approaches/test_gnn_metacontroller_approach.py
@@ -58,7 +58,7 @@ def test_gnn_metacontroller_approach_with_envs(env_name, num_epochs):
         "horizon": 10
     })
     env = create_new_env(env_name)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     approach = create_approach("gnn_metacontroller", env.predicates,
                                get_gt_options(env.get_name()), env.types,
                                env.action_space, train_tasks)

--- a/tests/approaches/test_gnn_option_policy_approach.py
+++ b/tests/approaches/test_gnn_option_policy_approach.py
@@ -56,13 +56,13 @@ def test_gnn_option_policy_approach_with_envs(env_name):
         "horizon": 10
     })
     env = create_new_env(env_name)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     approach = create_approach("gnn_option_policy", env.predicates,
                                get_gt_options(env.get_name()), env.types,
                                env.action_space, train_tasks)
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))
     assert approach.is_learning_based
-    task = env.get_test_tasks()[0]
+    task = env.get_test_tasks()[0].task
     with pytest.raises(AssertionError):  # haven't learned yet!
         approach.solve(task, timeout=CFG.timeout)
     approach.learn_from_offline_dataset(dataset)

--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -23,7 +23,7 @@ def test_predicate_grammar(segmenter):
     """Tests for _PredicateGrammar class."""
     utils.reset_config({"env": "cover", "segmenter": segmenter})
     env = CoverEnv()
-    train_task = env.get_train_tasks()[0]
+    train_task = env.get_train_tasks()[0].task
     state = train_task.init
     other_state = state.copy()
     robby = [o for o in state if o.type.name == "robot"][0]

--- a/tests/approaches/test_interactive_approach.py
+++ b/tests/approaches/test_interactive_approach.py
@@ -46,7 +46,7 @@ def test_interactive_learning_approach(predicate_classifier_model,
         "interactive_score_function": "frequency",
     })
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     initial_predicates = {
         p
         for p in env.predicates if p.name not in ["Covers", "Holding"]

--- a/tests/approaches/test_llm_base_renaming_approach.py
+++ b/tests/approaches/test_llm_base_renaming_approach.py
@@ -48,7 +48,7 @@ def test_llm_syntax_renaming_approach():
         "strips_learner": "oracle",
     })
     env = create_new_env(env_name)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     approach = _MockLLMBaseRenamingApproach(env.predicates,
                                             get_gt_options(env.get_name()),
                                             env.types, env.action_space,

--- a/tests/approaches/test_llm_bilevel_planning_approach.py
+++ b/tests/approaches/test_llm_bilevel_planning_approach.py
@@ -24,7 +24,7 @@ def test_llm_bilevel_planning_approach():
         "strips_learner": "oracle",
     })
     env = create_new_env(env_name)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     approach = LLMBilevelPlanningApproach(env.predicates,
                                           get_gt_options(env.get_name()),
                                           env.types, env.action_space,

--- a/tests/approaches/test_llm_open_loop_approach.py
+++ b/tests/approaches/test_llm_open_loop_approach.py
@@ -28,7 +28,7 @@ def test_llm_open_loop_approach():
         "offline_data_num_replays": 3,
     })
     env = create_new_env(env_name)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     approach = LLMOpenLoopApproach(env.predicates,
                                    get_gt_options(env.get_name()), env.types,
                                    env.action_space, train_tasks)

--- a/tests/approaches/test_llm_option_renaming_approach.py
+++ b/tests/approaches/test_llm_option_renaming_approach.py
@@ -17,7 +17,7 @@ def test_llm_option_renaming_approach():
         "strips_learner": "oracle",
     })
     env = create_new_env(env_name)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     approach = LLMOptionRenamingApproach(env.predicates,
                                          get_gt_options(env.get_name()),
                                          env.types, env.action_space,

--- a/tests/approaches/test_llm_predicate_renaming_approach.py
+++ b/tests/approaches/test_llm_predicate_renaming_approach.py
@@ -17,7 +17,7 @@ def test_llm_predicate_renaming_approach():
         "strips_learner": "oracle",
     })
     env = create_new_env(env_name)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     approach = LLMPredicateRenamingApproach(env.predicates,
                                             get_gt_options(env.get_name()),
                                             env.types, env.action_space,

--- a/tests/approaches/test_llm_syntax_renaming_approach.py
+++ b/tests/approaches/test_llm_syntax_renaming_approach.py
@@ -17,7 +17,7 @@ def test_llm_syntax_renaming_approach():
         "strips_learner": "oracle",
     })
     env = create_new_env(env_name)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     approach = LLMSyntaxRenamingApproach(env.predicates,
                                          get_gt_options(env.get_name()),
                                          env.types, env.action_space,

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -65,7 +65,7 @@ def _test_approach(env_name,
             "Can't exclude a goal predicate!"
     else:
         preds = env.predicates
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     if option_learner == "no_learning":
         options = get_gt_options(env.get_name())
     else:
@@ -75,7 +75,7 @@ def _test_approach(env_name,
     dataset = create_dataset(env, train_tasks, options)
     assert approach.is_learning_based
     approach.learn_from_offline_dataset(dataset)
-    task = env.get_test_tasks()[0]
+    task = env.get_test_tasks()[0].task
     if try_solving:
         if solve_exceptions is not None:
             assert not check_solution

--- a/tests/approaches/test_nsrt_rl_approach.py
+++ b/tests/approaches/test_nsrt_rl_approach.py
@@ -48,7 +48,7 @@ def test_nsrt_reinforcement_learning_approach(nsrt_rl_reward_epsilon):
         "nsrt_rl_reward_epsilon": nsrt_rl_reward_epsilon,
     })
     env = CoverMultistepOptions()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     # Make the last train task have a trivial goal so that it can be solved by
     # get_interaction_requests() even though we're not learning good models.
     train_tasks[-1] = Task(train_tasks[-1].init, set())

--- a/tests/approaches/test_online_nsrt_learning_approach.py
+++ b/tests/approaches/test_online_nsrt_learning_approach.py
@@ -32,7 +32,7 @@ def test_online_nsrt_learning_approach():
         "online_learning_lifelong": True
     })
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     approach = OnlineNSRTLearningApproach(env.predicates,
                                           get_gt_options(env.get_name()),
                                           env.types, env.action_space,

--- a/tests/approaches/test_online_pg3_approach.py
+++ b/tests/approaches/test_online_pg3_approach.py
@@ -31,7 +31,7 @@ def test_online_pg3_approach():
         "pg3_gbfs_max_expansions": 1
     })
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     approach = OnlinePG3Approach(env.predicates,
                                  get_gt_options(env.get_name()), env.types,
                                  env.action_space, train_tasks)

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -253,7 +253,8 @@ def test_oracle_approach(env_name, env_cls):
             args["num_test_tasks"] = 2
         utils.reset_config(args)
         env = env_cls(use_gui=False)
-        train_tasks = env.get_train_tasks()
+        train_tasks = [t.task for t in env.get_train_tasks()]
+        test_tasks = [t.task for t in env.get_test_tasks()]
         approach = OracleApproach(env.predicates,
                                   get_gt_options(env.get_name()), env.types,
                                   env.action_space, train_tasks)
@@ -261,7 +262,7 @@ def test_oracle_approach(env_name, env_cls):
         for task in train_tasks:
             policy = approach.solve(task, timeout=500)
             assert _policy_solves_task(policy, task, env.simulate)
-        for task in env.get_test_tasks():
+        for task in test_tasks:
             policy = approach.solve(task, timeout=500)
             assert _policy_solves_task(policy, task, env.simulate)
     # Tests if OracleApproach can load _OracleOptionModel
@@ -284,13 +285,13 @@ def test_planning_without_sim():
         # Raise an error (and fail the test) if simulate is called.
         mock_simulate.side_effect = AssertionError("Simulate called.")
         env = ProceduralTasksBlocksPDDLEnv(use_gui=False)
-        train_tasks = env.get_train_tasks()
+        train_tasks = [t.task for t in env.get_train_tasks()]
         approach = OracleApproach(env.predicates,
                                   get_gt_options(env.get_name()), env.types,
                                   env.action_space, train_tasks)
     # Test the policy outside of patch() because _policy_solves_task uses the
     # simulator.
-    task = env.get_test_tasks()[0]
+    task = env.get_test_tasks()[0].task
     policy = approach.solve(task, timeout=500)
     assert _policy_solves_task(policy, task, env.simulate)
     # Running the policy again should fail because the plan is empty.
@@ -338,7 +339,7 @@ def test_planning_without_sim():
         "bilevel_plan_without_sim": True,
     })
     env = CoverEnv(use_gui=False)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
 
     # Force options to be non-initiable.
     options = get_gt_options(env.get_name())
@@ -490,7 +491,7 @@ def test_cluttered_table_get_gt_nsrts(place_version):
         grasp_nsrt, place_nsrt = sorted(nsrts, key=lambda o: o.name)
         assert grasp_nsrt.name == "Grasp"
         assert place_nsrt.name == "Place"
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     for (i, task) in enumerate(train_tasks):
         if i < len(train_tasks) / 2:
             utils.reset_config(
@@ -597,7 +598,7 @@ def test_playroom_simple_get_gt_nsrts():
                          get_gt_options(env.get_name()))
     movetabletodial = [nsrt for nsrt in nsrts \
                        if nsrt.name == "MoveTableToDial"][0]
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     train_task = train_tasks[0]
     state = train_task.init
     objs = list(state)
@@ -627,7 +628,7 @@ def test_playroom_get_gt_nsrts():
                          get_gt_options(env.get_name()))
     movedialtodoor = [nsrt for nsrt in nsrts \
                       if nsrt.name == "MoveDialToDoor"][0]
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     train_task = train_tasks[0]
     state = train_task.init
     objs = list(state)

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -428,7 +428,7 @@ def test_cover_get_gt_nsrts():
     pick_nsrt, place_nsrt = sorted(nsrts, key=lambda o: o.name)
     assert pick_nsrt.name == "Pick"
     assert place_nsrt.name == "Place"
-    train_task = env.get_train_tasks()[0]
+    train_task = env.get_train_tasks()[0].task
     state = train_task.init
     block0, _, _, target0, _ = list(state)
     assert block0.name == "block0"

--- a/tests/approaches/test_pg3_analogy_approach.py
+++ b/tests/approaches/test_pg3_analogy_approach.py
@@ -30,7 +30,7 @@ def test_pg3_analogy_approach():
     env = create_new_env(env_name)
     nsrts = get_gt_nsrts(env.get_name(), env.predicates,
                          get_gt_options(env.get_name()))
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
 
     name_to_nsrt = {nsrt.name: nsrt for nsrt in nsrts}
 

--- a/tests/approaches/test_pg3_approach.py
+++ b/tests/approaches/test_pg3_approach.py
@@ -40,7 +40,7 @@ def test_pg3_approach(approach_name, approach_cls):
         "pg3_hc_enforced_depth": 0,
     })
     env = create_new_env(env_name)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     approach = approach_cls(env.predicates, get_gt_options(env.get_name()),
                             env.types, env.action_space, train_tasks)
     assert approach.get_name() == approach_name
@@ -187,7 +187,7 @@ def test_cluttered_table_pg3_approach():
         "sampler_learner": "oracle",
     })
     env = create_new_env(env_name)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     approach = PG3Approach(env.predicates, get_gt_options(env.get_name()),
                            env.types, env.action_space, train_tasks)
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))

--- a/tests/approaches/test_pg4_approach.py
+++ b/tests/approaches/test_pg4_approach.py
@@ -24,7 +24,7 @@ def test_pg4_approach():
         "cover_initial_holding_prob": 1.0,
     })
     env = create_new_env(env_name)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     approach = PG4Approach(env.predicates, get_gt_options(env.get_name()),
                            env.types, env.action_space, train_tasks)
     nsrts = get_gt_nsrts(env.get_name(), env.predicates,

--- a/tests/approaches/test_random_actions_approach.py
+++ b/tests/approaches/test_random_actions_approach.py
@@ -13,7 +13,7 @@ def test_random_actions_approach():
         "approach": "random_actions",
     })
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     task = train_tasks[0]
     approach = RandomActionsApproach(env.predicates,
                                      get_gt_options(env.get_name()), env.types,

--- a/tests/approaches/test_refinement_estimation_approach.py
+++ b/tests/approaches/test_refinement_estimation_approach.py
@@ -36,8 +36,8 @@ def test_refinement_estimation_approach():
         args["num_test_tasks"] = 2
     utils.reset_config(args)
     env = NarrowPassageEnv(use_gui=False)
-    train_tasks = env.get_train_tasks()
-    test_tasks = env.get_test_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
+    test_tasks = [t.task for t in env.get_test_tasks()]
     approach = RefinementEstimationApproach(env.predicates,
                                             get_gt_options(env.get_name()),
                                             env.types, env.action_space,

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -29,7 +29,7 @@ def test_demo_dataset():
         "num_train_tasks": 7,
     })
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     options = parse_config_included_options(env)
     dataset = create_dataset(env, train_tasks, options)
     assert len(dataset.trajectories) == 7
@@ -49,7 +49,7 @@ def test_demo_dataset():
         "num_train_tasks": 7,
     })
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))
     assert len(dataset.trajectories) == 7
     assert len(dataset.trajectories[0].states) == 3
@@ -76,7 +76,7 @@ def test_demo_dataset():
     Pick, Place = sorted(get_gt_options(env.get_name()))
     assert Pick.name == "Pick"
     assert Place.name == "Place"
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     options = parse_config_included_options(env)
     assert options == {Pick}
     dataset = create_dataset(env, train_tasks, options)
@@ -103,7 +103,7 @@ def test_demo_dataset():
         "num_train_tasks": 7,
     })
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     init = train_tasks[0].init
     HandEmpty = [pred for pred in env.predicates
                  if pred.name == "HandEmpty"][0]
@@ -120,7 +120,7 @@ def test_demo_dataset():
         "max_initial_demos": 3,
     })
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     assert len(train_tasks) == 7
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))
     assert len(dataset.trajectories) == 3
@@ -153,7 +153,7 @@ def test_demo_dataset():
     })
     video_file = os.path.join(video_dir, "cover__123__demo__task0.mp4")
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     assert len(train_tasks) == 1
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))
     assert len(dataset.trajectories) == 1
@@ -170,7 +170,7 @@ def test_demo_dataset():
         "bilevel_plan_without_sim": True,
     })
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     options = parse_config_included_options(env)
     dataset = create_dataset(env, train_tasks, options)
     assert len(dataset.trajectories) > 0
@@ -200,7 +200,7 @@ def test_demo_dataset_loading(num_train_tasks, load_data, demonstrator,
     if do_wipe_data_dir:
         shutil.rmtree(CFG.data_dir)
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     with expectation as e:
         dataset = create_dataset(env, train_tasks,
                                  get_gt_options(env.get_name()))
@@ -233,7 +233,7 @@ def test_demo_dataset_loading_tricky_case(num_train_tasks, load_data,
     if do_wipe_data_dir:
         shutil.rmtree(CFG.data_dir)
     env = BlocksEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))
     # Note the use of <= here rather than ==.
     assert len(dataset.trajectories) <= num_train_tasks
@@ -255,7 +255,7 @@ def test_demo_replay_dataset():
         "num_train_tasks": 5,
     })
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))
     assert len(dataset.trajectories) == 5 + 3
     assert len(dataset.trajectories[-1].states) == 2
@@ -278,7 +278,7 @@ def test_demo_replay_dataset():
         "num_train_tasks": 5,
     })
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     options = parse_config_included_options(env)
     dataset = create_dataset(env, train_tasks, options)
     assert len(dataset.trajectories) == 5 + 3
@@ -307,7 +307,7 @@ def test_demo_replay_dataset():
     Pick, Place = sorted(get_gt_options(env.get_name()))
     assert Pick.name == "Pick"
     assert Place.name == "Place"
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     options = parse_config_included_options(env)
     assert options == {Pick}
     dataset = create_dataset(env, train_tasks, options)
@@ -333,7 +333,7 @@ def test_demo_replay_dataset():
         "num_train_tasks": 5,
     })
     env = ClutteredTableEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))
     assert len(dataset.trajectories[-1].states) == 2
     assert len(dataset.trajectories[-1].actions) == 1
@@ -351,7 +351,7 @@ def test_dataset_with_annotations():
         "num_train_tasks": 5,
     })
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     trajectories = create_dataset(env, train_tasks,
                                   get_gt_options(env.get_name())).trajectories
     # The annotations and trajectories need to be the same length.
@@ -381,7 +381,7 @@ def test_ground_atom_dataset():
         "excluded_predicates": "Holding,Covers",
     })
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))
     assert len(dataset.trajectories) == 15
     assert len(dataset.annotations) == 15
@@ -432,7 +432,7 @@ def test_ground_atom_dataset():
         "excluded_predicates": "Holding,Covers",
     })
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     with pytest.raises(ValueError):
         create_dataset(env, train_tasks, get_gt_options(env.get_name()))
 
@@ -444,7 +444,7 @@ def test_empty_dataset():
         "offline_data_method": "empty",
     })
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))
     assert len(dataset.trajectories) == 0
     with pytest.raises(AssertionError):

--- a/tests/envs/test_base_env.py
+++ b/tests/envs/test_base_env.py
@@ -22,12 +22,12 @@ def test_env_creation():
         assert isinstance(env, BaseEnv)
         other_env = get_or_create_env(name)
         assert env is other_env
-        train_tasks = env.get_train_tasks()
+        train_tasks = [t.task for t in env.get_train_tasks()]
         for idx, train_task in enumerate(train_tasks):
             task = env.get_task("train", idx)
             assert train_task.init.allclose(task.init)
             assert train_task.goal == task.goal
-        test_tasks = env.get_test_tasks()
+        test_tasks = [t.task for t in env.get_test_tasks()]
         for idx, test_task in enumerate(test_tasks):
             task = env.get_task("test", idx)
             assert test_task.init.allclose(task.init)

--- a/tests/envs/test_blocks.py
+++ b/tests/envs/test_blocks.py
@@ -191,7 +191,7 @@ def test_blocks_load_task_from_json():
         })
 
         env = BlocksEnv()
-        test_tasks = env.get_test_tasks()
+        test_tasks = [t.task for t in env.get_test_tasks()]
 
     assert len(test_tasks) == 1
     task = test_tasks[0]
@@ -335,7 +335,7 @@ robby              1.35      0.75       0.7          1
 {"On": [["red_block", "green_block"], ["green_block", "blue_block"]],
  "OnTable": [["blue_block"]]}"""
             ]
-            test_tasks = env.get_test_tasks()
+            test_tasks = [t.task for t in env.get_test_tasks()]
 
     assert len(test_tasks) == 1
     task = test_tasks[0]

--- a/tests/envs/test_cover.py
+++ b/tests/envs/test_cover.py
@@ -9,7 +9,7 @@ from predicators.envs import create_new_env
 from predicators.envs.cover import CoverEnvRegrasp, CoverEnvTypedOptions, \
     CoverMultistepOptions
 from predicators.ground_truth_models import get_gt_options
-from predicators.structs import Action, Task
+from predicators.structs import Action, EnvironmentTask
 
 
 @pytest.mark.parametrize("env_name", ["cover", "cover_handempty"])
@@ -278,7 +278,7 @@ def test_cover_multistep_options():
         [0.17778981 - 0.05 / 2, 0.17778981 + 0.05 / 2])
     state.data[target1_hr] = np.array(
         [0.63629464 - 0.03 / 2, 0.63629464 + 0.03 / 2])
-    task = Task(state, task.goal)
+    task = EnvironmentTask(state, task.goal)
     action_arrs = [
         # Move to above block0
         np.array([0.05, 0., 0.], dtype=np.float32),

--- a/tests/envs/test_doors_env.py
+++ b/tests/envs/test_doors_env.py
@@ -4,7 +4,7 @@ import numpy as np
 from predicators import utils
 from predicators.envs.doors import DoorsEnv
 from predicators.ground_truth_models import get_gt_options
-from predicators.structs import Action, GroundAtom, Object, State, Task
+from predicators.structs import Action, GroundAtom, Object, State, EnvironmentTask
 
 
 def test_doors():
@@ -98,7 +98,7 @@ def test_doors():
     # Create a task with a goal to move to the bottom right room.
     goal_atom = GroundAtom(InRoom, [robot, bottom_right_room])
     goal = {goal_atom}
-    task = Task(state, goal)
+    task = EnvironmentTask(state, goal)
     env.render_state(state, task)
 
     ## Test simulate ##

--- a/tests/envs/test_doors_env.py
+++ b/tests/envs/test_doors_env.py
@@ -4,7 +4,8 @@ import numpy as np
 from predicators import utils
 from predicators.envs.doors import DoorsEnv
 from predicators.ground_truth_models import get_gt_options
-from predicators.structs import Action, GroundAtom, Object, State, EnvironmentTask
+from predicators.structs import Action, EnvironmentTask, GroundAtom, Object, \
+    State
 
 
 def test_doors():

--- a/tests/envs/test_narrow_passage.py
+++ b/tests/envs/test_narrow_passage.py
@@ -99,14 +99,14 @@ def test_narrow_passage_actions():
         s = env.simulate(s, Action(action))
     assert GroundAtom(TouchedGoal,
                       [robot, target]).holds(s)  # check touching goal
-    assert task.goal_holds(s)  # check task goal reached
+    assert task.task.goal_holds(s)  # check task goal reached
 
     # Test rendering entire plan
     policy = utils.action_arrs_to_policy(all_action_arrs)
     traj = utils.run_policy_with_simulator(policy,
                                            env.simulate,
                                            task.init,
-                                           task.goal_holds,
+                                           task.task.goal_holds,
                                            max_num_steps=len(all_action_arrs))
 
     # Render a state before door opens

--- a/tests/envs/test_narrow_passage.py
+++ b/tests/envs/test_narrow_passage.py
@@ -4,7 +4,7 @@ import numpy as np
 from predicators import utils
 from predicators.envs.narrow_passage import NarrowPassageEnv
 from predicators.ground_truth_models import get_gt_options
-from predicators.structs import Action, GroundAtom, Task
+from predicators.structs import Action, GroundAtom, EnvironmentTask
 
 
 def test_narrow_passage_properties():
@@ -61,7 +61,7 @@ def test_narrow_passage_actions():
     target, = state.get_objects(target_type)
     state.set(target, "x", 0.5)
     state.set(target, "y", 0.2)
-    task = Task(state, goal)
+    task = EnvironmentTask(state, goal)
 
     # Fixed action sequences to test (each is a list of action arrays)
     # Move to within range of door and open it
@@ -249,7 +249,7 @@ def test_narrow_passage_options():
     robot, = state.get_objects(robot_type)
     state.set(robot, "x", 0.25)
     state.set(robot, "y", 0.7)
-    fixed_task = Task(state, goal)
+    fixed_task = EnvironmentTask(state, goal)
     option_plan = [
         MoveAndOpenDoor.ground([robot, door], [0.1]),
     ]

--- a/tests/envs/test_narrow_passage.py
+++ b/tests/envs/test_narrow_passage.py
@@ -129,7 +129,7 @@ def test_narrow_passage_collisions():
     door_type, _, robot_type, _, _ = sorted(env.types)
 
     # Test robot should not be able to walk through each wall nor the door
-    sample_task = env.get_train_tasks()[0]
+    sample_task = env.get_train_tasks()[0].task
     test_robot_xs = [0.1, 0.35, 0.7, 0.9]
     y_midpoint = env.y_lb + (env.y_ub - env.y_lb) / 2
     down_action = Action(np.array([0, -0.08, 0]).astype(np.float32))
@@ -176,7 +176,7 @@ def test_narrow_passage_options():
     MoveAndOpenDoor, MoveToTarget = sorted(get_gt_options(env.get_name()))
     door_type, _, robot_type, target_type, _ = sorted(env.types)
 
-    task = env.get_train_tasks()[0]
+    task = env.get_train_tasks()[0].task
     state = task.init
     door, = state.get_objects(door_type)
     robot, = state.get_objects(robot_type)

--- a/tests/envs/test_narrow_passage.py
+++ b/tests/envs/test_narrow_passage.py
@@ -4,7 +4,7 @@ import numpy as np
 from predicators import utils
 from predicators.envs.narrow_passage import NarrowPassageEnv
 from predicators.ground_truth_models import get_gt_options
-from predicators.structs import Action, GroundAtom, EnvironmentTask
+from predicators.structs import Action, EnvironmentTask, GroundAtom
 
 
 def test_narrow_passage_properties():

--- a/tests/envs/test_pddl_env.py
+++ b/tests/envs/test_pddl_env.py
@@ -156,7 +156,7 @@ def test_pddlenv(domain_str, problem_strs):
     assert eat_fish_operator.delete_effects == set()
 
     # Problem creation checks.
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     assert len(train_tasks) == 1
     train_task = train_tasks[0]
     init = train_task.init
@@ -178,7 +178,7 @@ def test_pddlenv(domain_str, problem_strs):
         isRipe([ban1]), IsPink([salmon1])
     }
     assert train_task.goal == {ate([fish1]), ate([ban1]), ate([salmon1])}
-    test_tasks = env.get_test_tasks()
+    test_tasks = [t.task for t in env.get_test_tasks()]
     assert len(test_tasks) == 1
     test_task = test_tasks[0]
     init = test_task.init
@@ -278,11 +278,11 @@ def test_fixed_tasks_pddlenv(domain_str, problem_strs):
 
     # Just check that the correspondence is correct. Detailed testing is
     # covered by test_pddlenv.
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     assert len(train_tasks) == 1
     train_task = train_tasks[0]
     assert len(set(train_task.init)) == 3
-    test_tasks = env.get_test_tasks()
+    test_tasks = [t.task for t in env.get_test_tasks()]
     assert len(test_tasks) == 1
     test_task = test_tasks[0]
     assert len(set(test_task.init)) == 4
@@ -310,9 +310,9 @@ def test_fixed_tasks_blocks_pddl_env():
     assert {o.name
             for o in env.strips_operators
             } == {"pick-up", "put-down", "stack", "unstack"}
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     assert len(train_tasks) == 2
-    test_tasks = env.get_test_tasks()
+    test_tasks = [t.task for t in env.get_test_tasks()]
     assert len(test_tasks) == 2
     task = train_tasks[0]
     assert {a.predicate.name for a in task.goal} == {"on"}
@@ -339,9 +339,9 @@ def test_procedural_tasks_blocks_pddl_env():
     assert {o.name
             for o in env.strips_operators
             } == {"pick-up", "put-down", "stack", "unstack"}
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     assert len(train_tasks) == 2
-    test_tasks = env.get_test_tasks()
+    test_tasks = [t.task for t in env.get_test_tasks()]
     assert len(test_tasks) == 2
     task = train_tasks[0]
     assert {a.predicate.name for a in task.goal}.issubset({"on", "ontable"})
@@ -369,9 +369,9 @@ def test_procedural_tasks_delivery_pddl_env():
             } == {"pick-up", "move", "deliver"}
     assert {o.name
             for o in env.strips_operators} == {"pick-up", "move", "deliver"}
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     assert len(train_tasks) == 2
-    test_tasks = env.get_test_tasks()
+    test_tasks = [t.task for t in env.get_test_tasks()]
     assert len(test_tasks) == 2
     task = train_tasks[0]
     assert {a.predicate.name for a in task.goal}.issubset({"satisfied"})
@@ -400,9 +400,9 @@ def test_procedural_tasks_spanner_pddl_env():
     assert {o.name
             for o in env.strips_operators
             } == {"walk", "pickup_spanner", "tighten_nut"}
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     assert len(train_tasks) == 2
-    test_tasks = env.get_test_tasks()
+    test_tasks = [t.task for t in env.get_test_tasks()]
     assert len(test_tasks) == 2
     task = train_tasks[0]
     assert {a.predicate.name for a in task.goal}.issubset({"tightened"})
@@ -428,9 +428,9 @@ def test_procedural_tasks_forest_pddl_env():
     assert {o.name
             for o in get_gt_options(env.get_name())} == {"walk", "climb"}
     assert {o.name for o in env.strips_operators} == {"walk", "climb"}
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     assert len(train_tasks) == 2
-    test_tasks = env.get_test_tasks()
+    test_tasks = [t.task for t in env.get_test_tasks()]
     assert len(test_tasks) == 2
     task = train_tasks[0]
     assert {a.predicate.name for a in task.goal}.issubset({"at"})
@@ -457,9 +457,9 @@ def test_procedural_tasks_gripper_pddl_env():
             for o in get_gt_options(env.get_name())
             } == {"move", "pick", "drop"}
     assert {o.name for o in env.strips_operators} == {"move", "pick", "drop"}
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     assert len(train_tasks) == 2
-    test_tasks = env.get_test_tasks()
+    test_tasks = [t.task for t in env.get_test_tasks()]
     assert len(test_tasks) == 2
     task = train_tasks[0]
     assert {a.predicate.name for a in task.goal}.issubset({"at"})
@@ -487,9 +487,9 @@ def test_procedural_tasks_prefixed_gripper_pddl_env():
             for o in get_gt_options(env.get_name())
             } == {"move", "pick", "drop"}
     assert {o.name for o in env.strips_operators} == {"move", "pick", "drop"}
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     assert len(train_tasks) == 2
-    test_tasks = env.get_test_tasks()
+    test_tasks = [t.task for t in env.get_test_tasks()]
     assert len(test_tasks) == 2
     task = train_tasks[0]
     assert {a.predicate.name for a in task.goal}.issubset({"preat"})
@@ -517,9 +517,9 @@ def test_procedural_tasks_ferry_pddl_env():
             } == {"board", "sail", "debark"}
     assert {o.name
             for o in env.strips_operators} == {"board", "sail", "debark"}
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     assert len(train_tasks) == 2
-    test_tasks = env.get_test_tasks()
+    test_tasks = [t.task for t in env.get_test_tasks()]
     assert len(test_tasks) == 2
     task = train_tasks[0]
     assert {a.predicate.name for a in task.goal}.issubset({"at"})
@@ -546,9 +546,9 @@ def test_procedural_tasks_miconic_pddl_env():
     assert {o.name
             for o in env.strips_operators
             } == {"board", "depart", "up", "down"}
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     assert len(train_tasks) == 2
-    test_tasks = env.get_test_tasks()
+    test_tasks = [t.task for t in env.get_test_tasks()]
     assert len(test_tasks) == 2
     task = train_tasks[0]
     assert {a.predicate.name for a in task.goal}.issubset({"served"})

--- a/tests/envs/test_playroom.py
+++ b/tests/envs/test_playroom.py
@@ -57,7 +57,7 @@ def test_playroom_failure_cases(env_name):
     block0 = block_type("block0")
     block1 = block_type("block1")
     block2 = block_type("block2")
-    task = env.get_train_tasks()[0]
+    task = env.get_train_tasks()[0].task
     state = task.init
     atoms = utils.abstract(state, env.predicates)
     robot = None
@@ -155,7 +155,7 @@ def test_playroom_simulate_blocks(env_name):
     robot_type = [t for t in env.types if t.name == "robot"][0]
     block1 = block_type("block1")
     block2 = block_type("block2")
-    task = env.get_train_tasks()[0]
+    task = env.get_train_tasks()[0].task
     state = task.init
     robot = None
     for item in state:
@@ -209,7 +209,7 @@ def test_playroom_simulate_doors_and_dial():
     dial_type = [t for t in env.types if t.name == "dial"][0]
     door1 = door_type("door1")
     door6 = door_type("door6")
-    task = env.get_train_tasks()[0]
+    task = env.get_train_tasks()[0].task
     state = task.init
     robot = None
     dial = None
@@ -322,7 +322,7 @@ def test_playroom_simple_options():
     LightOn = [p for p in env.predicates if p.name == "LightOn"][0]
     robot = robot_type("robby")
     dial = dial_type("dial")
-    task = env.get_train_tasks()[0]
+    task = env.get_train_tasks()[0].task
     state = task.init
     # Run through a specific plan of options.
     MoveTableToDial = [
@@ -385,7 +385,7 @@ def test_playroom_options():
     region5 = region_type("region5")
     region6 = region_type("region6")
     region7 = region_type("region7")
-    task = env.get_train_tasks()[0]
+    task = env.get_train_tasks()[0].task
     state = task.init
     # Run through a specific plan of options.
     Pick = [o for o in get_gt_options(env.get_name()) if o.name == "Pick"][0]
@@ -474,7 +474,7 @@ def test_playroom_action_sequence_video():
     utils.reset_config({"env": "playroom"})
     env = PlayroomEnv()
     # Run through a specific plan of low-level actions.
-    task = env.get_train_tasks()[0]
+    task = env.get_train_tasks()[0].task
     action_arrs = [
         # Pick up a block
         np.array([11.8, 18, 0.45, -0.15, 0]).astype(np.float32),
@@ -522,7 +522,7 @@ def test_playroom_hard():
     utils.reset_config({"env": "playroom_hard"})
     env = PlayroomHardEnv()
     dial_type = [t for t in env.types if t.name == "dial"][0]
-    task = env.get_train_tasks()[0]
+    task = env.get_train_tasks()[0].task
     state = task.init
     dial = None
     for item in state:

--- a/tests/envs/test_pybullet_blocks.py
+++ b/tests/envs/test_pybullet_blocks.py
@@ -564,7 +564,7 @@ def test_pybullet_blocks_load_task_from_json():
         })
 
         env = PyBulletBlocksEnv(use_gui=False)
-        test_tasks = env.get_test_tasks()
+        test_tasks = [t.task for t in env.get_test_tasks()]
 
     assert len(test_tasks) == 1
     task = test_tasks[0]

--- a/tests/envs/test_sandwich.py
+++ b/tests/envs/test_sandwich.py
@@ -380,7 +380,7 @@ def test_sandwich_load_task_from_json():
         })
 
         env = SandwichEnv()
-        test_tasks = env.get_test_tasks()
+        test_tasks = [t.task for t in env.get_test_tasks()]
 
     assert len(test_tasks) == 1
     task = test_tasks[0]
@@ -414,7 +414,7 @@ def test_sandwich_load_task_from_json():
 {"On": [["bread1", "cheese0"], ["cheese0", "bread0"]],
  "OnBoard": [["bread0", "board"]]}"""
             ]
-            test_tasks = env.get_test_tasks()
+            test_tasks = [t.task for t in env.get_test_tasks()]
 
     assert len(test_tasks) == 1
     task = test_tasks[0]

--- a/tests/envs/test_screws.py
+++ b/tests/envs/test_screws.py
@@ -11,7 +11,7 @@ def test_screws():
     """Tests for ScrewsEnv class."""
     utils.reset_config({"seed": 0})
     env = ScrewsEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     task = train_tasks[0]
     env.render_state(task.init, task)
     # Goal predicates should be {ScrewInReceptacle}.

--- a/tests/envs/test_sokoban.py
+++ b/tests/envs/test_sokoban.py
@@ -62,9 +62,9 @@ def test_sokoban():
     assert env.action_space.shape == (9, )
     nsrts = get_gt_nsrts(env.get_name(), env.predicates, options)
     assert len(nsrts) == 12
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     assert len(train_tasks) == 1
-    test_tasks = env.get_test_tasks()
+    test_tasks = [t.task for t in env.get_test_tasks()]
     assert len(test_tasks) == 2
     task = test_tasks[1]
     state = env.reset("test", 1)

--- a/tests/envs/test_stick_button.py
+++ b/tests/envs/test_stick_button.py
@@ -7,7 +7,7 @@ import pytest
 from predicators import utils
 from predicators.envs.stick_button import StickButtonEnv
 from predicators.ground_truth_models import get_gt_options
-from predicators.structs import Action, GroundAtom, EnvironmentTask
+from predicators.structs import Action, EnvironmentTask, GroundAtom
 
 
 def test_stick_button():

--- a/tests/envs/test_stick_button.py
+++ b/tests/envs/test_stick_button.py
@@ -7,7 +7,7 @@ import pytest
 from predicators import utils
 from predicators.envs.stick_button import StickButtonEnv
 from predicators.ground_truth_models import get_gt_options
-from predicators.structs import Action, GroundAtom, Task
+from predicators.structs import Action, GroundAtom, EnvironmentTask
 
 
 def test_stick_button():
@@ -62,7 +62,7 @@ def test_stick_button():
     state.set(stick, "x", stick_x)
     state.set(stick, "y", (env.rz_y_ub + env.rz_y_lb) / 4)
     state.set(stick, "theta", np.pi / 4)
-    task = Task(state, task.goal)
+    task = EnvironmentTask(state, task.goal)
     env.render_state(state, task)
     assert GroundAtom(AboveNoButton, []).holds(state)
 

--- a/tests/explorers/test_base_explorer.py
+++ b/tests/explorers/test_base_explorer.py
@@ -15,7 +15,7 @@ def test_create_explorer():
     nsrts = get_gt_nsrts(env.get_name(), env.predicates,
                          get_gt_options(env.get_name()))
     option_model = _OracleOptionModel(env)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     # Greedy lookahead explorer.
     state_score_fn = lambda _1, _2: 0.0
     name = "greedy_lookahead"

--- a/tests/explorers/test_exploit_bilevel_planning_explorer.py
+++ b/tests/explorers/test_exploit_bilevel_planning_explorer.py
@@ -18,7 +18,7 @@ def test_exploit_bilevel_planning_explorer():
     nsrts = get_gt_nsrts(env.get_name(), env.predicates,
                          get_gt_options(env.get_name()))
     option_model = _OracleOptionModel(env)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     explorer = create_explorer("exploit_planning", env.predicates,
                                get_gt_options(env.get_name()), env.types,
                                env.action_space, train_tasks, nsrts,

--- a/tests/explorers/test_glib_explorer.py
+++ b/tests/explorers/test_glib_explorer.py
@@ -20,7 +20,7 @@ def test_glib_explorer(target_predicate):
     nsrts = get_gt_nsrts(env.get_name(), env.predicates,
                          get_gt_options(env.get_name()))
     option_model = _OracleOptionModel(env)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     # For testing purposes, score everything except target predicate low.
     score_fn = lambda atoms: target_predicate in str(atoms)
     explorer = create_explorer("glib",
@@ -88,7 +88,7 @@ def test_glib_explorer_failure_cases():
     nsrts = get_gt_nsrts(env.get_name(), env.predicates,
                          get_gt_options(env.get_name()))
     option_model = _OracleOptionModel(env)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     score_fn = lambda _: 0.0
     task_idx = 0
 

--- a/tests/explorers/test_greedy_lookahead_explorer.py
+++ b/tests/explorers/test_greedy_lookahead_explorer.py
@@ -21,7 +21,7 @@ def test_greedy_lookahead_explorer(target_predicate):
     nsrts = get_gt_nsrts(env.get_name(), env.predicates,
                          get_gt_options(env.get_name()))
     option_model = _OracleOptionModel(env)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     # For testing purposes, score everything except target predicate low.
     score_fn = lambda atoms, _: target_predicate in str(atoms)
     explorer = create_explorer("greedy_lookahead",
@@ -66,7 +66,7 @@ def test_greedy_lookahead_explorer_failure_cases():
     nsrts = get_gt_nsrts(env.get_name(), env.predicates,
                          get_gt_options(env.get_name()))
     option_model = _OracleOptionModel(env)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     state_score_fn = lambda _1, _2: 0.0
     task_idx = 0
     task = train_tasks[task_idx]

--- a/tests/explorers/test_no_explore_explorer.py
+++ b/tests/explorers/test_no_explore_explorer.py
@@ -14,7 +14,7 @@ def test_no_explore_explorer():
         "explorer": "no_explore",
     })
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     task_idx = 0
     task = train_tasks[task_idx]
     explorer = create_explorer("no_explore", env.predicates,

--- a/tests/explorers/test_online_learning.py
+++ b/tests/explorers/test_online_learning.py
@@ -105,7 +105,7 @@ def test_interaction():
         "max_num_steps_interaction_request": 3,
     })
     env = create_new_env("cover")
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     approach = _MockApproach(env.predicates, get_gt_options(env.get_name()),
                              env.types, env.action_space, train_tasks)
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))

--- a/tests/explorers/test_random_actions_explorer.py
+++ b/tests/explorers/test_random_actions_explorer.py
@@ -12,7 +12,7 @@ def test_random_actions_explorer():
         "explorer": "random_actions",
     })
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     task_idx = 0
     task = train_tasks[task_idx]
     explorer = create_explorer("random_actions", env.predicates,

--- a/tests/explorers/test_random_nsrts_explorer.py
+++ b/tests/explorers/test_random_nsrts_explorer.py
@@ -14,7 +14,7 @@ def test_random_nsrts_explorer():
         "explorer": "random_nsrts",
     })
     env = TouchOpenEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     task_idx = 0
     task = train_tasks[task_idx]
     options = get_gt_options(env.get_name())

--- a/tests/explorers/test_random_options_explorer.py
+++ b/tests/explorers/test_random_options_explorer.py
@@ -15,7 +15,7 @@ def test_random_options_explorer():
         "explorer": "random_options",
     })
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     task_idx = 0
     task = train_tasks[task_idx]
     explorer = create_explorer("random_options", env.predicates,

--- a/tests/nsrt_learning/strips_learning/test_oracle_learner.py
+++ b/tests/nsrt_learning/strips_learning/test_oracle_learner.py
@@ -22,7 +22,7 @@ def test_oracle_strips_learner():
     assert not pnads
     # With sufficiently representative data, all operators should be learned.
     env = create_new_env("blocks")
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))
     ground_atom_dataset = utils.create_ground_atom_dataset(
         dataset.trajectories, env.predicates)
@@ -69,7 +69,7 @@ def test_oracle_strips_learner():
         "segmenter": "atom_changes",
     })
     env = create_new_env("blocks")
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     dataset = create_dataset(env, train_tasks, set())
     ground_atom_dataset = utils.create_ground_atom_dataset(
         dataset.trajectories, env.predicates)

--- a/tests/nsrt_learning/test_option_learning.py
+++ b/tests/nsrt_learning/test_option_learning.py
@@ -39,7 +39,7 @@ def test_known_options_option_learner():
         "option_learner": "no_learning",
     })
     env = create_new_env("cover")
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     dataset = create_demo_replay_data(env, train_tasks,
                                       get_gt_options(env.get_name()))
     ground_atom_dataset = utils.create_ground_atom_dataset(
@@ -84,7 +84,7 @@ def test_oracle_option_learner_cover():
         "segmenter": "atom_changes",
     })
     env = create_new_env("cover")
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     dataset = create_demo_replay_data(env, train_tasks, known_options=set())
     ground_atom_dataset = utils.create_ground_atom_dataset(
         dataset.trajectories, env.predicates)
@@ -133,7 +133,7 @@ def test_oracle_option_learner_blocks():
         "blocks_num_blocks_test": [4],
     })
     env = create_new_env("blocks")
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     dataset = create_demo_replay_data(env, train_tasks, known_options=set())
     ground_atom_dataset = utils.create_ground_atom_dataset(
         dataset.trajectories, env.predicates)
@@ -310,7 +310,7 @@ def test_option_learning_approach_multistep_cover():
         "num_test_tasks": 10,
     })
     env = create_new_env("cover_multistep_options")
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     approach = create_approach("nsrt_learning", env.predicates,
                                get_gt_options(env.get_name()), env.types,
                                env.action_space, train_tasks)
@@ -347,7 +347,7 @@ def test_implicit_bc_option_learning_touch_point():
         "num_test_tasks": 10,
     })
     env = create_new_env("touch_point")
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     approach = create_approach("nsrt_learning", env.predicates,
                                get_gt_options(env.get_name()), env.types,
                                env.action_space, train_tasks)
@@ -400,7 +400,7 @@ def test_action_conversion():
     with patch(f"{_MODULE_PATH}.create_action_converter") as mocker:
         mocker.return_value = _ReverseOrderPadActionConverter()
         env = create_new_env("touch_point")
-        train_tasks = env.get_train_tasks()
+        train_tasks = [t.task for t in env.get_train_tasks()]
         approach = create_approach("nsrt_learning", env.predicates, set(),
                                    env.types, env.action_space, train_tasks)
         dataset = create_dataset(env, train_tasks, known_options=set())

--- a/tests/nsrt_learning/test_segmentation.py
+++ b/tests/nsrt_learning/test_segmentation.py
@@ -174,7 +174,7 @@ def test_segment_trajectory():
         "offline_data_method": "demo",
     })
     env = create_new_env("cover_multistep_options", do_cache=False)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     assert len(train_tasks) == 1
     dataset = create_dataset(env, train_tasks, known_options=set())
     ground_atom_dataset = utils.create_ground_atom_dataset(
@@ -215,7 +215,7 @@ def test_contact_based_segmentation(env):
         "excluded_predicates": "all",
     })
     env = create_new_env(env, do_cache=False)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     assert len(train_tasks) == 1
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))
     ground_atom_dataset = utils.create_ground_atom_dataset(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -209,7 +209,7 @@ def test_bilevel_planning_approach_failure_and_timeout():
         "num_test_tasks": 1,
     })
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     approach = _DummyFailureApproach(env.predicates,
                                      get_gt_options(env.get_name()), env.types,
                                      env.action_space, train_tasks)
@@ -243,7 +243,7 @@ def test_env_failure():
     })
     cover_options = get_gt_options("cover")
     env = _DummyCoverEnv()
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     approach = create_approach("random_actions", env.predicates, cover_options,
                                env.types, env.action_space, train_tasks)
     assert not approach.is_learning_based

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -45,7 +45,8 @@ def test_sesame_plan(sesame_check_expected_atoms, sesame_grounder, expectation,
     env = CoverEnv()
     nsrts = get_gt_nsrts(env.get_name(), env.predicates,
                          get_gt_options(env.get_name()))
-    task = env.get_test_tasks()[0]
+    env_task = env.get_test_tasks()[0]
+    task = env_task.task
     option_model = create_option_model(CFG.option_model_name)
     with expectation as e:
         plan, metrics = sesame_plan(
@@ -74,7 +75,8 @@ def test_task_plan():
     env = CoverEnv()
     nsrts = get_gt_nsrts(env.get_name(), env.predicates,
                          get_gt_options(env.get_name()))
-    task = env.get_train_tasks()[0]
+    env_task = env.get_train_tasks()[0]
+    task = env_task.task
     init_atoms = utils.abstract(task.init, env.predicates)
     objects = set(task.init)
     ground_nsrts, reachable_atoms = task_plan_grounding(
@@ -123,7 +125,8 @@ def test_sesame_plan_failures():
     option_model = create_option_model(CFG.option_model_name)
     approach = OracleApproach(env.predicates, get_gt_options(env.get_name()),
                               env.types, env.action_space, train_tasks)
-    task = train_tasks[0]
+    env_task = train_tasks[0]
+    task = env_task.task
     trivial_task = Task(task.init, set())
     policy = approach.solve(trivial_task, timeout=500)
     with pytest.raises(ApproachFailure):
@@ -239,7 +242,8 @@ def test_sesame_plan_failures():
     utils.reset_config({"env": "painting", "painting_num_objs_train": [10]})
     env = PaintingEnv()
     train_tasks = env.get_train_tasks()
-    task = train_tasks[0]
+    env_task = train_tasks[0]
+    task = env_task.task
     option_model = create_option_model(CFG.option_model_name)
     approach = OracleApproach(env.predicates, get_gt_options(env.get_name()),
                               env.types, env.action_space, train_tasks)
@@ -269,7 +273,8 @@ def test_sesame_plan_uninitiable_option():
                  nsrt.preconditions, nsrt.add_effects, nsrt.delete_effects,
                  nsrt.ignore_effects, new_option, nsrt.option_vars,
                  nsrt._sampler))
-    task = env.get_train_tasks()[0]
+    env_task = env.get_train_tasks()[0]
+    task = env_task.task
     with pytest.raises(PlanningFailure) as e:
         # Planning should reach sesame_max_skeletons_optimized
         sesame_plan(
@@ -296,7 +301,8 @@ def test_sesame_check_static_object_changes():
     env = CoverEnv()
     nsrts = get_gt_nsrts(env.get_name(), env.predicates,
                          get_gt_options(env.get_name()))
-    task = env.get_test_tasks()[0]
+    env_task = env.get_test_tasks()[0]
+    task = env_task.task
     option_model = create_option_model(CFG.option_model_name)
     # In Cover, the NSRTs do not contain the robot as an argument, so planning
     # is not possible if we are checking for static object changes.
@@ -324,7 +330,8 @@ def test_sesame_check_static_object_changes():
     env = BlocksEnv()
     nsrts = get_gt_nsrts(env.get_name(), env.predicates,
                          get_gt_options(env.get_name()))
-    task = env.get_test_tasks()[0]
+    env_task = env.get_test_tasks()[0]
+    task = env_task.task
     option_model = create_option_model(CFG.option_model_name)
     plan, _ = sesame_plan(
         task,
@@ -508,7 +515,8 @@ def test_policy_guided_sesame():
     env = CoverEnv()
     nsrts = get_gt_nsrts(env.get_name(), env.predicates,
                          get_gt_options(env.get_name()))
-    task = env.get_test_tasks()[0]
+    env_task = env.get_test_tasks()[0]
+    task = env_task.task
     option_model = create_option_model(CFG.option_model_name)
     # With a trivial policy, we would expect the number of nodes to be the
     # same as it would be if we planned with no policy.
@@ -658,7 +666,8 @@ def test_sesame_plan_fast_downward():
         env = ClutteredTableEnv()
         nsrts = get_gt_nsrts(env.get_name(), env.predicates,
                              get_gt_options(env.get_name()))
-        task = env.get_test_tasks()[0]
+        env_task = env.get_test_tasks()[0]
+        task = env_task.task
         option_model = create_option_model(CFG.option_model_name)
         try:
             plan, metrics = sesame_plan(

--- a/tests/test_predicate_search_score_functions.py
+++ b/tests/test_predicate_search_score_functions.py
@@ -104,7 +104,8 @@ def test_predicate_search_heuristic_base_classes():
         op_learning_score_function.evaluate(set())
     utils.reset_config({"env": "cover", "cover_initial_holding_prob": 0.0})
     env = CoverEnv()
-    train_tasks = env.get_train_tasks()
+    env_train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env_train_tasks]
     state = train_tasks[0].init
     other_state = state.copy()
     robby = [o for o in state if o.type.name == "robot"][0]
@@ -153,7 +154,8 @@ def test_prediction_error_score_function():
         else:
             initial_predicates.add(p)
     candidates = {p: 1.0 for p in name_to_pred.values()}
-    train_tasks = env.get_train_tasks()
+    env_train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env_train_tasks]
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))
     atom_dataset = utils.create_ground_atom_dataset(dataset.trajectories,
                                                     env.predicates)
@@ -187,7 +189,8 @@ def test_hadd_match_score_function():
         else:
             initial_predicates.add(p)
     candidates = {p: 1.0 for p in name_to_pred.values()}
-    train_tasks = env.get_train_tasks()
+    env_train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env_train_tasks]
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))
     atom_dataset = utils.create_ground_atom_dataset(dataset.trajectories,
                                                     env.predicates)
@@ -217,7 +220,8 @@ def test_relaxation_energy_score_function():
         else:
             initial_predicates.add(p)
     candidates = {p: 1.0 for p in name_to_pred.values()}
-    train_tasks = env.get_train_tasks()
+    env_train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env_train_tasks]
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))
     atom_dataset = utils.create_ground_atom_dataset(dataset.trajectories,
                                                     env.predicates)
@@ -327,7 +331,8 @@ def test_exact_energy_score_function():
         else:
             initial_predicates.add(p)
     candidates = {p: 1.0 for p in name_to_pred.values()}
-    train_tasks = env.get_train_tasks()
+    env_train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env_train_tasks]
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))
     atom_dataset = utils.create_ground_atom_dataset(dataset.trajectories,
                                                     env.predicates)
@@ -392,7 +397,8 @@ def test_count_score_functions():
     candidates = {p: 1.0 for p in name_to_pred.values()}
     NotHandEmpty = name_to_pred["HandEmpty"].get_negation()
     candidates[NotHandEmpty] = 1.0
-    train_tasks = env.get_train_tasks()
+    env_train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env_train_tasks]
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))
     atom_dataset = utils.create_ground_atom_dataset(dataset.trajectories,
                                                     env.predicates)
@@ -442,7 +448,8 @@ def test_branching_factor_score_function():
         forall_not_covers1: 1.0,
         Holding: 1.0,
     }
-    train_tasks = env.get_train_tasks()
+    env_train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env_train_tasks]
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))
     atom_dataset = utils.create_ground_atom_dataset(
         dataset.trajectories, env.goal_predicates | set(candidates))
@@ -476,7 +483,8 @@ def test_task_planning_score_function():
         Holding: 1.0,
         HandEmpty: 1.0,
     }
-    train_tasks = env.get_train_tasks()
+    env_train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env_train_tasks]
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))
     atom_dataset = utils.create_ground_atom_dataset(
         dataset.trajectories, env.goal_predicates | set(candidates))
@@ -521,7 +529,8 @@ def test_expected_nodes_score_function():
             Holding: 1.0,
             HandEmpty: 1.0,
         }
-        train_tasks = env.get_train_tasks()
+        env_train_tasks = env.get_train_tasks()
+        train_tasks = [t.task for t in env_train_tasks]
         dataset = create_dataset(env, train_tasks,
                                  get_gt_options(env.get_name()))
         atom_dataset = utils.create_ground_atom_dataset(
@@ -553,7 +562,8 @@ def test_expected_nodes_score_function():
         "offline_data_method": "demo",
         "min_data_for_nsrt": 0,
     })
-    train_tasks = env.get_train_tasks()
+    env_train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env_train_tasks]
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))
     atom_dataset = utils.create_ground_atom_dataset(
         dataset.trajectories, env.goal_predicates | set(candidates))

--- a/tests/test_teacher.py
+++ b/tests/test_teacher.py
@@ -17,7 +17,7 @@ def test_GroundAtomsHold():
     """Tests for answering queries of type GroundAtomsHoldQuery."""
     utils.reset_config({"env": "cover", "approach": "unittest"})
     env = create_new_env("cover")
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     teacher = Teacher(train_tasks)
     state = env.get_train_tasks()[0].init
     block_type = [t for t in env.types if t.name == "block"][0]
@@ -60,7 +60,7 @@ def test_DemonstrationQuery():
     """Tests for answering queries of type DemonstrationQuery."""
     utils.reset_config({"env": "cover", "approach": "unittest"})
     env = create_new_env("cover")
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     teacher = Teacher(train_tasks)
     train_task_idx = 0
     task = train_tasks[train_task_idx]
@@ -109,7 +109,7 @@ def test_PathToStateQuery():
     })
     # Test normal usage.
     env = create_new_env("cover_multistep_options")
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     teacher = Teacher(train_tasks)
     train_task_idx = 0
     task = train_tasks[train_task_idx]
@@ -173,7 +173,7 @@ def test_PathToStateQuery():
     # Test that an error is raised when an unsupported environment is used.
     utils.reset_config({"env": "painting", "approach": "unittest"})
     env = create_new_env("painting")
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     teacher = Teacher(train_tasks)
     task = train_tasks[0]
     state = task.init
@@ -201,7 +201,7 @@ def test_TeacherInteractionMonitor():
     termination_function = lambda s: True  # terminate immediately
     request = InteractionRequest(0, act_policy, query_policy,
                                  termination_function)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     teacher = Teacher(train_tasks)
     monitor = TeacherInteractionMonitor(request, teacher)
     assert monitor.get_query_cost() == 0.0
@@ -223,7 +223,7 @@ def test_TeacherInteractionMonitor():
     termination_function = lambda s: True  # terminate immediately
     request = InteractionRequest(0, act_policy, query_policy,
                                  termination_function)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     teacher = Teacher(train_tasks)
     monitor = TeacherInteractionMonitor(request, teacher)
     state = env.reset("train", 0)
@@ -250,7 +250,7 @@ def test_TeacherInteractionMonitorWithVideo():
     termination_function = lambda s: True  # terminate immediately
     request = InteractionRequest(0, act_policy, query_policy,
                                  termination_function)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     teacher = Teacher(train_tasks)
     monitor = TeacherInteractionMonitorWithVideo(env.render, request, teacher)
     assert monitor.get_query_cost() == 0.0
@@ -270,7 +270,7 @@ def test_TeacherInteractionMonitorWithVideo():
     termination_function = lambda s: True  # terminate immediately
     request = InteractionRequest(0, act_policy, query_policy,
                                  termination_function)
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     teacher = Teacher(train_tasks)
     monitor = TeacherInteractionMonitorWithVideo(env.render, request, teacher)
     state = env.reset("train", 0)
@@ -282,7 +282,7 @@ def test_answer_query():
     """Tests for Teacher.answer_query()."""
     utils.reset_config({"env": "cover", "approach": "unittest"})
     env = create_new_env("cover")
-    train_tasks = env.get_train_tasks()
+    train_tasks = [t.task for t in env.get_train_tasks()]
     teacher = Teacher(train_tasks)
     state = env.get_train_tasks()[0].init
 

--- a/tests/test_train_refinement_estimator.py
+++ b/tests/test_train_refinement_estimator.py
@@ -110,7 +110,7 @@ def test_train_refinement_estimator():
 
     # Test PlanningFailure if goal is not dr-reachable
     sample_env = NarrowPassageEnv()
-    sample_task = sample_env.get_train_tasks()[0]
+    sample_task = sample_env.get_train_tasks()[0].task
     sample_option_model = create_option_model("oracle")
     utils.reset_config_with_parser(parser)
     with pytest.raises(PlanningFailure):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -518,7 +518,7 @@ def test_run_policy():
     utils.reset_config({"env": "cover"})
     env = CoverEnv()
     policy = lambda _: Action(env.action_space.sample())
-    task = env.get_task("test", 0)
+    task = env.get_task("test", 0).task
     traj, metrics = utils.run_policy(policy,
                                      env,
                                      "test",
@@ -2170,7 +2170,7 @@ def test_create_pddl():
     env = CoverEnv()
     nsrts = get_gt_nsrts(env.get_name(), env.predicates,
                          get_gt_options(env.get_name()))
-    train_task = env.get_train_tasks()[0]
+    train_task = env.get_train_tasks()[0].task
     state = train_task.init
     objects = list(state)
     init_atoms = utils.abstract(state, env.predicates)
@@ -2281,7 +2281,7 @@ def test_create_pddl():
   )
 )"""
 
-    train_task = env.get_train_tasks()[0]
+    train_task = env.get_train_tasks()[0].task
     state = train_task.init
     objects = list(state)
     init_atoms = utils.abstract(state, env.predicates)
@@ -2326,7 +2326,7 @@ def test_VideoMonitor():
     env = CoverMultistepOptions()
     monitor = utils.VideoMonitor(env.render)
     policy = lambda _: Action(env.action_space.sample())
-    task = env.get_task("test", 0)
+    task = env.get_task("test", 0).task
     traj, _ = utils.run_policy(policy,
                                env,
                                "test",
@@ -2347,7 +2347,7 @@ def test_VideoMonitor():
 def test_SimulateVideoMonitor():
     """Tests for SimulateVideoMonitor()."""
     env = CoverMultistepOptions()
-    task = env.get_task("test", 0)
+    task = env.get_task("test", 0).task
     monitor = utils.SimulateVideoMonitor(task, env.render_state)
     policy = lambda _: Action(env.action_space.sample())
     traj, _ = utils.run_policy(policy,


### PR DESCRIPTION
this PR makes a new distinction between the tasks produced by the environment and the tasks that the agent uses for planning. the difference is that environment tasks contain arbitrary representations of observations and goals, whereas the planning tasks have `State` and `Set[GroundAtom]`.

the motivation for this PR is that we want to add a perception module (inside of a "cognitive manager") that can produce states from raw observations (e.g. images) and goals from raw descriptions (e.g. natural language).

one design choice that I made, noted in a comment, is to assume that the initial observations of training tasks contain enough information to produce a planning task. this is mostly for convenience and we can revisit it later if needed, but this assumption does hold in Sokoban, which is the environment that we're using for development of the perception / cogman stuff.