### PR TITLE
updates to painting and stick button environment for bridge approaches

### DIFF
--- a/predicators/envs/painting.py
+++ b/predicators/envs/painting.py
@@ -99,6 +99,8 @@ class PaintingEnv(BaseEnv):
                                   self._IsDirty_holds)
         self._IsClean = Predicate("IsClean", [self._obj_type],
                                   self._IsClean_holds)
+        self._IsOpen = Predicate("IsOpen", [self._lid_type],
+                                 self._IsOpen_holds)
         # Static objects (always exist no matter the settings).
         self._box = Object("receptacle_box", self._box_type)
         self._lid = Object("box_lid", self._lid_type)
@@ -283,7 +285,7 @@ class PaintingEnv(BaseEnv):
             self._InBox, self._InShelf, self._IsBoxColor, self._IsShelfColor,
             self._GripperOpen, self._OnTable, self._NotOnTable,
             self._HoldingTop, self._HoldingSide, self._Holding, self._IsWet,
-            self._IsDry, self._IsDirty, self._IsClean
+            self._IsDry, self._IsDirty, self._IsClean, self._IsOpen
         }
 
     @property
@@ -616,6 +618,10 @@ class PaintingEnv(BaseEnv):
     def _IsClean_holds(self, state: State, objects: Sequence[Object]) -> bool:
         obj, = objects
         return not self._IsDirty_holds(state, [obj])
+
+    def _IsOpen_holds(self, state: State, objects: Sequence[Object]) -> bool:
+        lid, = objects
+        return state.get(lid, "is_open") > 0.5
 
     def _get_held_object(self, state: State) -> Optional[Object]:
         for obj in state:

--- a/predicators/ground_truth_models/painting/nsrts.py
+++ b/predicators/ground_truth_models/painting/nsrts.py
@@ -45,6 +45,7 @@ class PaintingGroundTruthNSRTFactory(GroundTruthNSRTFactory):
         IsDry = predicates["IsDry"]
         IsDirty = predicates["IsDirty"]
         IsClean = predicates["IsClean"]
+        IsOpen = predicates["IsOpen"]
 
         # Options
         Pick = options["Pick"]
@@ -332,7 +333,7 @@ class PaintingGroundTruthNSRTFactory(GroundTruthNSRTFactory):
         option_vars = [robot, lid]
         option = OpenLid
         preconditions = {LiftedAtom(GripperOpen, [robot])}
-        add_effects = set()
+        add_effects = {LiftedAtom(IsOpen, [lid])}
         delete_effects = set()
 
         openlid_nsrt = NSRT("OpenLid", parameters, preconditions, add_effects,

--- a/tests/envs/test_painting.py
+++ b/tests/envs/test_painting.py
@@ -23,7 +23,7 @@ def test_painting():
     for task in env.get_test_tasks():
         for obj in task.init:
             assert len(obj.type.feature_names) == len(task.init[obj])
-    assert len(env.predicates) == 14
+    assert len(env.predicates) == 15
     assert {pred.name for pred in env.goal_predicates} == \
         {"InBox", "IsBoxColor", "InShelf", "IsShelfColor"}
     assert len(get_gt_options(env.get_name())) == 6

--- a/tests/envs/test_repeated_nextto_painting.py
+++ b/tests/envs/test_repeated_nextto_painting.py
@@ -18,7 +18,7 @@ def test_repeated_nextto_painting():
     for task in env.get_test_tasks():
         for obj in task.init:
             assert len(obj.type.feature_names) == len(task.init[obj])
-    assert len(env.predicates) == 18
+    assert len(env.predicates) == 19
     assert {pred.name for pred in env.goal_predicates} == \
         {"InBox", "IsBoxColor", "InShelf", "IsShelfColor"}
     assert len(get_gt_options(env.get_name())) == 9

--- a/tests/envs/test_stick_button.py
+++ b/tests/envs/test_stick_button.py
@@ -6,7 +6,7 @@ import pytest
 
 from predicators import utils
 from predicators.envs.stick_button import StickButtonEnv
-from predicators.ground_truth_models import get_gt_options
+from predicators.ground_truth_models import get_gt_nsrts, get_gt_options
 from predicators.structs import Action, EnvironmentTask, GroundAtom
 
 
@@ -29,7 +29,7 @@ def test_stick_button():
     assert len(env.goal_predicates) == 1
     AboveNoButton = [p for p in env.predicates if p.name == "AboveNoButton"][0]
     assert {pred.name for pred in env.goal_predicates} == {"Pressed"}
-    assert len(get_gt_options(env.get_name())) == 3
+    assert len(get_gt_options(env.get_name())) == 4
     assert len(env.types) == 4
     button_type, holder_type, robot_type, stick_type = sorted(env.types)
     assert button_type.name == "button"
@@ -167,9 +167,10 @@ def test_stick_button():
 
     ## Test options ##
 
-    PickStick, RobotPressButton, StickPressButton = sorted(
-        get_gt_options(env.get_name()))
+    options = get_gt_options(env.get_name())
+    PickStick, PlaceStick, RobotPressButton, StickPressButton = sorted(options)
     assert PickStick.name == "PickStick"
+    assert PlaceStick.name == "PlaceStick"
     assert RobotPressButton.name == "RobotPressButton"
     assert StickPressButton.name == "StickPressButton"
 
@@ -217,6 +218,21 @@ def test_stick_button():
         exceptions_to_break_on={utils.OptionExecutionFailure})
     assert traj.states[-2].get(unreachable_button, "pressed") < 0.5
     assert traj.states[-1].get(unreachable_button, "pressed") > 0.5
+
+    # Test PlaceStick.
+    option = PlaceStick.ground([robot, stick], [-0.1])
+    option_plan.append(option)
+
+    policy = utils.option_plan_to_policy(option_plan)
+    traj = utils.run_policy_with_simulator(
+        policy,
+        env.simulate,
+        task.init,
+        lambda _: False,
+        max_num_steps=1000,
+        exceptions_to_break_on={utils.OptionExecutionFailure})
+    assert traj.states[-2].get(stick, "held") > 0.5
+    assert traj.states[-1].get(stick, "held") < 0.5
 
     # Uncomment for debugging.
     # policy = utils.option_plan_to_policy(option_plan)
@@ -277,3 +293,11 @@ def test_stick_button():
     event.ydata = event.y
     assert isinstance(event_to_action(state, event), Action)
     plt.close()
+
+    # Special test for PlaceStick NSRT because it's not used by oracle.
+    nsrts = get_gt_nsrts(env.get_name(), env.predicates, options)
+    PlaceStick = next(iter(n for n in nsrts if n.name == "PlaceStick"))
+    ground_nsrt = PlaceStick.ground([robot, stick])
+    rng = np.random.default_rng(123)
+    option = ground_nsrt.sample_option(state, set(), rng)
+    assert -1 <= option.params[0] <= 1

--- a/tests/envs/test_stick_button.py
+++ b/tests/envs/test_stick_button.py
@@ -296,8 +296,8 @@ def test_stick_button():
 
     # Special test for PlaceStick NSRT because it's not used by oracle.
     nsrts = get_gt_nsrts(env.get_name(), env.predicates, options)
-    PlaceStick = next(iter(n for n in nsrts if n.name == "PlaceStick"))
-    ground_nsrt = PlaceStick.ground([robot, stick])
+    nsrt = next(iter(n for n in nsrts if n.name == "PlaceStickFromNothing"))
+    ground_nsrt = nsrt.ground([robot, stick])
     rng = np.random.default_rng(123)
     option = ground_nsrt.sample_option(state, set(), rng)
     assert -1 <= option.params[0] <= 1


### PR DESCRIPTION
two changes: (1) in painting, adding an `IsOpen(?lid)` predicate; (2) in stick button, adding the ability to place a stick back in the holder.

imo the stick button change is fine, although we'll have to make sure that the nightly experiments are unaffected. it's possible that the new NSRTs will slow down oracle planning a bit, but as long as it's not a major disaster, it's worth it.

the painting change is a bit sketchier. the reason for the change is that if nothing changes in the abstract state after the bridge policy executes opening the lid, there's no way for the bridge policy to realize that it's "done". what would happen without this new predicate is that the bridge policy would try to open the lid again, and it would fail and return control back to the planner. this would be kinda fine, but it's ugly to see two open lids happening consecutively in the "oracle" bridge policy. there are other ways that we could potentially address this, but I think just adding a `IsOpen(?lid)` predicate is fine. note that the learned operator for placing in the box will still be missing the precondition of the box lid being open because the `?lid` is a separate object from the `?box`. (I verified this by running `python predicators/main.py --env painting --approach nsrt_learning --seed 0` and inspecting the learned NSRTs and seeing that multiple skeletons are needed during planning still).