### PR TITLE
a few new flags for exit garage environment

### DIFF
--- a/predicators/envs/exit_garage.py
+++ b/predicators/envs/exit_garage.py
@@ -125,7 +125,7 @@ class ExitGarageEnv(BaseEnv):
             if collision and CFG.exit_garage_raise_environment_failure:
                 raise utils.EnvironmentFailure(
                     "Collision", info={"offending_objects": {collision_obj}})
-            # tf there is a collision or out-of-bounds, revert the move
+            # If there is a collision or out-of-bounds, revert the move
             if collision or self.coords_out_of_bounds(cx + dx, cy + dy):
                 next_state.set(self._car, "x", cx)
                 next_state.set(self._car, "y", cy)

--- a/predicators/envs/exit_garage.py
+++ b/predicators/envs/exit_garage.py
@@ -119,9 +119,14 @@ class ExitGarageEnv(BaseEnv):
             next_state.set(self._car, "x", cx + dx)
             next_state.set(self._car, "y", cy + dy)
             next_state.set(self._car, "theta", new_theta)
-            # If this causes a collision, revert the movement
-            if self.car_has_collision(next_state) or \
-                    self.coords_out_of_bounds(cx + dx, cy + dy):
+            # If this causes a collision, optionally raise failure
+            collision_obj = self.get_car_collision_object(next_state)
+            collision = collision_obj is not None
+            if collision and CFG.exit_garage_raise_environment_failure:
+                raise utils.EnvironmentFailure(
+                    "Collision", info={"offending_objects": {collision_obj}})
+            # tf there is a collision or out-of-bounds, revert the move
+            if collision or self.coords_out_of_bounds(cx + dx, cy + dy):
                 next_state.set(self._car, "x", cx)
                 next_state.set(self._car, "y", cy)
                 next_state.set(self._car, "theta", theta)
@@ -368,9 +373,8 @@ class ExitGarageEnv(BaseEnv):
         return True
 
     @classmethod
-    def car_has_collision(cls, state: State) -> bool:
-        """Returns True if the car has collided with the storage area or any
-        obstacle.
+    def get_car_collision_object(cls, state: State) -> Optional[Object]:
+        """Returns the object that the car has collided with, or None.
 
         This is made public because it is used both in simulate and in
         the externally-defined ground-truth options.
@@ -381,7 +385,7 @@ class ExitGarageEnv(BaseEnv):
         storage, = state.get_objects(cls._storage_type)
         storage_geom = cls._object_to_geom(storage, state)
         if car_geom.intersects(storage_geom):
-            return True
+            return storage
         # Check for collisions with obstacles
         for obstacle in state.get_objects(cls._obstacle_type):
             # Ignore this obstacle if it is being carried by the robot
@@ -389,8 +393,8 @@ class ExitGarageEnv(BaseEnv):
                 continue
             obstacle_geom = cls._object_to_geom(obstacle, state)
             if car_geom.intersects(obstacle_geom):
-                return True
-        return False
+                return obstacle
+        return None
 
     @classmethod
     def _placed_object_collides(cls, state: State, new_x: float,

--- a/predicators/ground_truth_models/exit_garage/__init__.py
+++ b/predicators/ground_truth_models/exit_garage/__init__.py
@@ -1,10 +1,8 @@
 """Ground-truth models for exit garage environment and variants."""
 
-from .ldl_bridge_policy import ExitGarageLDLBridgePolicyFactory
 from .nsrts import ExitGarageGroundTruthNSRTFactory
 from .options import ExitGarageGroundTruthOptionFactory
 
 __all__ = [
-    "ExitGarageGroundTruthNSRTFactory", "ExitGarageGroundTruthOptionFactory",
-    "ExitGarageLDLBridgePolicyFactory"
+    "ExitGarageGroundTruthNSRTFactory", "ExitGarageGroundTruthOptionFactory"
 ]

--- a/predicators/ground_truth_models/exit_garage/__init__.py
+++ b/predicators/ground_truth_models/exit_garage/__init__.py
@@ -1,8 +1,10 @@
 """Ground-truth models for exit garage environment and variants."""
 
+from .ldl_bridge_policy import ExitGarageLDLBridgePolicyFactory
 from .nsrts import ExitGarageGroundTruthNSRTFactory
 from .options import ExitGarageGroundTruthOptionFactory
 
 __all__ = [
-    "ExitGarageGroundTruthNSRTFactory", "ExitGarageGroundTruthOptionFactory"
+    "ExitGarageGroundTruthNSRTFactory", "ExitGarageGroundTruthOptionFactory",
+    "ExitGarageLDLBridgePolicyFactory"
 ]

--- a/predicators/ground_truth_models/exit_garage/options.py
+++ b/predicators/ground_truth_models/exit_garage/options.py
@@ -222,14 +222,18 @@ class ExitGarageGroundTruthOptionFactory(GroundTruthOptionFactory):
         def _collision_fn(pt: Array) -> bool:
             # Check for collision of car in non-holonomic case
             x, y, theta = pt
-            # Make a hypothetical state for the car at this point and check
-            # if there would be collisions.
-            s = state.copy()
-            s.set(move_obj, "x", x)
-            s.set(move_obj, "y", y)
-            s.set(move_obj, "theta", theta)
-            return ExitGarageEnv.car_has_collision(
-                s) or ExitGarageEnv.coords_out_of_bounds(x, y)
+            if ExitGarageEnv.coords_out_of_bounds(x, y):
+                return True
+            if not CFG.exit_garage_motion_planning_ignore_obstacles:
+                # Make a hypothetical state for the car at this point and check
+                # if there would be collisions.
+                s = state.copy()
+                s.set(move_obj, "x", x)
+                s.set(move_obj, "y", y)
+                s.set(move_obj, "theta", theta)
+                if ExitGarageEnv.get_car_collision_object(s) is not None:
+                    return True
+            return False
 
         rrt = utils.RRT(
             _sample_fn,

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -296,6 +296,8 @@ class GlobalSettings:
     exit_garage_rrt_num_attempts = 10
     exit_garage_rrt_num_iters = 100
     exit_garage_rrt_sample_goal_eps = 0.1
+    exit_garage_motion_planning_ignore_obstacles = False
+    exit_garage_raise_environment_failure = False
 
     # coffee env parameters
     coffee_num_cups_train = [1, 2]

--- a/tests/envs/test_exit_garage.py
+++ b/tests/envs/test_exit_garage.py
@@ -233,8 +233,8 @@ def test_exit_garage_collisions(raise_env_failure):
         with pytest.raises(utils.EnvironmentFailure) as e:
             for _ in range(50):
                 state = env.simulate(state, drive_car_action)
-            assert "Collision" in str(e)
-            assert e.info["offending_objects"] == {obstacle}
+        assert "Collision" in str(e)
+        assert e.value.info["offending_objects"] == {obstacle}
     else:
         for _ in range(50):
             state = env.simulate(state, drive_car_action)
@@ -256,8 +256,8 @@ def test_exit_garage_collisions(raise_env_failure):
         with pytest.raises(utils.EnvironmentFailure) as e:
             for _ in range(50):
                 state = env.simulate(state, drive_car_action)
-            assert "Collision" in str(e)
-            assert e.info["offending_objects"] == {storage}
+        assert "Collision" in str(e)
+        assert e.value.info["offending_objects"] == {storage}
     else:
         for _ in range(50):
             state = env.simulate(state, drive_car_action)

--- a/tests/envs/test_exit_garage.py
+++ b/tests/envs/test_exit_garage.py
@@ -1,6 +1,7 @@
 """Test cases for the exit_garage environment."""
 
 import numpy as np
+import pytest
 
 from predicators import utils
 from predicators.envs.exit_garage import ExitGarageEnv
@@ -181,16 +182,23 @@ def test_exit_garage_actions():
     env.render_state(traj.states[-1], task)  # state at end
 
 
-def test_exit_garage_collisions():
+@pytest.mark.parametrize("raise_env_failure", (True, False))
+def test_exit_garage_collisions(raise_env_failure):
     """Test that the car can't go through obstacles or storage area."""
     utils.reset_config({
-        "env": "exit_garage",
-        "exit_garage_min_num_obstacles": 1,
-        "exit_garage_max_num_obstacles": 1,
-        "num_train_tasks": 1,
+        "env":
+        "exit_garage",
+        "exit_garage_min_num_obstacles":
+        1,
+        "exit_garage_max_num_obstacles":
+        1,
+        "num_train_tasks":
+        1,
+        "exit_garage_raise_environment_failure":
+        raise_env_failure,
     })
     env = ExitGarageEnv()
-    car_type, obstacle_type, robot_type, _ = sorted(env.types)
+    car_type, obstacle_type, robot_type, storage_type = sorted(env.types)
 
     # Create sample state
     sample_task = env.get_train_tasks()[0].task
@@ -221,10 +229,17 @@ def test_exit_garage_collisions():
     state.set(obstacle, "x", 0.5)
     state.set(obstacle, "y", 0.32)
     drive_car_action = Action(np.array([0.099, 0, 0, 0, 0]).astype(np.float32))
-    for _ in range(50):
-        state = env.simulate(state, drive_car_action)
-    # Make sure car didn't go past obstacle
-    assert state.get(car, "x") < 0.5
+    if raise_env_failure:
+        with pytest.raises(utils.EnvironmentFailure) as e:
+            for _ in range(50):
+                state = env.simulate(state, drive_car_action)
+            assert "Collision" in str(e)
+            assert e.info["offending_objects"] == {obstacle}
+    else:
+        for _ in range(50):
+            state = env.simulate(state, drive_car_action)
+        # Make sure car didn't go past obstacle
+        assert state.get(car, "x") < 0.5
 
     # Test car can go past if obstacle is picked up
     state.set(obstacle, "carried", 1)
@@ -236,10 +251,18 @@ def test_exit_garage_collisions():
     state.set(car, "x", 0.15)
     state.set(car, "y", 0.3)
     state.set(car, "theta", np.pi / 2.0)  # pointed up
-    for _ in range(50):
-        state = env.simulate(state, drive_car_action)
-    # Make sure car stopped before storage area
-    assert 0.5 <= state.get(car, "y") <= 0.8
+    storage, = state.get_objects(storage_type)
+    if raise_env_failure:
+        with pytest.raises(utils.EnvironmentFailure) as e:
+            for _ in range(50):
+                state = env.simulate(state, drive_car_action)
+            assert "Collision" in str(e)
+            assert e.info["offending_objects"] == {storage}
+    else:
+        for _ in range(50):
+            state = env.simulate(state, drive_car_action)
+        # Make sure car stopped before storage area
+        assert 0.5 <= state.get(car, "y") <= 0.8
 
 
 def test_exit_garage_options():


### PR DESCRIPTION
because I want to use the environment for some bridge policy stuff. these changes should have no effect on the existing code unless you pass in new flags.

there are two new flags:
1. if `--exit_garage_raise_environment_failure True`, then an `EnvironmentFailure` is raised when the car collides with an object.
2. if `--exit_garage_motion_planning_ignore_obstacles True`, then the motion planner does not take into account the obstacles at all.

together, the idea is that we'll make an optimistic plan that ignores the obstacles and then use a bridge policy to store the obstacles when an EnvironmentFailure is encountered.