### PR TITLE
oracle bridge policy approach

### DIFF
--- a/predicators/approaches/bilevel_planning_approach.py
+++ b/predicators/approaches/bilevel_planning_approach.py
@@ -20,8 +20,8 @@ from predicators.planning import PlanningFailure, PlanningTimeout, \
     fd_plan_from_sas_file, generate_sas_file_for_fd, sesame_plan, task_plan, \
     task_plan_grounding
 from predicators.settings import CFG
-from predicators.structs import NSRT, Action, Metrics, ParameterizedOption, \
-    Predicate, State, Task, Type, _GroundNSRT, _Option, GroundAtom
+from predicators.structs import NSRT, Action, GroundAtom, Metrics, \
+    ParameterizedOption, Predicate, State, Task, Type, _GroundNSRT, _Option
 
 
 class BilevelPlanningApproach(BaseApproach):
@@ -59,8 +59,8 @@ class BilevelPlanningApproach(BaseApproach):
         # Run task planning only and then greedily sample and execute in the
         # policy.
         if self._plan_without_sim:
-            nsrt_plan, _, metrics = self._run_task_plan(task, nsrts, preds,
-                                                     timeout, seed)
+            nsrt_plan, _, metrics = self._run_task_plan(
+                task, nsrts, preds, timeout, seed)
             self._last_nsrt_plan = nsrt_plan
             policy = utils.nsrt_plan_to_greedy_policy(nsrt_plan, task.goal,
                                                       self._rng)
@@ -111,9 +111,10 @@ class BilevelPlanningApproach(BaseApproach):
 
         return plan, metrics
 
-    def _run_task_plan(self, task: Task, nsrts: Set[NSRT],
-                       preds: Set[Predicate], timeout: float, seed: int,
-                       **kwargs: Any) -> Tuple[List[_GroundNSRT], List[Set[GroundAtom]], Metrics]:
+    def _run_task_plan(
+        self, task: Task, nsrts: Set[NSRT], preds: Set[Predicate],
+        timeout: float, seed: int, **kwargs: Any
+    ) -> Tuple[List[_GroundNSRT], List[Set[GroundAtom]], Metrics]:
 
         init_atoms = utils.abstract(task.init, preds)
         goal = task.goal

--- a/predicators/approaches/bridge_policy_approach.py
+++ b/predicators/approaches/bridge_policy_approach.py
@@ -73,10 +73,7 @@ class BridgePolicyApproach(OracleApproach):
 
             # Switch control from planner to bridge.
             if current_control == "planner":
-                # Planner failed on the first time step.
-                if failed_nsrt is None:
-                    assert s.allclose(task.init)
-                    raise ApproachFailure("Planning failed in init state.")
+                assert failed_nsrt is not None
                 logging.debug(f"Failed NSRT: {failed_nsrt.name}"
                               f"{failed_nsrt.objects}.")
                 logging.debug("Switching control from planner to bridge.")

--- a/predicators/approaches/bridge_policy_approach.py
+++ b/predicators/approaches/bridge_policy_approach.py
@@ -1,0 +1,160 @@
+"""A simulator-free planning approach that uses a bridge policy to compensate
+for lack of downward refinability.
+
+Like bilevel-planning-without-sim, the approach makes an abstract plan and then
+greedily samples and executes each skill in the abstract plan. If at any point
+the skill fails to achieve its operator effects, control switches to a bridge
+policy, which takes the current state (low-level and abstract) and the last
+failed skill identity and returns a ground option or "done" (DummyOption). If
+"done", control is given back to the planner, which replans. If the bridge
+policy outputs a ground option, that ground option is executed until
+termination and then the bridge policy is called again.
+
+The bridge policy is so named because it's meant to serve as a "bridge back to
+plannability" in states where the planner has gotten stuck.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, Callable, List, Set, Tuple
+
+from gym.spaces import Box
+
+from predicators import utils
+from predicators.approaches import ApproachFailure
+from predicators.approaches.oracle_approach import OracleApproach
+from predicators.bridge_policies import create_bridge_policy
+from predicators.settings import CFG
+from predicators.structs import NSRT, Action, DummyOption, Metrics, \
+    ParameterizedOption, Predicate, State, Task, Type, _GroundNSRT, _Option
+from predicators.utils import OptionExecutionFailure
+
+
+class BridgePolicyApproach(OracleApproach):
+    """A simulator-free bilevel planning approach that uses a bridge policy."""
+
+    def __init__(self,
+                 initial_predicates: Set[Predicate],
+                 initial_options: Set[ParameterizedOption],
+                 types: Set[Type],
+                 action_space: Box,
+                 train_tasks: List[Task],
+                 task_planning_heuristic: str = "default",
+                 max_skeletons_optimized: int = -1) -> None:
+        super().__init__(initial_predicates, initial_options, types,
+                         action_space, train_tasks, task_planning_heuristic,
+                         max_skeletons_optimized)
+        self._bridge_policy = create_bridge_policy(CFG.bridge_policy)
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "bridge_policy"
+
+    def _solve(self, task: Task, timeout: int) -> Callable[[State], Action]:
+        goal = task.goal
+
+        # Start by planning. Note that we cannot start with the bridge policy
+        # because the bridge policy takes as input the last failed NSRT.
+        current_control = "planner"
+        current_option, current_nsrt, remaining_nsrt_plan = \
+            self._get_next_option_by_planning(task, timeout)
+
+        # Used to detect if an NSRT has failed / is stuck.
+        state_history: List[State] = []
+        option_history: List[Tuple[_Option, int]] = []  # (option, init time)
+
+        def _policy(s: State) -> Action:
+            nonlocal current_control, current_option, current_nsrt, remaining_nsrt_plan
+            current_task = Task(s, goal)
+            state_history.append(s)
+
+            # Try to execute the current option.
+            if not self._current_option_is_stuck(current_option, current_nsrt,
+                                                 state_history,
+                                                 option_history):
+                try:
+                    return current_option.policy(s)
+                except OptionExecutionFailure:
+                    # Something went wrong, so we need a new option.
+                    pass
+
+            found_new_option = False
+
+            # Case 1: planner is in control and there is another NSRT in
+            # the queue.
+            if current_control == "planner" and remaining_nsrt_plan:
+                try:
+                    current_option, current_nsrt, remaining_nsrt_plan = \
+                        self._pop_option_from_nsrt_plan(remaining_nsrt_plan, current_task)
+                    found_new_option = True
+                except OptionExecutionFailure:
+                    # The next option in the queue failed to initiate. Go
+                    # on to Case 2.
+                    pass
+
+            # Case 2: planner is in control, but failed, so need to switch
+            # to bridge policy.
+            if current_control == "planner" and not found_new_option:
+                current_control = "bridge"
+                atoms = utils.abstract(s, self._get_current_predicates())
+                current_option = self._bridge_policy(s, atoms, current_nsrt)
+                # If the bridge policy is done immediately, then we should
+                # attempt to replan.
+                if current_option is not DummyOption:
+                    found_new_option = True
+
+            # Case 3: bridge policy is in control, but just finished, so
+            # we need to switch back to the planner.
+            if current_control == "bridge" and not found_new_option:
+                assert current_option is DummyOption
+                current_control = "planner"
+                try:
+                    current_option, current_nsrt, remaining_nsrt_plan = \
+                        self._get_next_option_by_planning(current_task, timeout)
+                    found_new_option = True
+                except OptionExecutionFailure:
+                    raise ApproachFailure("Bridge policy terminated and "
+                                          "then planning failed.")
+
+            assert found_new_option
+            t = len(state_history) - 1
+            option_history.append((current_option, t))
+
+            try:
+                return current_option.policy(s)
+            except OptionExecutionFailure as e:
+                raise ApproachFailure(e.args[0], e.info)
+
+        return _policy
+
+    def _current_option_is_stuck(
+            self, current_option: _Option, current_nsrt: _GroundNSRT,
+            state_history: List[State],
+            option_history: List[Tuple[_Option, int]]) -> bool:
+        # TODO!!!!
+        return False
+
+    def _get_next_option_by_planning(
+            self, task: Task,
+            timeout: float) -> Tuple[_Option, _GroundNSRT, List[_GroundNSRT]]:
+        """Returns an initiated option and the remainder of an option plan."""
+
+        # Ensure random over successive calls.
+        self._num_calls += 1
+        seed = self._seed + self._num_calls
+        nsrts = self._get_current_nsrts()
+        preds = self._get_current_predicates()
+
+        nsrt_plan, _ = self._run_task_plan(task, nsrts, preds, timeout, seed)
+        return self._pop_option_from_nsrt_plan(nsrt_plan, task)
+
+    def _pop_option_from_nsrt_plan(
+            self, nsrt_plan: List[_GroundNSRT],
+            task: Task) -> Tuple[_Option, _GroundNSRT, List[_GroundNSRT]]:
+        if not nsrt_plan:
+            raise ApproachFailure("Failed to find an initial abstract plan.")
+        nsrt = nsrt_plan.pop(0)
+        option = nsrt.sample_option(task.init, task.goal, self._rng)
+        if not option.initiable(task.init):
+            raise OptionExecutionFailure("Greedy option not initiable.")
+        return option, nsrt, nsrt_plan

--- a/predicators/approaches/bridge_policy_approach.py
+++ b/predicators/approaches/bridge_policy_approach.py
@@ -73,7 +73,10 @@ class BridgePolicyApproach(OracleApproach):
 
             # Switch control from planner to bridge.
             if current_control == "planner":
-                assert failed_nsrt is not None
+                # Planning failed on the first time step.
+                if failed_nsrt is None:
+                    assert s.allclose(task.init)
+                    raise ApproachFailure("Planning failed on init state.")
                 logging.debug(f"Failed NSRT: {failed_nsrt.name}"
                               f"{failed_nsrt.objects}.")
                 logging.debug("Switching control from planner to bridge.")

--- a/predicators/approaches/bridge_policy_approach.py
+++ b/predicators/approaches/bridge_policy_approach.py
@@ -86,13 +86,14 @@ class BridgePolicyApproach(OracleApproach):
                     return current_policy(s)
                 except OptionExecutionFailure as e:
                     pass
-            
+
             # Switch control from bridge to planner.
             logging.debug("Switching control from bridge to planner.")
             assert current_control == "bridge"
             current_task = Task(s, task.goal)
             current_control = "planner"
-            current_policy = self._get_policy_by_planning(current_task, timeout)
+            current_policy = self._get_policy_by_planning(
+                current_task, timeout)
             try:
                 return current_policy(s)
             except OptionExecutionFailure as e:
@@ -100,7 +101,8 @@ class BridgePolicyApproach(OracleApproach):
 
         return _policy
 
-    def _get_policy_by_planning(self, task: Task, timeout: float) -> Callable[[State], Action]:
+    def _get_policy_by_planning(self, task: Task,
+                                timeout: float) -> Callable[[State], Action]:
         """Raises an OptionExecutionFailure with the last_failured_nsrt in its
         info dict in the case where execution fails."""
 
@@ -110,9 +112,10 @@ class BridgePolicyApproach(OracleApproach):
         nsrts = self._get_current_nsrts()
         preds = self._get_current_predicates()
 
-        nsrt_queue, atoms_seq, _ = self._run_task_plan(task, nsrts, preds, timeout, seed)
+        nsrt_queue, atoms_seq, _ = self._run_task_plan(task, nsrts, preds,
+                                                       timeout, seed)
         atoms_queue = utils.compute_necessary_atoms_seq(
-                nsrt_queue, atoms_seq, task.goal)[1:]
+            nsrt_queue, atoms_seq, task.goal)[1:]
         cur_nsrt: Optional[_GroundNSRT] = None
         last_nsrt: Optional[_GroundNSRT] = None
         cur_option = DummyOption
@@ -122,23 +125,26 @@ class BridgePolicyApproach(OracleApproach):
             if cur_option is DummyOption or cur_option.terminal(state):
                 last_nsrt = cur_nsrt
                 if not nsrt_queue:
-                    raise OptionExecutionFailure("Greedy option plan exhausted.",
+                    raise OptionExecutionFailure(
+                        "Greedy option plan exhausted.",
                         info={"last_failed_nsrt": last_nsrt})
                 if last_nsrt is not None:
                     expected_atoms = atoms_queue.pop(0)
                     if not all(a.holds(state) for a in expected_atoms):
-                        raise OptionExecutionFailure("Executing the option "
+                        raise OptionExecutionFailure(
+                            "Executing the option "
                             "failed to achieve the NSRT effects.",
                             info={"last_failed_nsrt": last_nsrt})
                 cur_nsrt = nsrt_queue.pop(0)
                 logging.debug(f"Using NSRT {cur_nsrt.name}{cur_nsrt.objects} "
-                               "from planner.")
-                cur_option = cur_nsrt.sample_option(state, task.goal, self._rng)
+                              "from planner.")
+                cur_option = cur_nsrt.sample_option(state, task.goal,
+                                                    self._rng)
                 if not cur_option.initiable(state):
-                    raise OptionExecutionFailure("Greedy option not initiable.",
+                    raise OptionExecutionFailure(
+                        "Greedy option not initiable.",
                         info={"last_failed_nsrt": last_nsrt})
             act = cur_option.policy(state)
             return act
 
         return _policy
-    

--- a/predicators/approaches/bridge_policy_approach.py
+++ b/predicators/approaches/bridge_policy_approach.py
@@ -106,7 +106,7 @@ class BridgePolicyApproach(OracleApproach):
 
     def _get_policy_by_planning(self, task: Task,
                                 timeout: float) -> Callable[[State], Action]:
-        """Raises an OptionExecutionFailure with the last_failured_nsrt in its
+        """Raises an OptionExecutionFailure with the last_failed_nsrt in its
         info dict in the case where execution fails."""
 
         # Ensure random over successive calls.

--- a/predicators/bridge_policies/__init__.py
+++ b/predicators/bridge_policies/__init__.py
@@ -1,8 +1,11 @@
 """Handle creation of bridge policies."""
 
+from typing import Set
+
 from predicators import utils
 from predicators.bridge_policies.base_bridge_policy import BaseBridgePolicy, \
     BridgePolicyDone
+from predicators.structs import NSRT, Predicate
 
 __all__ = ["BaseBridgePolicy", "BridgePolicyDone", "create_bridge_policy"]
 
@@ -10,11 +13,12 @@ __all__ = ["BaseBridgePolicy", "BridgePolicyDone", "create_bridge_policy"]
 utils.import_submodules(__path__, __name__)
 
 
-def create_bridge_policy(name: str) -> BaseBridgePolicy:
+def create_bridge_policy(name: str, predicates: Set[Predicate],
+                         nsrts: Set[NSRT]) -> BaseBridgePolicy:
     """Create a bridge policy given its name."""
     for cls in utils.get_all_subclasses(BaseBridgePolicy):
         if not cls.__abstractmethods__ and cls.get_name() == name:
-            bridge_policy = cls()
+            bridge_policy = cls(predicates, nsrts)
             break
     else:
         raise NotImplementedError(f"Unknown bridge policy: {name}")

--- a/predicators/bridge_policies/__init__.py
+++ b/predicators/bridge_policies/__init__.py
@@ -1,7 +1,8 @@
 """Handle creation of bridge policies."""
 
 from predicators import utils
-from predicators.bridge_policies.base_bridge_policy import BaseBridgePolicy, BridgePolicyDone
+from predicators.bridge_policies.base_bridge_policy import BaseBridgePolicy, \
+    BridgePolicyDone
 
 __all__ = ["BaseBridgePolicy", "BridgePolicyDone", "create_bridge_policy"]
 

--- a/predicators/bridge_policies/__init__.py
+++ b/predicators/bridge_policies/__init__.py
@@ -1,9 +1,9 @@
 """Handle creation of bridge policies."""
 
 from predicators import utils
-from predicators.bridge_policies.base_bridge_policy import BaseBridgePolicy
+from predicators.bridge_policies.base_bridge_policy import BaseBridgePolicy, BridgePolicyDone
 
-__all__ = ["BaseBridgePolicy", "create_bridge_policy"]
+__all__ = ["BaseBridgePolicy", "BridgePolicyDone", "create_bridge_policy"]
 
 # Find the subclasses.
 utils.import_submodules(__path__, __name__)

--- a/predicators/bridge_policies/__init__.py
+++ b/predicators/bridge_policies/__init__.py
@@ -1,0 +1,20 @@
+"""Handle creation of bridge policies."""
+
+from predicators import utils
+from predicators.bridge_policies.base_bridge_policy import BaseBridgePolicy
+
+__all__ = ["BaseBridgePolicy", "create_bridge_policy"]
+
+# Find the subclasses.
+utils.import_submodules(__path__, __name__)
+
+
+def create_bridge_policy(name: str) -> BaseBridgePolicy:
+    """Create a bridge policy given its name."""
+    for cls in utils.get_all_subclasses(BaseBridgePolicy):
+        if not cls.__abstractmethods__ and cls.get_name() == name:
+            bridge_policy = cls()
+            break
+    else:
+        raise NotImplementedError(f"Unknown bridge policy: {name}")
+    return bridge_policy

--- a/predicators/bridge_policies/base_bridge_policy.py
+++ b/predicators/bridge_policies/base_bridge_policy.py
@@ -1,9 +1,9 @@
 """Base class for a bridge policy."""
 
 import abc
-from typing import Set
+from typing import Callable, Set
 
-from predicators.structs import GroundAtom, State, _GroundNSRT, _Option
+from predicators.structs import GroundAtom, State, _GroundNSRT, _Option, Action
 
 
 class BaseBridgePolicy(abc.ABC):
@@ -17,7 +17,7 @@ class BaseBridgePolicy(abc.ABC):
         raise NotImplementedError("Override me!")
 
     @abc.abstractmethod
-    def __call__(self, state: State, atoms: Set[GroundAtom],
-                 failed_nsrt: _GroundNSRT) -> _Option:
-        """The main method implementing the bridge policy."""
+    def get_policy(self, state: State, atoms: Set[GroundAtom],
+                 failed_nsrt: _GroundNSRT) -> Callable[[State], Action]:
+        """The main method creating the bridge policy."""
         raise NotImplementedError("Override me!")

--- a/predicators/bridge_policies/base_bridge_policy.py
+++ b/predicators/bridge_policies/base_bridge_policy.py
@@ -3,7 +3,10 @@
 import abc
 from typing import Callable, Set
 
-from predicators.structs import Action, State, _GroundNSRT
+import numpy as np
+
+from predicators.settings import CFG
+from predicators.structs import NSRT, Action, Predicate, State, _GroundNSRT
 
 
 class BridgePolicyDone(Exception):
@@ -12,6 +15,11 @@ class BridgePolicyDone(Exception):
 
 class BaseBridgePolicy(abc.ABC):
     """Base bridge policy."""
+
+    def __init__(self, predicates: Set[Predicate], nsrts: Set[NSRT]) -> None:
+        self._predicates = predicates
+        self._nsrts = nsrts
+        self._rng = np.random.default_rng(CFG.seed)
 
     @classmethod
     @abc.abstractmethod

--- a/predicators/bridge_policies/base_bridge_policy.py
+++ b/predicators/bridge_policies/base_bridge_policy.py
@@ -1,0 +1,23 @@
+"""Base class for a bridge policy."""
+
+import abc
+from typing import Set
+
+from predicators.structs import GroundAtom, State, _GroundNSRT, _Option
+
+
+class BaseBridgePolicy(abc.ABC):
+    """Base bridge policy."""
+
+    @classmethod
+    @abc.abstractmethod
+    def get_name(cls) -> str:
+        """Get the unique name of this bridge policy, for future use as the
+        argument to `--bridge_policy`."""
+        raise NotImplementedError("Override me!")
+
+    @abc.abstractmethod
+    def __call__(self, state: State, atoms: Set[GroundAtom],
+                 failed_nsrt: _GroundNSRT) -> _Option:
+        """The main method implementing the bridge policy."""
+        raise NotImplementedError("Override me!")

--- a/predicators/bridge_policies/base_bridge_policy.py
+++ b/predicators/bridge_policies/base_bridge_policy.py
@@ -3,7 +3,11 @@
 import abc
 from typing import Callable, Set
 
-from predicators.structs import GroundAtom, State, _GroundNSRT, _Option, Action
+from predicators.structs import State, _GroundNSRT, Action
+
+
+class BridgePolicyDone(Exception):
+    """Raised when a bridge policy is done executing."""
 
 
 class BaseBridgePolicy(abc.ABC):
@@ -17,7 +21,6 @@ class BaseBridgePolicy(abc.ABC):
         raise NotImplementedError("Override me!")
 
     @abc.abstractmethod
-    def get_policy(self, state: State, atoms: Set[GroundAtom],
-                 failed_nsrt: _GroundNSRT) -> Callable[[State], Action]:
+    def get_policy(self, failed_nsrt: _GroundNSRT) -> Callable[[State], Action]:
         """The main method creating the bridge policy."""
         raise NotImplementedError("Override me!")

--- a/predicators/bridge_policies/base_bridge_policy.py
+++ b/predicators/bridge_policies/base_bridge_policy.py
@@ -3,7 +3,7 @@
 import abc
 from typing import Callable, Set
 
-from predicators.structs import State, _GroundNSRT, Action
+from predicators.structs import Action, State, _GroundNSRT
 
 
 class BridgePolicyDone(Exception):
@@ -21,6 +21,7 @@ class BaseBridgePolicy(abc.ABC):
         raise NotImplementedError("Override me!")
 
     @abc.abstractmethod
-    def get_policy(self, failed_nsrt: _GroundNSRT) -> Callable[[State], Action]:
+    def get_policy(self,
+                   failed_nsrt: _GroundNSRT) -> Callable[[State], Action]:
         """The main method creating the bridge policy."""
         raise NotImplementedError("Override me!")

--- a/predicators/bridge_policies/oracle_bridge_policy.py
+++ b/predicators/bridge_policies/oracle_bridge_policy.py
@@ -71,13 +71,15 @@ def _create_painting_oracle_bridge_policy(
     def _bridge_policy(state: State, atoms: Set[GroundAtom],
                        failed_nsrt: _GroundNSRT) -> _Option:
         del atoms  # not used
-        assert failed_nsrt.name == "PlaceInBox"
-        held_obj, _, robot = failed_nsrt.objects
+
         lid = next(o for o in state if o.type.name == "lid")
 
         # If the box lid is already open, the bridge policy is done.
-        if state.get(lid, "is_open") > 0.5:
+        # Second case should only happen when the shelf placements fail.
+        if state.get(lid, "is_open") > 0.5 or failed_nsrt.name != "PlaceInBox":
             raise BridgePolicyDone()
+
+        held_obj, _, robot = failed_nsrt.objects
 
         if GripperOpen.holds(state, [robot]):
             next_nsrt = OpenLid.ground([lid, robot])

--- a/predicators/bridge_policies/oracle_bridge_policy.py
+++ b/predicators/bridge_policies/oracle_bridge_policy.py
@@ -1,0 +1,41 @@
+"""A hand-written bridge policy."""
+
+from typing import Callable, List, Set
+
+from predicators.bridge_policies import BaseBridgePolicy
+from predicators.envs import BaseEnv
+from predicators.settings import CFG
+from predicators.structs import GroundAtom, State, Task, _GroundNSRT, _Option
+
+
+class OracleBridgePolicy(BaseBridgePolicy):
+    """A hand-written bridge policy."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._oracle_policy = self._create_oracle_policy()
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "oracle"
+
+    @property
+    def is_learning_based(self) -> bool:
+        return False
+
+    def __call__(self, state: State, atoms: Set[GroundAtom],
+                 failed_nsrt: _GroundNSRT) -> _Option:
+        return self._oracle_policy(state, atoms, failed_nsrt)
+
+    def _create_oracle_policy(
+            self) -> Callable[[State, Set[GroundAtom], _GroundNSRT], _Option]:
+        env_name = CFG.env
+        if env_name == "painting":
+            return _painting_oracle_bridge_policy
+        raise NotImplementedError(f"No oracle bridge policy for {env_name}")
+
+
+def _painting_oracle_bridge_policy(state: State, atoms: Set[GroundAtom],
+                                   failed_nsrt: _GroundNSRT) -> _Option:
+    import ipdb
+    ipdb.set_trace()

--- a/predicators/bridge_policies/oracle_bridge_policy.py
+++ b/predicators/bridge_policies/oracle_bridge_policy.py
@@ -54,6 +54,7 @@ def _create_oracle_bridge_policy(env_name: str, nsrts: Set[NSRT],
     if env_name == "painting":
         return _create_painting_oracle_bridge_policy(nsrt_name_to_nsrt,
                                                      pred_name_to_pred, rng)
+
     raise NotImplementedError(f"No oracle bridge policy for {env_name}")
 
 

--- a/predicators/bridge_policies/oracle_bridge_policy.py
+++ b/predicators/bridge_policies/oracle_bridge_policy.py
@@ -1,5 +1,6 @@
 """A hand-written bridge policy."""
 
+import logging
 from typing import Callable, List, Set, Dict
 import numpy as np
 
@@ -79,6 +80,9 @@ def _create_painting_oracle_bridge_policy(nsrt_name_to_nsrt: Dict[str, NSRT], pr
             next_nsrt = OpenLid.ground([lid, robot])
         else:
             next_nsrt = PlaceOnTable.ground([held_obj, robot])
+
+        logging.debug(f"Using NSRT {next_nsrt.name}{next_nsrt.objects} "
+                      "from bridge policy.")
 
         goal = set()  # goal assumed not used by sampler
         return next_nsrt.sample_option(state, goal, rng)

--- a/predicators/bridge_policies/oracle_bridge_policy.py
+++ b/predicators/bridge_policies/oracle_bridge_policy.py
@@ -5,7 +5,7 @@ from typing import Callable, List, Set
 from predicators.bridge_policies import BaseBridgePolicy
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
-from predicators.structs import GroundAtom, State, Task, _GroundNSRT, _Option
+from predicators.structs import GroundAtom, State, Task, _GroundNSRT, _Option, Action
 
 
 class OracleBridgePolicy(BaseBridgePolicy):
@@ -13,7 +13,7 @@ class OracleBridgePolicy(BaseBridgePolicy):
 
     def __init__(self) -> None:
         super().__init__()
-        self._oracle_policy = self._create_oracle_policy()
+        self._oracle_bridge_policy = self._create_oracle_bridge_policy()
 
     @classmethod
     def get_name(cls) -> str:
@@ -23,11 +23,13 @@ class OracleBridgePolicy(BaseBridgePolicy):
     def is_learning_based(self) -> bool:
         return False
 
-    def __call__(self, state: State, atoms: Set[GroundAtom],
-                 failed_nsrt: _GroundNSRT) -> _Option:
-        return self._oracle_policy(state, atoms, failed_nsrt)
+    def get_policy(self, state: State, atoms: Set[GroundAtom],
+                 failed_nsrt: _GroundNSRT) -> Callable[[State], Action]:
+        bridge_policy = self._oracle_bridge_policy(state, atoms, failed_nsrt)
+        # TODO: convert bridge policy into regular policy
+        import ipdb; ipdb.set_trace()
 
-    def _create_oracle_policy(
+    def _create_oracle_bridge_policy(
             self) -> Callable[[State, Set[GroundAtom], _GroundNSRT], _Option]:
         env_name = CFG.env
         if env_name == "painting":

--- a/predicators/bridge_policies/oracle_bridge_policy.py
+++ b/predicators/bridge_policies/oracle_bridge_policy.py
@@ -1,19 +1,28 @@
 """A hand-written bridge policy."""
 
-from typing import Callable, List, Set
+from typing import Callable, List, Set, Dict
+import numpy as np
 
-from predicators.bridge_policies import BaseBridgePolicy
-from predicators.envs import BaseEnv
+from predicators.bridge_policies import BaseBridgePolicy, BridgePolicyDone
+from predicators.envs import BaseEnv, get_or_create_env
 from predicators.settings import CFG
-from predicators.structs import GroundAtom, State, Task, _GroundNSRT, _Option, Action
+from predicators.structs import GroundAtom, State, Task, _GroundNSRT, _Option, Action, BridgePolicy, NSRT, DummyOption, Predicate
+from predicators.ground_truth_models import get_gt_nsrts, get_gt_options
+from predicators import utils
 
 
 class OracleBridgePolicy(BaseBridgePolicy):
     """A hand-written bridge policy."""
 
     def __init__(self) -> None:
+        # TODO initialize with predicates and NSRTs instead
         super().__init__()
-        self._oracle_bridge_policy = self._create_oracle_bridge_policy()
+        env = get_or_create_env(CFG.env)
+        options = get_gt_options(CFG.env)
+        self._predicates = set(env.predicates)
+        self._nsrts = get_gt_nsrts(CFG.env, self._predicates, options)
+        self._rng = np.random.default_rng(CFG.seed)
+        self._oracle_bridge_policy = _create_oracle_bridge_policy(CFG.env, self._nsrts, self._predicates, self._rng)
 
     @classmethod
     def get_name(cls) -> str:
@@ -23,21 +32,55 @@ class OracleBridgePolicy(BaseBridgePolicy):
     def is_learning_based(self) -> bool:
         return False
 
-    def get_policy(self, state: State, atoms: Set[GroundAtom],
-                 failed_nsrt: _GroundNSRT) -> Callable[[State], Action]:
-        bridge_policy = self._oracle_bridge_policy(state, atoms, failed_nsrt)
-        # TODO: convert bridge policy into regular policy
-        import ipdb; ipdb.set_trace()
+    def get_policy(self, failed_nsrt: _GroundNSRT) -> Callable[[State], Action]:
 
-    def _create_oracle_bridge_policy(
-            self) -> Callable[[State, Set[GroundAtom], _GroundNSRT], _Option]:
-        env_name = CFG.env
-        if env_name == "painting":
-            return _painting_oracle_bridge_policy
-        raise NotImplementedError(f"No oracle bridge policy for {env_name}")
+        # Create action policy.
+        cur_option = DummyOption
+
+        def _policy(state: State) -> Action:
+            nonlocal cur_option
+            if cur_option is DummyOption or cur_option.terminal(state):
+                atoms = utils.abstract(state, self._predicates)
+                cur_option = self._oracle_bridge_policy(state, atoms, failed_nsrt)
+                if not cur_option.initiable(state):
+                    raise OptionExecutionFailure("Bridge option not initiable.")
+            act = cur_option.policy(state)
+            return act
+
+        return _policy
 
 
-def _painting_oracle_bridge_policy(state: State, atoms: Set[GroundAtom],
-                                   failed_nsrt: _GroundNSRT) -> _Option:
-    import ipdb
-    ipdb.set_trace()
+def _create_oracle_bridge_policy(env_name: str, nsrts: Set[NSRT], predicates: Set[Predicate], rng: np.random.Generator) -> BridgePolicy:
+    nsrt_name_to_nsrt = {n.name: n for n in nsrts}
+    pred_name_to_pred = {p.name: p for p in predicates}
+
+    if env_name == "painting":
+        return _create_painting_oracle_bridge_policy(nsrt_name_to_nsrt, pred_name_to_pred, rng)
+    raise NotImplementedError(f"No oracle bridge policy for {env_name}")
+
+
+def _create_painting_oracle_bridge_policy(nsrt_name_to_nsrt: Dict[str, NSRT], pred_name_to_pred: Dict[str, Predicate], rng: np.random.Generator) -> BridgePolicy:
+
+    PlaceOnTable = nsrt_name_to_nsrt["PlaceOnTable"]
+    OpenLid = nsrt_name_to_nsrt["OpenLid"]
+
+    GripperOpen = pred_name_to_pred["GripperOpen"]
+
+    def _bridge_policy(state: State, atoms: Set[GroundAtom], failed_nsrt: _GroundNSRT) -> _Option:
+        assert failed_nsrt.name == "PlaceInBox"
+        held_obj, box, robot = failed_nsrt.objects
+        lid = next(o for o in state if o.type.name == "lid")
+
+        # If the box lid is already open, the bridge policy is done.
+        if state.get(lid, "is_open") > 0.5:
+            raise BridgePolicyDone()
+
+        if GripperOpen.holds(state, [robot]):
+            next_nsrt = OpenLid.ground([lid, robot])
+        else:
+            next_nsrt = PlaceOnTable.ground([held_obj, robot])
+
+        goal = set()  # goal assumed not used by sampler
+        return next_nsrt.sample_option(state, goal, rng)
+
+    return _bridge_policy

--- a/predicators/envs/painting.py
+++ b/predicators/envs/painting.py
@@ -213,6 +213,8 @@ class PaintingEnv(BaseEnv):
             return next_state
         if receptacle == "box" and state.get(self._lid, "is_open") < 0.5:
             # Cannot place in box if lid is not open
+            import ipdb
+            ipdb.set_trace()
             raise utils.EnvironmentFailure("Box lid is closed.",
                                            {"offending_objects": {self._lid}})
         # Detect top grasp vs side grasp

--- a/predicators/envs/painting.py
+++ b/predicators/envs/painting.py
@@ -213,8 +213,6 @@ class PaintingEnv(BaseEnv):
             return next_state
         if receptacle == "box" and state.get(self._lid, "is_open") < 0.5:
             # Cannot place in box if lid is not open
-            import ipdb
-            ipdb.set_trace()
             raise utils.EnvironmentFailure("Box lid is closed.",
                                            {"offending_objects": {self._lid}})
         # Detect top grasp vs side grasp

--- a/predicators/envs/painting.py
+++ b/predicators/envs/painting.py
@@ -19,6 +19,7 @@ from predicators.envs import BaseEnv
 from predicators.settings import CFG
 from predicators.structs import Action, EnvironmentTask, GroundAtom, Object, \
     Predicate, State, Type
+from predicators.utils import EnvironmentFailure
 
 
 class PaintingEnv(BaseEnv):
@@ -213,8 +214,11 @@ class PaintingEnv(BaseEnv):
             return next_state
         if receptacle == "box" and state.get(self._lid, "is_open") < 0.5:
             # Cannot place in box if lid is not open
-            raise utils.EnvironmentFailure("Box lid is closed.",
-                                           {"offending_objects": {self._lid}})
+            if CFG.painting_raise_environment_failure:
+                raise EnvironmentFailure("Box lid is closed.",
+                                         {"offending_objects": {self._lid}})
+            else:
+                return next_state
         # Detect top grasp vs side grasp
         grasp = state.get(held_obj, "grasp")
         if grasp > self.top_grasp_thresh:

--- a/predicators/envs/painting.py
+++ b/predicators/envs/painting.py
@@ -14,7 +14,6 @@ import numpy as np
 from gym.spaces import Box
 from matplotlib import patches
 
-from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
 from predicators.structs import Action, EnvironmentTask, GroundAtom, Object, \
@@ -217,8 +216,7 @@ class PaintingEnv(BaseEnv):
             if CFG.painting_raise_environment_failure:
                 raise EnvironmentFailure("Box lid is closed.",
                                          {"offending_objects": {self._lid}})
-            else:
-                return next_state
+            return next_state
         # Detect top grasp vs side grasp
         grasp = state.get(held_obj, "grasp")
         if grasp > self.top_grasp_thresh:

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -91,6 +91,7 @@ class GlobalSettings:
     painting_num_objs_test = [3, 4]
     painting_max_objs_in_goal = float("inf")
     painting_goal_receptacles = "box_and_shelf"  # box_and_shelf, box, shelf
+    painting_raise_environment_failure = True
 
     # repeated_nextto_painting (rnt_painting) env parameters
     rnt_painting_num_objs_train = [8, 9, 10]

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -511,6 +511,9 @@ class GlobalSettings:
     cnn_refinement_estimator_crop_bounds = (320, 400, 100, 650)
     cnn_refinement_estimator_downsample = 2
 
+    # bridge policy parameters
+    bridge_policy = "oracle"  # default bridge policy
+
     # glib explorer parameters
     glib_min_goal_size = 1
     glib_max_goal_size = 1

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -1624,3 +1624,4 @@ ParameterizedTerminal = Callable[[State, Dict, Sequence[Object], Array], bool]
 AbstractPolicy = Callable[[Set[GroundAtom], Set[Object], Set[GroundAtom]],
                           Optional[_GroundNSRT]]
 RGBA = Tuple[float, float, float, float]
+BridgePolicy = Callable[[State, Set[GroundAtom], _GroundNSRT], _Option]

--- a/tests/approaches/test_bridge_policy_approach.py
+++ b/tests/approaches/test_bridge_policy_approach.py
@@ -1,9 +1,16 @@
 """Test cases for the BridgePolicyApproach class."""
+
+from unittest.mock import patch
+
+import predicators.bridge_policies.oracle_bridge_policy
 from predicators import utils
 from predicators.approaches.bridge_policy_approach import BridgePolicyApproach
+from predicators.bridge_policies import BridgePolicyDone
 from predicators.envs import get_or_create_env
 from predicators.ground_truth_models import get_gt_options
 from predicators.settings import CFG
+
+_MODULE_PATH = predicators.bridge_policies.oracle_bridge_policy.__name__
 
 
 def test_bridge_policy_approach():
@@ -24,11 +31,29 @@ def test_bridge_policy_approach():
                                     get_gt_options(env.get_name()), env.types,
                                     env.action_space, train_tasks)
     assert approach.get_name() == "bridge_policy"
-    for task in test_tasks:
+    task = test_tasks[0]
+    policy = approach.solve(task, timeout=500)
+    traj = utils.run_policy_with_simulator(policy,
+                                           env.simulate,
+                                           task.init,
+                                           task.goal_holds,
+                                           max_num_steps=CFG.horizon)
+    assert task.goal_holds(traj.states[-1])
+
+    # Test case where bridge policy hands back control to planner immediately.
+    # The policy should get stuck and not achieve the goal, but not crash.
+    def done_option_policy(s):
+        del s  # ununsed
+        raise BridgePolicyDone()
+
+    with patch(f"{_MODULE_PATH}.OracleBridgePolicy.get_policy") as m:
+        m.return_value = done_option_policy
         policy = approach.solve(task, timeout=500)
         traj = utils.run_policy_with_simulator(policy,
                                                env.simulate,
                                                task.init,
                                                task.goal_holds,
-                                               max_num_steps=CFG.horizon)
-        assert task.goal_holds(traj.states[-1])
+                                               max_num_steps=25)
+        assert not task.goal_holds(traj.states[-1])
+        for t in range(-1, -5, 1):
+            assert traj.actions[t].get_option().name == "Place"

--- a/tests/approaches/test_bridge_policy_approach.py
+++ b/tests/approaches/test_bridge_policy_approach.py
@@ -1,0 +1,39 @@
+"""Test cases for the BridgePolicyApproach class."""
+from predicators import utils
+from predicators.approaches.bridge_policy_approach import BridgePolicyApproach
+from predicators.envs import get_or_create_env
+from predicators.ground_truth_models import get_gt_options
+from predicators.settings import CFG
+
+
+def _policy_solves_task(policy, task, simulator):
+    """Helper method used in this file, copied from test_oracle_approach.py."""
+    traj = utils.run_policy_with_simulator(policy,
+                                           simulator,
+                                           task.init,
+                                           task.goal_holds,
+                                           max_num_steps=CFG.horizon)
+    return task.goal_holds(traj.states[-1])
+
+
+def test_bridge_policy_approach():
+    """Tests for BridgePolicyApproach class."""
+    args = {
+        "refinement_estimator": "bridge_policy",
+        "env": "painting",
+        "painting_lid_open_prob": 0.0,
+        "painting_raise_environment_failure": False,
+        "num_train_tasks": 0,
+        "num_test_tasks": 1,
+    }
+    utils.reset_config(args)
+    env = get_or_create_env(CFG.env)
+    train_tasks = [t.task for t in env.get_train_tasks()]
+    test_tasks = [t.task for t in env.get_test_tasks()]
+    approach = BridgePolicyApproach(env.predicates,
+                                    get_gt_options(env.get_name()), env.types,
+                                    env.action_space, train_tasks)
+    assert approach.get_name() == "bridge_policy"
+    for task in test_tasks:
+        policy = approach.solve(task, timeout=500)
+        assert _policy_solves_task(policy, task, env.simulate)

--- a/tests/approaches/test_bridge_policy_approach.py
+++ b/tests/approaches/test_bridge_policy_approach.py
@@ -2,8 +2,8 @@
 
 from unittest.mock import patch
 
-import pytest
 import numpy as np
+import pytest
 
 import predicators.approaches.bridge_policy_approach
 import predicators.bridge_policies.oracle_bridge_policy
@@ -13,8 +13,8 @@ from predicators.approaches.bridge_policy_approach import BridgePolicyApproach
 from predicators.bridge_policies import BridgePolicyDone
 from predicators.envs import get_or_create_env
 from predicators.ground_truth_models import get_gt_options
-from predicators.structs import DummyOption, STRIPSOperator
 from predicators.settings import CFG
+from predicators.structs import DummyOption, STRIPSOperator
 
 _APPROACH_PATH = predicators.approaches.bridge_policy_approach.__name__
 _ORACLE_BRIDGE_PATH = predicators.bridge_policies.oracle_bridge_policy.__name__

--- a/tests/approaches/test_bridge_policy_approach.py
+++ b/tests/approaches/test_bridge_policy_approach.py
@@ -6,16 +6,6 @@ from predicators.ground_truth_models import get_gt_options
 from predicators.settings import CFG
 
 
-def _policy_solves_task(policy, task, simulator):
-    """Helper method used in this file, copied from test_oracle_approach.py."""
-    traj = utils.run_policy_with_simulator(policy,
-                                           simulator,
-                                           task.init,
-                                           task.goal_holds,
-                                           max_num_steps=CFG.horizon)
-    return task.goal_holds(traj.states[-1])
-
-
 def test_bridge_policy_approach():
     """Tests for BridgePolicyApproach class."""
     args = {
@@ -36,4 +26,9 @@ def test_bridge_policy_approach():
     assert approach.get_name() == "bridge_policy"
     for task in test_tasks:
         policy = approach.solve(task, timeout=500)
-        assert _policy_solves_task(policy, task, env.simulate)
+        traj = utils.run_policy_with_simulator(policy,
+                                               env.simulate,
+                                               task.init,
+                                               task.goal_holds,
+                                               max_num_steps=CFG.horizon)
+        assert task.goal_holds(traj.states[-1])

--- a/tests/bridge_policies/test_base_bridge_policy.py
+++ b/tests/bridge_policies/test_base_bridge_policy.py
@@ -1,0 +1,21 @@
+"""Test cases for the base bridge policy class."""
+
+import pytest
+
+from predicators import utils
+from predicators.bridge_policies import BaseBridgePolicy, create_bridge_policy
+from predicators.envs import get_or_create_env
+from predicators.ground_truth_models import get_gt_nsrts, get_gt_options
+
+
+def test_bridge_policy_creation():
+    """Tests for create_bridge_policy()."""
+    utils.reset_config({"env": "painting"})
+    env = get_or_create_env("painting")
+    options = get_gt_options("painting")
+    nsrts = get_gt_nsrts("painting", env.predicates, options)
+    bridge_policy = create_bridge_policy("oracle", env.predicates, nsrts)
+    assert isinstance(bridge_policy, BaseBridgePolicy)
+    assert bridge_policy.get_name() == "oracle"
+    with pytest.raises(NotImplementedError):
+        create_bridge_policy("not a real bridge policy", env.predicates, nsrts)

--- a/tests/bridge_policies/test_oracle_bridge_policy.py
+++ b/tests/bridge_policies/test_oracle_bridge_policy.py
@@ -1,0 +1,53 @@
+"""Test cases for the oracle bridge policy class."""
+
+import numpy as np
+import pytest
+
+from predicators import utils
+from predicators.bridge_policies.oracle_bridge_policy import \
+    OracleBridgePolicy, _create_oracle_bridge_policy
+from predicators.envs import get_or_create_env
+from predicators.ground_truth_models import get_gt_nsrts, get_gt_options
+from predicators.settings import CFG
+
+
+def test_oracle_bridge_policy():
+    """Tests for OracleBridgePolicy."""
+    utils.reset_config({"env": "painting"})
+    env = get_or_create_env("painting")
+    options = get_gt_options("painting")
+    nsrts = get_gt_nsrts("painting", env.predicates, options)
+    bridge_policy = OracleBridgePolicy(env.predicates, nsrts)
+    rng = np.random.default_rng(123)
+
+    nsrt_name_to_nsrt = {n.name: n for n in nsrts}
+    test_tasks = [t.task for t in env.get_test_tasks()]
+    task = test_tasks[0]
+    state = task.init
+    held_obj = next(o for o in state if o.type.name == "obj")
+    box = next(o for o in state if o.type.name == "box")
+    robot = next(o for o in state if o.type.name == "robot")
+    failed_nsrt = nsrt_name_to_nsrt["PlaceInBox"].ground(
+        [held_obj, box, robot])
+    invalid_nsrt = nsrt_name_to_nsrt["PickFromTop"].ground([held_obj, robot])
+
+    # Test case where bridge policy returns an invalid option.
+    def invalid_option_policy(s, a, failed_nsrt):
+        del a, failed_nsrt  # ununsed
+        option = invalid_nsrt.sample_option(s, set(), rng)
+        return option
+
+    bridge_policy._oracle_bridge_policy = invalid_option_policy  # pylint: disable=protected-access
+
+    policy = bridge_policy.get_policy(failed_nsrt)
+    traj = utils.run_policy_with_simulator(policy,
+                                           env.simulate,
+                                           task.init,
+                                           task.goal_holds,
+                                           max_num_steps=CFG.horizon)
+    # Goal not achieved, but should not crash.
+    assert not task.goal_holds(traj.states[-1])
+
+    with pytest.raises(NotImplementedError):
+        _create_oracle_bridge_policy("not a real env", nsrts, env.predicates,
+                                     rng)


### PR DESCRIPTION
solving painting without a simulator! also, as a bonus, solving much larger painting problems than ever before possible (see below).

example:

```python predicators/main.py --env painting --approach bridge_policy --seed 0 --painting_lid_open_prob 0.0 --painting_raise_environment_failure False --debug```

leads to

```
Using NSRT PickFromSide(obj0:obj, robby:robot) from planner.
Using NSRT Wash(obj0:obj, robby:robot) from planner.
Using NSRT Dry(obj0:obj, robby:robot) from planner.
Using NSRT PaintToShelf(obj0:obj, receptacle_shelf:shelf, robby:robot) from planner.
Using NSRT PlaceInShelf(obj0:obj, receptacle_shelf:shelf, robby:robot) from planner.
Using NSRT PickFromTop(obj2:obj, robby:robot) from planner.
Using NSRT PaintToBox(obj2:obj, receptacle_box:box, robby:robot) from planner.
Using NSRT PlaceInBox(obj2:obj, receptacle_box:box, robby:robot) from planner.
Failed NSRT: PlaceInBox(obj2:obj, receptacle_box:box, robby:robot).
Switching control from planner to bridge.
Using NSRT PlaceOnTable[obj2:obj, robby:robot] from bridge policy.
Using NSRT OpenLid[box_lid:lid, robby:robot] from bridge policy.
Switching control from bridge to planner.
Using NSRT PickFromTop(obj2:obj, robby:robot) from planner.
Using NSRT PlaceInBox(obj2:obj, receptacle_box:box, robby:robot) from planner.
Using NSRT PickFromSide(obj1:obj, robby:robot) from planner.
Using NSRT Dry(obj1:obj, robby:robot) from planner.
Using NSRT PaintToShelf(obj1:obj, receptacle_shelf:shelf, robby:robot) from planner.
Using NSRT PlaceInShelf(obj1:obj, receptacle_shelf:shelf, robby:robot) from planner.
Task 1 / 50: SOLVED
```

and 50/50 solved.

also, we can use fast downward and solve problems with 50 objects no problem (each test task < 1s).

```
python predicators/main.py --env painting --approach bridge_policy --seed 0 --painting_lid_open_prob 0.0 --painting_raise_environment_failure False --painting_num_objs_test '[50]' --sesame_task_planner fdsat --horizon 10000
```

gets 50/50. for reference, planning with oracle with 10 objects times out (with the default timeout of 10s per task).

this improvement is for two reasons:
1. we can use fast downward now
2. we only need to run the planner twice per problem in this example, so we're only ever considering two skeletons
