### PR TITLE
make sokoban seeds independent

### DIFF
--- a/predicators/envs/sokoban.py
+++ b/predicators/envs/sokoban.py
@@ -74,11 +74,10 @@ class SokobanEnv(BaseEnv):
         self._box_loc_to_name: Dict[Tuple[int, int], str] = {}
 
     def _generate_train_tasks(self) -> List[Task]:
-        return self._get_tasks(num=CFG.num_train_tasks, seed_offset=0)
+        return self._get_tasks(num=CFG.num_train_tasks, train_or_test="train")
 
     def _generate_test_tasks(self) -> List[Task]:
-        return self._get_tasks(num=CFG.num_test_tasks,
-                               seed_offset=CFG.test_env_seed_offset)
+        return self._get_tasks(num=CFG.num_test_tasks, train_or_test="test")
 
     @classmethod
     def get_name(cls) -> str:
@@ -141,10 +140,8 @@ class SokobanEnv(BaseEnv):
         self._current_state = self._current_task.init
         # We now need to reset the underlying gym environment to the correct
         # state.
-        seed_offset = CFG.seed
-        if train_or_test == "test":
-            seed_offset += CFG.test_env_seed_offset
-        self._reset_initial_state_from_seed(seed_offset + task_idx)
+        seed = self._get_task_seed(train_or_test, task_idx)
+        self._reset_initial_state_from_seed(seed)
         assert self.get_state().allclose(self._current_state)
         return self._current_state.copy()
 
@@ -159,10 +156,10 @@ class SokobanEnv(BaseEnv):
         self._current_state = self._observation_to_state(obs)
         return self._current_state.copy()
 
-    def _get_tasks(self, num: int, seed_offset: int) -> List[Task]:
+    def _get_tasks(self, num: int, train_or_test: str) -> List[Task]:
         tasks = []
-        for i in range(num):
-            seed = i + seed_offset + CFG.seed
+        for task_idx in range(num):
+            seed = self._get_task_seed(train_or_test, task_idx)
             obs = self._reset_initial_state_from_seed(seed)
             init_state = self._observation_to_state(obs)
             # The goal is always for all goal objects to be covered.
@@ -364,3 +361,14 @@ class SokobanEnv(BaseEnv):
     @classmethod
     def _is_dynamic(cls, obj: Object, state: State) -> bool:
         return not cls._is_static(obj, state)
+
+    @staticmethod
+    def _get_task_seed(train_or_test: str, task_idx: int) -> int:
+        assert task_idx < CFG.test_env_seed_offset
+        entropy = CFG.seed
+        if train_or_test == "test":
+            entropy += CFG.test_env_seed_offset
+        seed_sequence = np.random.SeedSequence(entropy)
+        # Need to cast to int because generate_state() returns a numpy int.
+        task_seed = int(seed_sequence.generate_state(task_idx + 1)[-1])
+        return task_seed

--- a/predicators/envs/sokoban.py
+++ b/predicators/envs/sokoban.py
@@ -365,6 +365,13 @@ class SokobanEnv(BaseEnv):
     @staticmethod
     def _get_task_seed(train_or_test: str, task_idx: int) -> int:
         assert task_idx < CFG.test_env_seed_offset
+        # SeedSequence generates a sequence of random values given an integer
+        # "entropy". We use CFG.seed to define the "entropy" and then get the
+        # n^th generated random value and use that to seed the gym environment.
+        # This is all to avoid unintentional dependence between experiments
+        # that are conducted with consecutive random seeds. For example, if
+        # we used CFG.seed + task_idx to seed the gym environment, there would
+        # be overlap between experiments when CFG.seed = 1, CFG.seed = 2, etc.
         entropy = CFG.seed
         if train_or_test == "test":
             entropy += CFG.test_env_seed_offset

--- a/tests/envs/test_sokoban.py
+++ b/tests/envs/test_sokoban.py
@@ -78,9 +78,7 @@ def test_sokoban():
     # Hardcode a sequence of actions to achieve one example of GoalCovered.
     # This is brittle, but we don't want to plan because it could be slow
     # without Fast Downward, which is not installed on the test server.
-    plan = [
-        "MoveDown", "MoveDown", "MoveLeft", "MoveLeft", "MoveUp", "PushRight"
-    ]
+    plan = ["PushUp", "PushUp"]
     option_names = {o.name: o for o in options}
     for name in plan:
         param_option = option_names[name]


### PR DESCRIPTION
before this, we would be seeding the gym environment with 0, 1, 2, 3... in the first experiment, and then 1, 2, 3, 4... in the second experiment, etc., because we usually just increment seeds when we run multiple trials.

closes #1432