### PR TITLE
Clustering pred invention clean

### DIFF
--- a/predicators/approaches/bridge_policy_approach.py
+++ b/predicators/approaches/bridge_policy_approach.py
@@ -308,7 +308,9 @@ class BridgePolicyApproach(OracleApproach):
             for nsrt in nsrts:
                 for ground_nsrt in utils.all_ground_nsrts(nsrt, objects):
                     add_atoms = frozenset(ground_nsrt.add_effects)
-                    effects_to_ground_nsrt[add_atoms] = ground_nsrt
+                    del_atoms = frozenset(ground_nsrt.delete_effects)
+                    ground_effects = (add_atoms, del_atoms)
+                    effects_to_ground_nsrt[ground_effects] = ground_nsrt
 
             # Collect the irrational transitions and turn atom changes into
             # ground NSRTs.
@@ -319,8 +321,10 @@ class BridgePolicyApproach(OracleApproach):
                 # Step was irrational, so include it.
                 # Assume all changes were necessary; we don't know otherwise.
                 add_atoms = frozenset(atoms[t + 1] - atoms[t])
+                del_atoms = frozenset(atoms[t] - atoms[t + 1])
+                ground_effects = (add_atoms, del_atoms)
                 try:
-                    ground_nsrt = effects_to_ground_nsrt[add_atoms]
+                    ground_nsrt = effects_to_ground_nsrt[ground_effects]
                 except KeyError:  # pragma: no cover
                     logging.warning("WARNING: no NSRT found for add atoms "
                                     f"{add_atoms}. Skipping transition.")

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -22,7 +22,7 @@ from predicators.predicate_search_score_functions import \
     _PredicateSearchScoreFunction, create_score_function
 from predicators.settings import CFG
 from predicators.structs import Dataset, GroundAtom, GroundAtomTrajectory, \
-    Object, ParameterizedOption, Predicate, State, Task, Type
+    Object, ParameterizedOption, Predicate, Segment, State, Task, Type
 
 ################################################################################
 #                          Programmatic classifiers                            #
@@ -774,7 +774,8 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
         # Select a subset of the candidates to keep.
         logging.info("Selecting a subset...")
         if CFG.grammar_search_pred_selection_approach == "score_optimization":
-            self._learned_predicates = self._select_predicates_by_score_hillclimbing(
+            self._learned_predicates = \
+                self._select_predicates_by_score_hillclimbing(
                 candidates, score_function, self._initial_predicates,
                 atom_dataset, self._train_tasks)
         elif CFG.grammar_search_pred_selection_approach == "clustering":
@@ -902,7 +903,10 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
                                   for op_name in anno_list)
             # Next, make a dictionary mapping operator name to segments
             # where that operator was used.
-            gt_op_to_segments = {op_name: [] for op_name in all_gt_op_names}
+            gt_op_to_segments: Dict[str, List[Segment]] = {
+                op_name: []
+                for op_name in all_gt_op_names
+            }
             for op_list, seg_list in zip(dataset.annotations, segmented_trajs):
                 assert len(seg_list) == len(op_list)
                 for op_name, segment in zip(op_list, seg_list):

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -918,19 +918,6 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
                 assert len(seg_list) == len(op_list)
                 for ground_nsrt, segment in zip(op_list, seg_list):
                     gt_op_to_segments[ground_nsrt.parent].append(segment)
-            # consistent_add_effs_preds: Set[Predicate] = set()
-            # # Now, select predicates that change as add effects consistently
-            # # within all segments that map to a particular operator.
-            # for seg_list in gt_op_to_segments.values():
-            #     unique_add_effect_preds: Set[Predicate] = set()
-            #     for seg in seg_list:
-            #         if len(unique_add_effect_preds) == 0:
-            #             unique_add_effect_preds = set(
-            #                 atom.predicate for atom in seg.add_effects)
-            #         else:
-            #             unique_add_effect_preds &= set(
-            #                 atom.predicate for atom in seg.add_effects)
-            #     consistent_add_effs_preds |= unique_add_effect_preds
 
             # Before selecting some subset of predicates to keep, we first
             # get the set of all predicates that ever change.

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -783,7 +783,7 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
                 candidates, self._initial_predicates, dataset, atom_dataset)
         logging.info("Done.")
         # Finally, learn NSRTs via superclass, using all the kept predicates.
-        self._learn_nsrts(dataset.trajectories, online_learning_cycle=None)
+        self._learn_nsrts(dataset.trajectories, online_learning_cycle=None, annotations=dataset.annotations)
 
     def _select_predicates_by_score_hillclimbing(
             self, candidates: Dict[Predicate, float],

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -783,9 +783,12 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
                 candidates, self._initial_predicates, dataset, atom_dataset)
         logging.info("Done.")
         # Finally, learn NSRTs via superclass, using all the kept predicates.
+        annotations = None
+        if dataset.has_annotations:
+            annotations = dataset.annotations
         self._learn_nsrts(dataset.trajectories,
                           online_learning_cycle=None,
-                          annotations=dataset.annotations)
+                          annotations=annotations)
 
     def _select_predicates_by_score_hillclimbing(
             self, candidates: Dict[Predicate, float],

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -899,8 +899,8 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
             ]
             assert len(segmented_trajs) == len(dataset.annotations)
             # First, get the set of all ground truth operator names.
-            all_gt_op_names = set(op_name for anno_list in dataset.annotations
-                                  for op_name in anno_list)
+            all_gt_op_names = set(ground_nsrt.parent.name for anno_list in dataset.annotations
+                                  for ground_nsrt in anno_list)
             # Next, make a dictionary mapping operator name to segments
             # where that operator was used.
             gt_op_to_segments: Dict[str, List[Segment]] = {
@@ -909,8 +909,8 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
             }
             for op_list, seg_list in zip(dataset.annotations, segmented_trajs):
                 assert len(seg_list) == len(op_list)
-                for op_name, segment in zip(op_list, seg_list):
-                    gt_op_to_segments[op_name].append(segment)
+                for ground_nsrt, segment in zip(op_list, seg_list):
+                    gt_op_to_segments[ground_nsrt.parent.name].append(segment)
             predicates_to_keep: Set[Predicate] = set()
             for seg_list in gt_op_to_segments.values():
                 unique_add_effect_preds: Set[Predicate] = set()

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -779,8 +779,7 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
                 atom_dataset, self._train_tasks)
         elif CFG.grammar_search_pred_selection_approach == "clustering":
             self._learned_predicates = self._select_predicates_by_clustering(
-                candidates, self._initial_predicates, dataset, atom_dataset,
-                self._train_tasks)
+                candidates, self._initial_predicates, dataset, atom_dataset)
         logging.info("Done.")
         # Finally, learn NSRTs via superclass, using all the kept predicates.
         self._learn_nsrts(dataset.trajectories, online_learning_cycle=None)
@@ -885,8 +884,7 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
     def _select_predicates_by_clustering(
             self, candidates: Dict[Predicate,
                                    float], initial_predicates: Set[Predicate],
-            dataset: Dataset, atom_dataset: List[GroundAtomTrajectory],
-            train_tasks: List[Task]) -> Set[Predicate]:
+            dataset: Dataset, atom_dataset: List[GroundAtomTrajectory]) -> Set[Predicate]:
         # TODO: implement clustering
         # if CFG.predicate_learning_clusterer == "oracle":
         assert CFG.offline_data_method == "demo+gt_operators"

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -773,18 +773,24 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
             atom_dataset, candidates, self._train_tasks)
         # Select a subset of the candidates to keep.
         logging.info("Selecting a subset...")
-        self._learned_predicates = self._select_predicates_to_keep(
-            candidates, score_function, self._initial_predicates, atom_dataset,
-            self._train_tasks)
+        if CFG.grammar_search_pred_selection_approach == "score_optimization":
+            self._learned_predicates = self._select_predicates_by_score_hillclimbing(
+                candidates, score_function, self._initial_predicates,
+                atom_dataset, self._train_tasks)
+        elif CFG.grammar_search_pred_selection_approach == "clustering":
+            self._learned_predicates = self._select_predicates_by_clustering(
+                candidates, self._initial_predicates, dataset, atom_dataset,
+                self._train_tasks)
         logging.info("Done.")
         # Finally, learn NSRTs via superclass, using all the kept predicates.
         self._learn_nsrts(dataset.trajectories, online_learning_cycle=None)
 
-    def _select_predicates_to_keep(self, candidates: Dict[
-        Predicate, float], score_function: _PredicateSearchScoreFunction,
-                                   initial_predicates: Set[Predicate],
-                                   atom_dataset: List[GroundAtomTrajectory],
-                                   train_tasks: List[Task]) -> Set[Predicate]:
+    def _select_predicates_by_score_hillclimbing(
+            self, candidates: Dict[Predicate, float],
+            score_function: _PredicateSearchScoreFunction,
+            initial_predicates: Set[Predicate],
+            atom_dataset: List[GroundAtomTrajectory],
+            train_tasks: List[Task]) -> Set[Predicate]:
         """Perform a greedy search over predicate sets."""
 
         # There are no goal states for this search; run until exhausted.
@@ -875,3 +881,45 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
         score_function.evaluate(kept_predicates)  # log useful numbers
 
         return set(kept_predicates)
+
+    def _select_predicates_by_clustering(
+            self, candidates: Dict[Predicate,
+                                   float], initial_predicates: Set[Predicate],
+            dataset: Dataset, atom_dataset: List[GroundAtomTrajectory],
+            train_tasks: List[Task]) -> Set[Predicate]:
+        # TODO: implement clustering
+        # if CFG.predicate_learning_clusterer == "oracle":
+        assert CFG.offline_data_method == "demo+gt_operators"
+        assert dataset.annotations is not None and len(
+            dataset.annotations) == len(dataset.trajectories)
+        assert CFG.segmenter == "option_changes"
+        segmented_trajs = [segment_trajectory(traj) for traj in atom_dataset]
+        assert len(segmented_trajs) == len(dataset.annotations)
+        # First, get the set of all ground truth operator names.
+        all_gt_op_names = set(op_name for anno_list in dataset.annotations
+                              for op_name in anno_list)
+        # Next, make a dictionary mapping operator name to segments
+        # where that operator was used.
+        gt_op_to_segments = {op_name: [] for op_name in all_gt_op_names}
+        for op_list, seg_list in zip(dataset.annotations, segmented_trajs):
+            assert len(seg_list) == len(op_list)
+            for op_name, segment in zip(op_list, seg_list):
+                gt_op_to_segments[op_name].append(segment)
+        predicates_to_keep: Set[Predicate] = set()
+        for seg_list in gt_op_to_segments.values():
+            unique_add_effect_preds: Set[Predicate] = set()
+            for seg in seg_list:
+                if len(unique_add_effect_preds) == 0:
+                    unique_add_effect_preds = set(atom.predicate
+                                                  for atom in seg.add_effects)
+                else:
+                    unique_add_effect_preds &= set(atom.predicate
+                                                   for atom in seg.add_effects)
+            predicates_to_keep |= unique_add_effect_preds
+
+        logging.info(f"\nSelected {len(predicates_to_keep)} predicates out of "
+                     f"{len(candidates)} candidates:")
+        for pred in predicates_to_keep:
+            logging.info(f"\t{pred}")
+
+        return predicates_to_keep

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -783,7 +783,9 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
                 candidates, self._initial_predicates, dataset, atom_dataset)
         logging.info("Done.")
         # Finally, learn NSRTs via superclass, using all the kept predicates.
-        self._learn_nsrts(dataset.trajectories, online_learning_cycle=None, annotations=dataset.annotations)
+        self._learn_nsrts(dataset.trajectories,
+                          online_learning_cycle=None,
+                          annotations=dataset.annotations)
 
     def _select_predicates_by_score_hillclimbing(
             self, candidates: Dict[Predicate, float],
@@ -869,6 +871,7 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
                                                | initial_predicates),
                                            segmented_trajs,
                                            verify_harmlessness=False,
+                                           annotations=None,
                                            verbose=False):
             for atom in pnad.op.preconditions:
                 preds_in_preconds.add(atom.predicate)
@@ -899,7 +902,8 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
             ]
             assert len(segmented_trajs) == len(dataset.annotations)
             # First, get the set of all ground truth operator names.
-            all_gt_op_names = set(ground_nsrt.parent.name for anno_list in dataset.annotations
+            all_gt_op_names = set(ground_nsrt.parent.name
+                                  for anno_list in dataset.annotations
                                   for ground_nsrt in anno_list)
             # Next, make a dictionary mapping operator name to segments
             # where that operator was used.
@@ -928,32 +932,34 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
             # Next, select predicates that are consistent (either, it is
             # an add effect, or a delete effect, or doesn't change)
             # within all demos.
-            predicates_to_keep : Set[Predicate] = set()
+            predicates_to_keep: Set[Predicate] = set()
             for pred in consistent_add_effs_preds:
                 keep_pred = True
                 for seg_list in gt_op_to_segments.values():
                     segment_0 = seg_list[0]
-                    pred_in_add_effs_0 = pred in [atom.predicate for atom in segment_0.add_effects]
-                    pred_in_del_effs_0 = pred in [atom.predicate for atom in segment_0.delete_effects]
-                    # pred_in_unchanged_0 = pred in [atom.predicate for atom in (segment_0.final_atoms & segment_0.init_atoms)]
-
+                    pred_in_add_effs_0 = pred in [
+                        atom.predicate for atom in segment_0.add_effects
+                    ]
+                    pred_in_del_effs_0 = pred in [
+                        atom.predicate for atom in segment_0.delete_effects
+                    ]
                     for seg in seg_list[1:]:
-                        pred_in_curr_add_effs = pred in [atom.predicate for atom in seg.add_effects]
-                        pred_in_curr_del_effs = pred in [atom.predicate for atom in seg.delete_effects]
-                        pred_in_curr_unchanged = pred in [atom.predicate for atom in (seg.final_atoms & seg.init_atoms)]
-
-                        if not ((pred_in_add_effs_0 == pred_in_curr_add_effs) and (pred_in_del_effs_0 == pred_in_curr_del_effs)):
-                            # import ipdb; ipdb.set_trace()
+                        pred_in_curr_add_effs = pred in [
+                            atom.predicate for atom in seg.add_effects
+                        ]
+                        pred_in_curr_del_effs = pred in [
+                            atom.predicate for atom in seg.delete_effects
+                        ]
+                        if not ((pred_in_add_effs_0 == pred_in_curr_add_effs)
+                                and
+                                (pred_in_del_effs_0 == pred_in_curr_del_effs)):
                             keep_pred = False
                             break
-
                     if not keep_pred:
                         break
-                
+
                 else:
                     predicates_to_keep.add(pred)
-
-            # predicates_to_keep = consistent_add_effs_preds
 
             # Remove all the initial predicates.
             predicates_to_keep -= initial_predicates

--- a/predicators/approaches/interactive_learning_approach.py
+++ b/predicators/approaches/interactive_learning_approach.py
@@ -137,7 +137,9 @@ class InteractiveLearningApproach(NSRTLearningApproach):
                 (self._predicates_to_learn - {pred}) | {new_pred}
 
         # Learn NSRTs via superclass
-        self._learn_nsrts(self._dataset.trajectories, online_learning_cycle)
+        self._learn_nsrts(self._dataset.trajectories,
+                          online_learning_cycle,
+                          annotations=self._dataset.annotations)
 
         # Save the things we need other than the NSRTs, which were already
         # saved in the above call to self._learn_nsrts()

--- a/predicators/approaches/llm_bilevel_planning_approach.py
+++ b/predicators/approaches/llm_bilevel_planning_approach.py
@@ -93,7 +93,7 @@ class LLMBilevelPlanningApproach(LLMOpenLoopApproach):
         nsrts = self._get_current_nsrts()
         preds = self._get_current_predicates()
         task = Task(state, goal)
-        options, metrics = self._run_sesame_plan(
+        options, _, metrics = self._run_sesame_plan(
             task,
             nsrts,
             preds,

--- a/predicators/approaches/nsrt_learning_approach.py
+++ b/predicators/approaches/nsrt_learning_approach.py
@@ -7,7 +7,7 @@ or options.
 import logging
 import os
 import time
-from typing import Dict, List, Optional, Set, Any
+from typing import Any, Dict, List, Optional, Set
 
 import dill as pkl
 from gym.spaces import Box
@@ -49,10 +49,13 @@ class NSRTLearningApproach(BilevelPlanningApproach):
         # The only thing we need to do here is learn NSRTs,
         # which we split off into a different function in case
         # subclasses want to make use of it.
-        self._learn_nsrts(dataset.trajectories, online_learning_cycle=None)
+        self._learn_nsrts(dataset.trajectories,
+                          online_learning_cycle=None,
+                          annotations=dataset.annotations)
 
     def _learn_nsrts(self, trajectories: List[LowLevelTrajectory],
-                     online_learning_cycle: Optional[int], annotations: Optional[List[Any]]) -> None:
+                     online_learning_cycle: Optional[int],
+                     annotations: Optional[List[Any]]) -> None:
         dataset_fname, _ = utils.create_dataset_filename_str(
             saving_ground_atoms=True,
             online_learning_cycle=online_learning_cycle)

--- a/predicators/approaches/nsrt_learning_approach.py
+++ b/predicators/approaches/nsrt_learning_approach.py
@@ -49,12 +49,10 @@ class NSRTLearningApproach(BilevelPlanningApproach):
         # The only thing we need to do here is learn NSRTs,
         # which we split off into a different function in case
         # subclasses want to make use of it.
-        annotations = None
-        if dataset.has_annotations:
-            annotations = dataset.annotations
         self._learn_nsrts(dataset.trajectories,
                           online_learning_cycle=None,
-                          annotations=annotations)
+                          annotations=(dataset.annotations
+                                       if dataset.has_annotations else None))
 
     def _learn_nsrts(self, trajectories: List[LowLevelTrajectory],
                      online_learning_cycle: Optional[int],

--- a/predicators/approaches/nsrt_learning_approach.py
+++ b/predicators/approaches/nsrt_learning_approach.py
@@ -7,7 +7,7 @@ or options.
 import logging
 import os
 import time
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set, Any
 
 import dill as pkl
 from gym.spaces import Box
@@ -52,7 +52,7 @@ class NSRTLearningApproach(BilevelPlanningApproach):
         self._learn_nsrts(dataset.trajectories, online_learning_cycle=None)
 
     def _learn_nsrts(self, trajectories: List[LowLevelTrajectory],
-                     online_learning_cycle: Optional[int]) -> None:
+                     online_learning_cycle: Optional[int], annotations: Optional[List[Any]]) -> None:
         dataset_fname, _ = utils.create_dataset_filename_str(
             saving_ground_atoms=True,
             online_learning_cycle=online_learning_cycle)
@@ -102,7 +102,8 @@ class NSRTLearningApproach(BilevelPlanningApproach):
                                   self._initial_options,
                                   self._action_space,
                                   ground_atom_dataset,
-                                  sampler_learner=CFG.sampler_learner)
+                                  sampler_learner=CFG.sampler_learner,
+                                  annotations=annotations)
         save_path = utils.get_approach_save_path_str()
         with open(f"{save_path}_{online_learning_cycle}.NSRTs", "wb") as f:
             pkl.dump(self._nsrts, f)

--- a/predicators/approaches/nsrt_learning_approach.py
+++ b/predicators/approaches/nsrt_learning_approach.py
@@ -53,8 +53,8 @@ class NSRTLearningApproach(BilevelPlanningApproach):
         if dataset.has_annotations:
             annotations = dataset.annotations
         self._learn_nsrts(dataset.trajectories,
-                        online_learning_cycle=None,
-                        annotations=annotations)
+                          online_learning_cycle=None,
+                          annotations=annotations)
 
     def _learn_nsrts(self, trajectories: List[LowLevelTrajectory],
                      online_learning_cycle: Optional[int],

--- a/predicators/approaches/nsrt_learning_approach.py
+++ b/predicators/approaches/nsrt_learning_approach.py
@@ -49,9 +49,12 @@ class NSRTLearningApproach(BilevelPlanningApproach):
         # The only thing we need to do here is learn NSRTs,
         # which we split off into a different function in case
         # subclasses want to make use of it.
+        annotations = None
+        if dataset.has_annotations:
+            annotations = dataset.annotations
         self._learn_nsrts(dataset.trajectories,
-                          online_learning_cycle=None,
-                          annotations=dataset.annotations)
+                        online_learning_cycle=None,
+                        annotations=annotations)
 
     def _learn_nsrts(self, trajectories: List[LowLevelTrajectory],
                      online_learning_cycle: Optional[int],

--- a/predicators/approaches/online_nsrt_learning_approach.py
+++ b/predicators/approaches/online_nsrt_learning_approach.py
@@ -95,7 +95,7 @@ class OnlineNSRTLearningApproach(NSRTLearningApproach):
         # Re-learn the NSRTs.
         annotations = None
         if self._dataset.has_annotations:
-            annotations = self._dataset.annotations
+            annotations = self._dataset.annotations  # pragma: no cover
         self._learn_nsrts(self._dataset.trajectories,
                           self._online_learning_cycle,
                           annotations=annotations)

--- a/predicators/approaches/online_nsrt_learning_approach.py
+++ b/predicators/approaches/online_nsrt_learning_approach.py
@@ -93,9 +93,12 @@ class OnlineNSRTLearningApproach(NSRTLearningApproach):
             traj = LowLevelTrajectory(result.states, result.actions)
             self._update_dataset(traj)
         # Re-learn the NSRTs.
+        annotations = None
+        if self._dataset.has_annotations:
+            annotations = self._dataset.annotations
         self._learn_nsrts(self._dataset.trajectories,
                           self._online_learning_cycle,
-                          annotations=self._dataset.annotations)
+                          annotations=annotations)
         # Advance the online learning cycle.
         self._online_learning_cycle += 1
 

--- a/predicators/approaches/online_nsrt_learning_approach.py
+++ b/predicators/approaches/online_nsrt_learning_approach.py
@@ -94,7 +94,8 @@ class OnlineNSRTLearningApproach(NSRTLearningApproach):
             self._update_dataset(traj)
         # Re-learn the NSRTs.
         self._learn_nsrts(self._dataset.trajectories,
-                          self._online_learning_cycle)
+                          self._online_learning_cycle,
+                          annotations=self._dataset.annotations)
         # Advance the online learning cycle.
         self._online_learning_cycle += 1
 

--- a/predicators/approaches/pg3_approach.py
+++ b/predicators/approaches/pg3_approach.py
@@ -149,9 +149,12 @@ class PG3Approach(NSRTLearningApproach):
 
     def learn_from_offline_dataset(self, dataset: Dataset) -> None:
         # First, learn NSRTs.
+        annotations = None
+        if dataset.has_annotations:
+            annotations = dataset.annotations
         self._learn_nsrts(dataset.trajectories,
                           online_learning_cycle=None,
-                          annotations=dataset.annotations)
+                          annotations=annotations)
         # Now, learn the LDL policy.
         self._learn_ldl(online_learning_cycle=None)
 

--- a/predicators/approaches/pg3_approach.py
+++ b/predicators/approaches/pg3_approach.py
@@ -149,7 +149,9 @@ class PG3Approach(NSRTLearningApproach):
 
     def learn_from_offline_dataset(self, dataset: Dataset) -> None:
         # First, learn NSRTs.
-        self._learn_nsrts(dataset.trajectories, online_learning_cycle=None)
+        self._learn_nsrts(dataset.trajectories,
+                          online_learning_cycle=None,
+                          annotations=dataset.annotations)
         # Now, learn the LDL policy.
         self._learn_ldl(online_learning_cycle=None)
 

--- a/predicators/approaches/pg3_approach.py
+++ b/predicators/approaches/pg3_approach.py
@@ -151,7 +151,7 @@ class PG3Approach(NSRTLearningApproach):
         # First, learn NSRTs.
         annotations = None
         if dataset.has_annotations:
-            annotations = dataset.annotations
+            annotations = dataset.annotations  # pragma: no cover
         self._learn_nsrts(dataset.trajectories,
                           online_learning_cycle=None,
                           annotations=annotations)

--- a/predicators/approaches/pg4_approach.py
+++ b/predicators/approaches/pg4_approach.py
@@ -20,7 +20,7 @@ from predicators.approaches.bilevel_planning_approach import \
 from predicators.approaches.pg3_approach import PG3Approach
 from predicators.settings import CFG
 from predicators.structs import NSRT, AbstractPolicy, Action, Metrics, \
-    Predicate, State, Task, _Option
+    Predicate, State, Task, _GroundNSRT, _Option
 
 
 class PG4Approach(PG3Approach):
@@ -37,9 +37,10 @@ class PG4Approach(PG3Approach):
         # but it's not the direct child, so we can't use super().
         return BilevelPlanningApproach._solve(self, task, timeout)  # pylint: disable=protected-access
 
-    def _run_sesame_plan(self, task: Task, nsrts: Set[NSRT],
-                         preds: Set[Predicate], timeout: float, seed: int,
-                         **kwargs: Any) -> Tuple[List[_Option], Metrics]:
+    def _run_sesame_plan(
+            self, task: Task, nsrts: Set[NSRT], preds: Set[Predicate],
+            timeout: float, seed: int,
+            **kwargs: Any) -> Tuple[List[_Option], List[_GroundNSRT], Metrics]:
         """Generates a plan choosing the best skeletons generated from policy-
         based skeletons and primitive successors."""
         abstract_policy: AbstractPolicy = lambda a, o, g: utils.query_ldl(

--- a/predicators/approaches/refinement_estimation_approach.py
+++ b/predicators/approaches/refinement_estimation_approach.py
@@ -17,7 +17,7 @@ from predicators.refinement_estimators import BaseRefinementEstimator, \
     create_refinement_estimator
 from predicators.settings import CFG
 from predicators.structs import NSRT, Metrics, ParameterizedOption, \
-    Predicate, Task, Type, _Option
+    Predicate, Task, Type, _GroundNSRT, _Option
 
 
 class RefinementEstimationApproach(OracleApproach):
@@ -59,9 +59,10 @@ class RefinementEstimationApproach(OracleApproach):
     def get_name(cls) -> str:
         return "refinement_estimation"
 
-    def _run_sesame_plan(self, task: Task, nsrts: Set[NSRT],
-                         preds: Set[Predicate], timeout: float, seed: int,
-                         **kwargs: Any) -> Tuple[List[_Option], Metrics]:
+    def _run_sesame_plan(
+            self, task: Task, nsrts: Set[NSRT], preds: Set[Predicate],
+            timeout: float, seed: int,
+            **kwargs: Any) -> Tuple[List[_Option], List[_GroundNSRT], Metrics]:
         """Generates a plan choosing the best skeletons based on a given
         refinement cost estimator."""
         result = super()._run_sesame_plan(

--- a/predicators/datasets/__init__.py
+++ b/predicators/datasets/__init__.py
@@ -20,11 +20,22 @@ def create_dataset(env: BaseEnv, train_tasks: List[Task],
     Some or all of this data may be loaded from disk.
     """
     if CFG.offline_data_method == "demo":
-        return create_demo_data(env, train_tasks, known_options)
+        return create_demo_data(env,
+                                train_tasks,
+                                known_options,
+                                annotate_with_gt_ops=False)
+    if CFG.offline_data_method == "demo+gt_operators":
+        return create_demo_data(env,
+                                train_tasks,
+                                known_options,
+                                annotate_with_gt_ops=True)
     if CFG.offline_data_method == "demo+replay":
         return create_demo_replay_data(env, train_tasks, known_options)
     if CFG.offline_data_method == "demo+ground_atoms":
-        base_dataset = create_demo_data(env, train_tasks, known_options)
+        base_dataset = create_demo_data(env,
+                                        train_tasks,
+                                        known_options,
+                                        annotate_with_gt_ops=False)
         _, excluded_preds = utils.parse_config_excluded_predicates(env)
         n = int(CFG.teacher_dataset_num_examples)
         assert n >= 1, "Must have at least 1 example of each predicate"

--- a/predicators/datasets/demo_only.py
+++ b/predicators/datasets/demo_only.py
@@ -168,7 +168,7 @@ def _generate_demonstrations(env: BaseEnv, train_tasks: List[Task],
         event_to_action = env.get_event_to_action_fn()
     trajectories = []
     if annotate_with_gt_ops:
-        annotations: List[List[str]] = []
+        annotations = []
     num_tasks = min(len(train_tasks), CFG.max_initial_demos)
     rng = np.random.default_rng(CFG.seed)
     for idx, task in enumerate(train_tasks):
@@ -255,8 +255,7 @@ def _generate_demonstrations(env: BaseEnv, train_tasks: List[Task],
         # nsrt used to the list of annotations.
         if annotate_with_gt_ops:
             last_nsrt_plan = oracle_approach.get_last_nsrt_plan()
-            annotations.append(
-                [ground_nsrt for ground_nsrt in last_nsrt_plan])
+            annotations.append(list(last_nsrt_plan))
         if CFG.make_demo_videos:
             assert monitor is not None
             video = monitor.get_video()

--- a/predicators/datasets/demo_only.py
+++ b/predicators/datasets/demo_only.py
@@ -256,7 +256,7 @@ def _generate_demonstrations(env: BaseEnv, train_tasks: List[Task],
         if annotate_with_gt_ops:
             last_nsrt_plan = oracle_approach.get_last_nsrt_plan()
             annotations.append(
-                [ground_nsrt.parent.name for ground_nsrt in last_nsrt_plan])
+                [ground_nsrt for ground_nsrt in last_nsrt_plan])
         if CFG.make_demo_videos:
             assert monitor is not None
             video = monitor.get_video()

--- a/predicators/datasets/demo_only.py
+++ b/predicators/datasets/demo_only.py
@@ -109,7 +109,10 @@ def _create_demo_data_with_loading(env: BaseEnv, train_tasks: List[Task],
     with open(os.path.join(CFG.data_dir, fname), "rb") as f:
         dataset = pkl.load(f)
     loaded_trajectories = dataset.trajectories
-    loaded_annotations = dataset.annotations
+    if dataset.has_annotations:
+        loaded_annotations = dataset.annotations
+    else:
+        loaded_annotations = None
     # If we're trying to annotate with ground truth operators,
     # then check that the dataset we're loading has annotations.
     if annotate_with_gt_ops:
@@ -121,13 +124,19 @@ def _create_demo_data_with_loading(env: BaseEnv, train_tasks: List[Task],
         train_tasks_start_idx=train_tasks_start_idx,
         annotate_with_gt_ops=annotate_with_gt_ops)
     generated_trajectories = generated_dataset.trajectories
-    generated_annotations = generated_dataset.annotations
+    if generated_dataset.has_annotations:
+        generated_annotations = generated_dataset.annotations
+    else:
+        generated_annotations = None
     logging.info(f"\n\nLOADED DATASET OF {len(loaded_trajectories)} "
                  "DEMONSTRATIONS")
     logging.info(
         f"CREATED {len(generated_dataset.trajectories)} DEMONSTRATIONS")
-    dataset = Dataset(loaded_trajectories + generated_trajectories,
-                      loaded_annotations + generated_annotations)
+    if generated_annotations is not None and loaded_annotations is not None:
+        dataset = Dataset(loaded_trajectories + generated_trajectories,
+                          loaded_annotations + generated_annotations)
+    else:
+        dataset = Dataset(loaded_trajectories + generated_trajectories)
     with open(dataset_fname, "wb") as f:
         pkl.dump(dataset, f)
     return dataset

--- a/predicators/datasets/demo_replay.py
+++ b/predicators/datasets/demo_replay.py
@@ -17,7 +17,10 @@ def create_demo_replay_data(
         env: BaseEnv, train_tasks: List[Task],
         known_options: Set[ParameterizedOption]) -> Dataset:
     """Create offline datasets by collecting demos and replaying."""
-    demo_dataset = create_demo_data(env, train_tasks, known_options)
+    demo_dataset = create_demo_data(env,
+                                    train_tasks,
+                                    known_options,
+                                    annotate_with_gt_ops=False)
     # We will sample from states uniformly at random.
     # The reason for doing it this way, rather than combining
     # all states into one list, is that we want to compute

--- a/predicators/explorers/bilevel_planning_explorer.py
+++ b/predicators/explorers/bilevel_planning_explorer.py
@@ -37,7 +37,7 @@ class BilevelPlanningExplorer(BaseExplorer):
         seed = self._seed + self._num_calls
         # Note: subclasses are responsible for catching PlanningFailure and
         # PlanningTimeout and handling them accordingly.
-        plan, _ = sesame_plan(
+        plan, _, _ = sesame_plan(
             task,
             self._option_model,
             self._nsrts,

--- a/predicators/ground_truth_models/painting/nsrts.py
+++ b/predicators/ground_truth_models/painting/nsrts.py
@@ -392,8 +392,8 @@ class PaintingGroundTruthNSRTFactory(GroundTruthNSRTFactory):
                     y = state.get(objs[0], "pose_y")
                     z = state.get(objs[0], "pose_z")
                 elif env_name == "repeated_nextto_painting":
-                    # Release the object at a randomly-chosen position on the table
-                    # such that it is NextTo the robot.
+                    # Release the object at a randomly-chosen position on
+                    # the table such that it is NextTo the robot.
                     robot_y = state.get(objs[1], "pose_y")
                     table_lb = RepeatedNextToPaintingEnv.table_lb
                     table_ub = RepeatedNextToPaintingEnv.table_ub

--- a/predicators/ground_truth_models/painting/nsrts.py
+++ b/predicators/ground_truth_models/painting/nsrts.py
@@ -342,75 +342,76 @@ class PaintingGroundTruthNSRTFactory(GroundTruthNSRTFactory):
         nsrts.add(openlid_nsrt)
 
         # PlaceOnTable
-        obj = Variable("?obj", obj_type)
-        robot = Variable("?robot", robot_type)
-        parameters = [obj, robot]
-        option_vars = [robot]
-        option = Place
-        if env_name == "painting":
-            # The environment is a little weird: the object is technically
-            # already OnTable when we go to place it on the table, because
-            # of how the classifier is implemented.
-            preconditions = {
-                LiftedAtom(Holding, [obj]),
-                LiftedAtom(OnTable, [obj]),
-            }
-            add_effects = {
-                LiftedAtom(GripperOpen, [robot]),
-            }
-            delete_effects = {
-                LiftedAtom(Holding, [obj]),
-                LiftedAtom(HoldingTop, [obj]),
-                LiftedAtom(HoldingSide, [obj]),
-            }
-        elif env_name == "repeated_nextto_painting":
-            preconditions = {
-                LiftedAtom(Holding, [obj]),
-                LiftedAtom(NextTo, [robot, obj]),
-                LiftedAtom(NextToTable, [robot]),
-            }
-            add_effects = {
-                LiftedAtom(GripperOpen, [robot]),
-                LiftedAtom(OnTable, [obj]),
-            }
-            delete_effects = {
-                LiftedAtom(Holding, [obj]),
-                LiftedAtom(HoldingTop, [obj]),
-                LiftedAtom(HoldingSide, [obj]),
-                LiftedAtom(NotOnTable, [obj]),
-            }
-
-        def placeontable_sampler(state: State, goal: Set[GroundAtom],
-                                 rng: np.random.Generator,
-                                 objs: Sequence[Object]) -> Array:
-            del goal  # unused
-            x = state.get(objs[0], "pose_x")
+        for HoldingSideOrTop in [HoldingSide, HoldingTop]:
+            obj = Variable("?obj", obj_type)
+            robot = Variable("?robot", robot_type)
+            parameters = [obj, robot]
+            option_vars = [robot]
+            option = Place
             if env_name == "painting":
-                # Always release the object where it is, to avoid the
-                # possibility of collisions with other objects.
-                y = state.get(objs[0], "pose_y")
-                z = state.get(objs[0], "pose_z")
+                # The environment is a little weird: the object is technically
+                # already OnTable when we go to place it on the table, because
+                # of how the classifier is implemented.
+                preconditions = {
+                    LiftedAtom(Holding, [obj]),
+                    LiftedAtom(OnTable, [obj]),
+                    LiftedAtom(HoldingSideOrTop, [obj]),
+                }
+                add_effects = {
+                    LiftedAtom(GripperOpen, [robot]),
+                }
+                delete_effects = {
+                    LiftedAtom(Holding, [obj]),
+                    LiftedAtom(HoldingSideOrTop, [obj]),
+                }
             elif env_name == "repeated_nextto_painting":
-                # Release the object at a randomly-chosen position on the table
-                # such that it is NextTo the robot.
-                robot_y = state.get(objs[1], "pose_y")
-                table_lb = RepeatedNextToPaintingEnv.table_lb
-                table_ub = RepeatedNextToPaintingEnv.table_ub
-                y = state.get(objs[0], "pose_y")
-                z = state.get(objs[0], "pose_z")
-                if table_lb < robot_y < table_ub:
-                    nextto_thresh = RepeatedNextToPaintingEnv.nextto_thresh
-                    y_sample_lb = max(table_lb, robot_y - nextto_thresh)
-                    y_sample_ub = min(table_ub, robot_y + nextto_thresh)
-                    y = rng.uniform(y_sample_lb, y_sample_ub)
-                    z = RepeatedNextToPaintingEnv.obj_z
-            return np.array([x, y, z], dtype=np.float32)
+                preconditions = {
+                    LiftedAtom(Holding, [obj]),
+                    LiftedAtom(NextTo, [robot, obj]),
+                    LiftedAtom(NextToTable, [robot]),
+                    LiftedAtom(HoldingSideOrTop, [obj]),
+                }
+                add_effects = {
+                    LiftedAtom(GripperOpen, [robot]),
+                    LiftedAtom(OnTable, [obj]),
+                }
+                delete_effects = {
+                    LiftedAtom(Holding, [obj]),
+                    LiftedAtom(HoldingSideOrTop, [obj]),
+                    LiftedAtom(NotOnTable, [obj]),
+                }
 
-        placeontable_nsrt = NSRT("PlaceOnTable", parameters,
-                                 preconditions, add_effects, delete_effects,
-                                 set(), option, option_vars,
-                                 placeontable_sampler)
-        nsrts.add(placeontable_nsrt)
+            def placeontable_sampler(state: State, goal: Set[GroundAtom],
+                                     rng: np.random.Generator,
+                                     objs: Sequence[Object]) -> Array:
+                del goal  # unused
+                x = state.get(objs[0], "pose_x")
+                if env_name == "painting":
+                    # Always release the object where it is, to avoid the
+                    # possibility of collisions with other objects.
+                    y = state.get(objs[0], "pose_y")
+                    z = state.get(objs[0], "pose_z")
+                elif env_name == "repeated_nextto_painting":
+                    # Release the object at a randomly-chosen position on the table
+                    # such that it is NextTo the robot.
+                    robot_y = state.get(objs[1], "pose_y")
+                    table_lb = RepeatedNextToPaintingEnv.table_lb
+                    table_ub = RepeatedNextToPaintingEnv.table_ub
+                    y = state.get(objs[0], "pose_y")
+                    z = state.get(objs[0], "pose_z")
+                    if table_lb < robot_y < table_ub:
+                        nextto_thresh = RepeatedNextToPaintingEnv.nextto_thresh
+                        y_sample_lb = max(table_lb, robot_y - nextto_thresh)
+                        y_sample_ub = min(table_ub, robot_y + nextto_thresh)
+                        y = rng.uniform(y_sample_lb, y_sample_ub)
+                        z = RepeatedNextToPaintingEnv.obj_z
+                return np.array([x, y, z], dtype=np.float32)
+
+            placeontable_nsrt = NSRT(
+                f"PlaceOnTableFrom{HoldingSideOrTop.name}", parameters,
+                preconditions, add_effects, delete_effects, set(), option,
+                option_vars, placeontable_sampler)
+            nsrts.add(placeontable_nsrt)
 
         if env_name == "repeated_nextto_painting":
 

--- a/predicators/ground_truth_models/painting/painting_bridge_policy.ldl
+++ b/predicators/ground_truth_models/painting/painting_bridge_policy.ldl
@@ -5,10 +5,10 @@
         :goals ()
         :action (OpenLid ?lid ?robot)
     )
-    (:rule PlaceOnTable
+    (:rule PlaceOnTableFromHoldingTop
         :parameters (?obj - obj ?robot - robot)
         :preconditions (and (Holding ?obj) (HoldingTop ?obj) (IsClean ?obj) (IsDry ?obj) (OnTable ?obj) (PlaceFailed_arg0 ?robot) (not (GripperOpen ?robot)))
         :goals ()
-        :action (PlaceOnTable ?obj ?robot)
+        :action (PlaceOnTableFromHoldingTop ?obj ?robot)
     )
 )

--- a/predicators/ground_truth_models/painting/painting_bridge_policy.ldl
+++ b/predicators/ground_truth_models/painting/painting_bridge_policy.ldl
@@ -11,10 +11,4 @@
         :goals ()
         :action (PlaceOnTableFromHoldingTop ?obj ?robot)
     )
-    (:rule PlaceOnTableFromHoldingSide
-            :parameters (?obj - obj ?robot - robot)
-            :preconditions (and (Holding ?obj) (HoldingSide ?obj) (IsClean ?obj) (IsDry ?obj) (OnTable ?obj) (PlaceFailed_arg0 ?robot) (not (GripperOpen ?robot)))
-            :goals ()
-            :action (PlaceOnTableFromHoldingSide ?obj ?robot)
-    )
 )

--- a/predicators/ground_truth_models/painting/painting_bridge_policy.ldl
+++ b/predicators/ground_truth_models/painting/painting_bridge_policy.ldl
@@ -11,4 +11,10 @@
         :goals ()
         :action (PlaceOnTableFromHoldingTop ?obj ?robot)
     )
+    (:rule PlaceOnTableFromHoldingSide
+            :parameters (?obj - obj ?robot - robot)
+            :preconditions (and (Holding ?obj) (HoldingSide ?obj) (IsClean ?obj) (IsDry ?obj) (OnTable ?obj) (PlaceFailed_arg0 ?robot) (not (GripperOpen ?robot)))
+            :goals ()
+            :action (PlaceOnTableFromHoldingSide ?obj ?robot)
+    )
 )

--- a/predicators/nsrt_learning/nsrt_learning_main.py
+++ b/predicators/nsrt_learning/nsrt_learning_main.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, List, Set, Tuple, Optional, Any
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import numpy as np
 from gym.spaces import Box

--- a/predicators/nsrt_learning/nsrt_learning_main.py
+++ b/predicators/nsrt_learning/nsrt_learning_main.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Set, Tuple, Optional, Any
 
 import numpy as np
 from gym.spaces import Box
@@ -22,7 +22,7 @@ def learn_nsrts_from_data(
     trajectories: List[LowLevelTrajectory], train_tasks: List[Task],
     predicates: Set[Predicate], known_options: Set[ParameterizedOption],
     action_space: Box, ground_atom_dataset: List[GroundAtomTrajectory],
-    sampler_learner: str
+    sampler_learner: str, annotations: Optional[List[Any]]
 ) -> Tuple[Set[NSRT], List[List[Segment]], Dict[Segment, NSRT]]:
     """Learn NSRTs from the given dataset of low-level transitions, using the
     given set of predicates.
@@ -83,7 +83,8 @@ def learn_nsrts_from_data(
             predicates,
             segmented_trajs,
             verify_harmlessness=True,
-            verbose=(CFG.option_learner != "no_learning"))
+            verbose=(CFG.option_learner != "no_learning"),
+            annotations=annotations)
 
         # Save least complex learned PNAD set across data orderings.
         pnads_complexity = sum(pnad.op.get_complexity() for pnad in pnads)

--- a/predicators/nsrt_learning/strips_learning/__init__.py
+++ b/predicators/nsrt_learning/strips_learning/__init__.py
@@ -1,6 +1,6 @@
 """This directory contains algorithms for STRIPS operator learning."""
 
-from typing import List, Set, Optional, Any
+from typing import Any, List, Optional, Set
 
 from predicators import utils
 from predicators.nsrt_learning.strips_learning.base_strips_learner import \
@@ -31,7 +31,8 @@ def learn_strips_operators(trajectories: List[LowLevelTrajectory],
         if not cls.__abstractmethods__ and \
            cls.get_name() == CFG.strips_learner:
             learner = cls(trajectories, train_tasks, predicates,
-                          segmented_trajs, verify_harmlessness, annotations, verbose)
+                          segmented_trajs, verify_harmlessness, annotations,
+                          verbose)
             break
     else:
         raise ValueError(f"Unrecognized STRIPS learner: {CFG.strips_learner}")

--- a/predicators/nsrt_learning/strips_learning/__init__.py
+++ b/predicators/nsrt_learning/strips_learning/__init__.py
@@ -1,6 +1,6 @@
 """This directory contains algorithms for STRIPS operator learning."""
 
-from typing import List, Set
+from typing import List, Set, Optional, Any
 
 from predicators import utils
 from predicators.nsrt_learning.strips_learning.base_strips_learner import \
@@ -20,6 +20,7 @@ def learn_strips_operators(trajectories: List[LowLevelTrajectory],
                            predicates: Set[Predicate],
                            segmented_trajs: List[List[Segment]],
                            verify_harmlessness: bool,
+                           annotations: Optional[List[Any]],
                            verbose: bool = True) -> List[PNAD]:
     """Learn strips operators on the given data segments.
 
@@ -30,7 +31,7 @@ def learn_strips_operators(trajectories: List[LowLevelTrajectory],
         if not cls.__abstractmethods__ and \
            cls.get_name() == CFG.strips_learner:
             learner = cls(trajectories, train_tasks, predicates,
-                          segmented_trajs, verify_harmlessness, verbose)
+                          segmented_trajs, verify_harmlessness, annotations, verbose)
             break
     else:
         raise ValueError(f"Unrecognized STRIPS learner: {CFG.strips_learner}")

--- a/predicators/nsrt_learning/strips_learning/base_strips_learner.py
+++ b/predicators/nsrt_learning/strips_learning/base_strips_learner.py
@@ -2,7 +2,7 @@
 
 import abc
 import logging
-from typing import Dict, List, Optional, Set, Tuple, Any
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from predicators import utils
 from predicators.planning import task_plan_with_option_plan_constraint

--- a/predicators/nsrt_learning/strips_learning/base_strips_learner.py
+++ b/predicators/nsrt_learning/strips_learning/base_strips_learner.py
@@ -2,7 +2,7 @@
 
 import abc
 import logging
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple, Any
 
 from predicators import utils
 from predicators.planning import task_plan_with_option_plan_constraint
@@ -21,6 +21,7 @@ class BaseSTRIPSLearner(abc.ABC):
                  predicates: Set[Predicate],
                  segmented_trajs: List[List[Segment]],
                  verify_harmlessness: bool,
+                 annotations: Optional[List[Any]],
                  verbose: bool = True) -> None:
         self._trajectories = trajectories
         self._train_tasks = train_tasks
@@ -29,6 +30,7 @@ class BaseSTRIPSLearner(abc.ABC):
         self._verify_harmlessness = verify_harmlessness
         self._verbose = verbose
         self._num_segments = sum(len(t) for t in segmented_trajs)
+        self._annotations = annotations
         assert len(self._trajectories) == len(self._segmented_trajs)
 
     def learn(self) -> List[PNAD]:

--- a/predicators/nsrt_learning/strips_learning/oracle_clustering_learner.py
+++ b/predicators/nsrt_learning/strips_learning/oracle_clustering_learner.py
@@ -1,0 +1,98 @@
+"""Oracle for STRIPS learning."""
+
+import logging
+from typing import List, Set
+
+from predicators.envs import get_or_create_env
+from predicators.ground_truth_models import get_gt_nsrts, get_gt_options
+from predicators.nsrt_learning.strips_learning import BaseSTRIPSLearner
+from predicators.settings import CFG
+from predicators.structs import PNAD, Datastore, DummyOption, LiftedAtom, Segment, Predicate
+
+
+class OracleSTRIPSLearner(BaseSTRIPSLearner):
+    """Base class for a STRIPS learner that uses oracle operators
+    but re-learns all the components via currently-implemented
+    methods in the base class."""
+
+    def _induce_add_effects_by_intersection(self, pnad: PNAD) -> Set[LiftedAtom]:
+        """Given a PNAD with a nonempty datastore, compute the add effects
+        for the PNAD's operator by intersecting all lifted add effects."""
+        assert len(pnad.datastore) > 0
+        for i, (segment, var_to_obj) in enumerate(pnad.datastore):
+            objects = set(var_to_obj.values())
+            obj_to_var = {o: v for v, o in var_to_obj.items()}
+            atoms = {
+                atom
+                for atom in segment.add_effects
+                if all(o in objects for o in atom.objects)
+            }
+            lifted_atoms = {atom.lift(obj_to_var) for atom in atoms}
+            if i == 0:
+                add_effects = lifted_atoms
+            else:
+                add_effects &= lifted_atoms
+        return add_effects
+
+    def _compute_datastore_given_pnad_name(self, pnad_name: str, dummy_pnad: PNAD) -> Datastore:
+        datastore = []
+        for seg_traj, op_name_list in zip(self._segmented_trajs, self._annotations):
+            assert len(seg_traj) == len(op_name_list)
+            for segment, op_name in zip(seg_traj, op_name_list):
+                if op_name == pnad_name:
+                    objs = set(segment.trajectory.states[0])
+                    pnad, sub = self._find_best_matching_pnad_and_sub(segment, objs, [dummy_pnad])
+                    assert pnad == dummy_pnad
+                    datastore.append((segment, sub))
+        return datastore
+
+    def _find_add_effect_intersection_preds(self, segments: List[Segment]) -> Set[Predicate]:
+        unique_add_effect_preds: Set[Predicate] = set()
+        for seg in segments:
+            if len(unique_add_effect_preds) == 0:
+                unique_add_effect_preds = set(
+                    atom.predicate for atom in seg.add_effects)
+            else:
+                unique_add_effect_preds &= set(
+                    atom.predicate for atom in seg.add_effects)
+        return unique_add_effect_preds
+
+    def _learn(self) -> List[PNAD]:
+        # For this learner to work, we need annotations to be non-null
+        # and the length of the annotations to match the length of
+        # the trajectory set.
+        assert self._annotations is not None
+        assert len(self._annotations) == len(self._trajectories)
+        assert CFG.offline_data_method == "demo+gt_operators"
+
+        env = get_or_create_env(CFG.env)
+        env_options = get_gt_options(env.get_name())
+        gt_nsrts = get_gt_nsrts(env.get_name(), env.predicates, env_options)
+        pnads: List[PNAD] = []
+        for nsrt in gt_nsrts:
+            # If options are unknown, use a dummy option spec.
+            if CFG.option_learner == "no_learning":
+                option_spec = (nsrt.option, list(nsrt.option_vars))
+            else:
+                option_spec = (DummyOption.parent, [])
+
+            dummy_op = nsrt.op.copy_with(preconditions=set(), add_effects=set(), delete_effects=set(), ignore_effects=self._predicates)
+            initial_dummy_pnad = PNAD(dummy_op, [], option_spec)
+            datastore = self._compute_datastore_given_pnad_name(nsrt.name, initial_dummy_pnad)
+
+            assert(len(datastore) > 0)
+
+            dummy_pnad_with_datastore = PNAD(dummy_op, datastore, option_spec)
+            add_effects = self._induce_add_effects_by_intersection(dummy_pnad_with_datastore)
+            preconditions = self._induce_preconditions_via_intersection(dummy_pnad_with_datastore)
+            correct_pnad = PNAD(dummy_pnad_with_datastore.op.copy_with(preconditions=preconditions, add_effects=add_effects), datastore, option_spec)
+            self._compute_pnad_delete_effects(correct_pnad)
+            self._compute_pnad_ignore_effects(correct_pnad)
+            
+            pnads.append(correct_pnad)
+                
+        return pnads
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "oracle_clustering"

--- a/predicators/nsrt_learning/strips_learning/oracle_clustering_learner.py
+++ b/predicators/nsrt_learning/strips_learning/oracle_clustering_learner.py
@@ -6,8 +6,7 @@ from predicators.envs import get_or_create_env
 from predicators.ground_truth_models import get_gt_nsrts, get_gt_options
 from predicators.nsrt_learning.strips_learning import BaseSTRIPSLearner
 from predicators.settings import CFG
-from predicators.structs import NSRT, PNAD, Datastore, DummyOption, \
-    LiftedAtom, Predicate, Segment
+from predicators.structs import NSRT, PNAD, Datastore, DummyOption, LiftedAtom
 
 
 class OracleSTRIPSLearner(BaseSTRIPSLearner):

--- a/predicators/nsrt_learning/strips_learning/oracle_clustering_learner.py
+++ b/predicators/nsrt_learning/strips_learning/oracle_clustering_learner.py
@@ -1,12 +1,13 @@
 """Oracle for STRIPS learning."""
 
-from typing import List, Set
+from typing import List, Set, Tuple
 
 from predicators.envs import get_or_create_env
 from predicators.ground_truth_models import get_gt_nsrts, get_gt_options
 from predicators.nsrt_learning.strips_learning import BaseSTRIPSLearner
 from predicators.settings import CFG
-from predicators.structs import NSRT, PNAD, Datastore, DummyOption, LiftedAtom
+from predicators.structs import NSRT, PNAD, Datastore, DummyOption, \
+    LiftedAtom, ParameterizedOption, Variable
 
 
 class OracleSTRIPSLearner(BaseSTRIPSLearner):
@@ -60,7 +61,8 @@ class OracleSTRIPSLearner(BaseSTRIPSLearner):
         gt_nsrts = get_gt_nsrts(env.get_name(), env.predicates, env_options)
         pnads: List[PNAD] = []
         for nsrt in gt_nsrts:
-            option_spec = (DummyOption.parent, [])
+            option_spec: Tuple[ParameterizedOption,
+                               List[Variable]] = (DummyOption.parent, [])
             # If options are unknown, use a dummy option spec.
             if CFG.option_learner == "no_learning":
                 option_spec = (nsrt.option, list(nsrt.option_vars))

--- a/predicators/nsrt_learning/strips_learning/oracle_clustering_learner.py
+++ b/predicators/nsrt_learning/strips_learning/oracle_clustering_learner.py
@@ -1,4 +1,5 @@
-"""Oracle for STRIPS learning."""
+"""STRIPS learner that leverages access to oracle operators used to generate
+demonstrations via bilevel planning."""
 
 from typing import List, Set, Tuple
 
@@ -10,9 +11,15 @@ from predicators.structs import NSRT, PNAD, Datastore, DummyOption, \
     LiftedAtom, ParameterizedOption, Variable
 
 
-class OracleSTRIPSLearner(BaseSTRIPSLearner):
+class OracleClusteringSTRIPSLearner(BaseSTRIPSLearner):
     """Base class for a STRIPS learner that uses oracle operators but re-learns
-    all the components via currently-implemented methods in the base class."""
+    all the components via currently-implemented methods in the base class.
+
+    This is different from the oracle learner because here, we assume
+    that our demo data is annotated with the ground-truth operators used
+    to produce it. We thus know exactly how to associate (i.e, cluster)
+    demos into sets corresponding to each operator.
+    """
 
     def _induce_add_effects_by_intersection(self,
                                             pnad: PNAD) -> Set[LiftedAtom]:

--- a/predicators/nsrt_learning/strips_learning/oracle_clustering_learner.py
+++ b/predicators/nsrt_learning/strips_learning/oracle_clustering_learner.py
@@ -48,18 +48,6 @@ class OracleSTRIPSLearner(BaseSTRIPSLearner):
                     datastore.append((segment, var_to_obj_sub))
         return datastore
 
-    def _find_add_effect_intersection_preds(
-            self, segments: List[Segment]) -> Set[Predicate]:
-        unique_add_effect_preds: Set[Predicate] = set()
-        for seg in segments:
-            if len(unique_add_effect_preds) == 0:
-                unique_add_effect_preds = set(atom.predicate
-                                              for atom in seg.add_effects)
-            else:
-                unique_add_effect_preds &= set(atom.predicate
-                                               for atom in seg.add_effects)
-        return unique_add_effect_preds
-
     def _learn(self) -> List[PNAD]:
         # For this learner to work, we need annotations to be non-null
         # and the length of the annotations to match the length of
@@ -73,11 +61,10 @@ class OracleSTRIPSLearner(BaseSTRIPSLearner):
         gt_nsrts = get_gt_nsrts(env.get_name(), env.predicates, env_options)
         pnads: List[PNAD] = []
         for nsrt in gt_nsrts:
+            option_spec = (DummyOption.parent, [])
             # If options are unknown, use a dummy option spec.
             if CFG.option_learner == "no_learning":
                 option_spec = (nsrt.option, list(nsrt.option_vars))
-            else:
-                option_spec = (DummyOption.parent, [])
 
             datastore = self._compute_datastores_given_nsrt(nsrt)
             pnad = PNAD(nsrt.op, datastore, option_spec)

--- a/predicators/planning.py
+++ b/predicators/planning.py
@@ -45,22 +45,23 @@ class _Node:
 
 
 def sesame_plan(
-        task: Task,
-        option_model: _OptionModelBase,
-        nsrts: Set[NSRT],
-        predicates: Set[Predicate],
-        types: Set[Type],
-        timeout: float,
-        seed: int,
-        task_planning_heuristic: str,
-        max_skeletons_optimized: int,
-        max_horizon: int,
-        abstract_policy: Optional[AbstractPolicy] = None,
-        max_policy_guided_rollout: int = 0,
-        refinement_estimator: Optional[BaseRefinementEstimator] = None,
-        check_dr_reachable: bool = True,
-        allow_noops: bool = False,
-        use_visited_state_set: bool = False) -> Tuple[List[_Option], Metrics]:
+    task: Task,
+    option_model: _OptionModelBase,
+    nsrts: Set[NSRT],
+    predicates: Set[Predicate],
+    types: Set[Type],
+    timeout: float,
+    seed: int,
+    task_planning_heuristic: str,
+    max_skeletons_optimized: int,
+    max_horizon: int,
+    abstract_policy: Optional[AbstractPolicy] = None,
+    max_policy_guided_rollout: int = 0,
+    refinement_estimator: Optional[BaseRefinementEstimator] = None,
+    check_dr_reachable: bool = True,
+    allow_noops: bool = False,
+    use_visited_state_set: bool = False
+) -> Tuple[List[_Option], List[_GroundNSRT], Metrics]:
     """Run bilevel planning.
 
     Return a sequence of options, and a dictionary of metrics for this
@@ -104,22 +105,23 @@ def sesame_plan(
 
 
 def _sesame_plan_with_astar(
-        task: Task,
-        option_model: _OptionModelBase,
-        nsrts: Set[NSRT],
-        predicates: Set[Predicate],
-        types: Set[Type],
-        timeout: float,
-        seed: int,
-        task_planning_heuristic: str,
-        max_skeletons_optimized: int,
-        max_horizon: int,
-        abstract_policy: Optional[AbstractPolicy] = None,
-        max_policy_guided_rollout: int = 0,
-        refinement_estimator: Optional[BaseRefinementEstimator] = None,
-        check_dr_reachable: bool = True,
-        allow_noops: bool = False,
-        use_visited_state_set: bool = False) -> Tuple[List[_Option], Metrics]:
+    task: Task,
+    option_model: _OptionModelBase,
+    nsrts: Set[NSRT],
+    predicates: Set[Predicate],
+    types: Set[Type],
+    timeout: float,
+    seed: int,
+    task_planning_heuristic: str,
+    max_skeletons_optimized: int,
+    max_horizon: int,
+    abstract_policy: Optional[AbstractPolicy] = None,
+    max_policy_guided_rollout: int = 0,
+    refinement_estimator: Optional[BaseRefinementEstimator] = None,
+    check_dr_reachable: bool = True,
+    allow_noops: bool = False,
+    use_visited_state_set: bool = False
+) -> Tuple[List[_Option], List[_GroundNSRT], Metrics]:
     """The default version of SeSamE, which runs A* to produce skeletons."""
     init_atoms = utils.abstract(task.init, predicates)
     objects = list(task.init)
@@ -186,7 +188,7 @@ def _sesame_plan_with_astar(
                         f" samples, discovering "
                         f"{int(metrics['num_failures_discovered'])} failures")
                     metrics["plan_length"] = len(plan)
-                    return plan, metrics
+                    return plan, skeleton, metrics
                 partial_refinements.append((skeleton, plan))
                 if time.perf_counter() - start_time > timeout:
                     raise PlanningTimeout(
@@ -1013,10 +1015,10 @@ def fd_plan_from_sas_file(
 
 
 def _sesame_plan_with_fast_downward(
-        task: Task, option_model: _OptionModelBase, nsrts: Set[NSRT],
-        predicates: Set[Predicate], types: Set[Type], timeout: float,
-        seed: int, max_horizon: int,
-        optimal: bool) -> Tuple[List[_Option], Metrics]:  # pragma: no cover
+    task: Task, option_model: _OptionModelBase, nsrts: Set[NSRT],
+    predicates: Set[Predicate], types: Set[Type], timeout: float, seed: int,
+    max_horizon: int, optimal: bool
+) -> Tuple[List[_Option], List[_GroundNSRT], Metrics]:  # pragma: no cover
     """A version of SeSamE that runs the Fast Downward planner to produce a
     single skeleton, then calls run_low_level_search() to turn it into a plan.
 
@@ -1071,7 +1073,7 @@ def _sesame_plan_with_fast_downward(
                     raise PlanningTimeout("Planning timed out in refinement!")
                 raise PlanningFailure("Skeleton produced by FD not refinable!")
             metrics["plan_length"] = len(plan)
-            return plan, metrics
+            return plan, skeleton, metrics
         except _DiscoveredFailureException as e:
             metrics["num_failures_discovered"] += 1
             _update_sas_file_with_failure(e.discovered_failure, sas_file)

--- a/predicators/planning.py
+++ b/predicators/planning.py
@@ -904,6 +904,11 @@ def task_plan_with_option_plan_constraint(
             # during grounding.
             if applicable_nsrt.option != gt_param_option:
                 continue
+
+            # if "{NOT-On(block1:block, block3:block), ((0:block).pose_z<=[idx 3]0.282)(block0:block), ((0:block).pose_z<=[idx 1]0.342)(block0:block), ((0:block).pose_z<=[idx 0]0.461)(block0:block), NOT-On(block0:block, block1:block), ((0:robot).fingers<=[idx 0]0.5)(robby:robot), NOT-On(block3:block, block2:block), ((0:block).pose_z<=[idx 3]0.282)(block3:block), ((0:block).pose_z<=[idx 1]0.342)(block1:block), ((0:block).pose_z<=[idx 1]0.342)(block3:block), NOT-OnTable(block2:block), OnTable(block0:block), Forall[1:block].[NOT-On(0,1)](block3:block), ((0:block).pose_z<=[idx 3]0.282)(block1:block), NOT-On(block2:block, block3:block), On(block1:block, block0:block), ((0:block).pose_z<=[idx 0]0.461)(block1:block), NOT-((0:block).pose_z<=[idx 3]0.282)(block2:block), Forall[1:block].[NOT-On(0,1)](block0:block), NOT-On(block2:block, block2:block), NOT-On(block2:block, block0:block), Forall[0:block].[NOT-On(0,1)](block1:block), NOT-((0:block).pose_z<=[idx 1]0.342)(block2:block), NOT-Forall[0:block].[((0:block).pose_z<=[idx 1]0.342)(0)](), NOT-On(block0:block, block2:block), OnTable(block3:block), Forall[0:block].[NOT-On(0,1)](block3:block), NOT-Forall[0:block].[NOT-On(0,1)](block0:block), NOT-Forall[1:block].[NOT-On(0,1)](block1:block), NOT-On(block1:block, block1:block), NOT-OnTable(block1:block), Forall[1:block].[NOT-On(0,1)](block2:block), NOT-On(block3:block, block0:block), Forall[0:block].[NOT-On(0,1)](block2:block), NOT-On(block2:block, block1:block), NOT-On(block1:block, block2:block), NOT-On(block0:block, block3:block), NOT-((0:block).pose_z<=[idx 0]0.461)(block2:block), NOT-On(block3:block, block1:block), NOT-On(block0:block, block0:block), NOT-Forall[0:block].[((0:block).pose_z<=[idx 0]0.461)(0)](), NOT-On(block3:block, block3:block), ((0:block).pose_z<=[idx 0]0.461)(block3:block)}" in str(atoms_seq[idx_into_traj]):
+            # if "Stack" in str(gt_param_option):
+            #     import ipdb; ipdb.set_trace()
+
             if applicable_nsrt.option_objs != gt_objects:
                 continue
             if atoms_seq is not None and not \

--- a/predicators/planning.py
+++ b/predicators/planning.py
@@ -904,11 +904,6 @@ def task_plan_with_option_plan_constraint(
             # during grounding.
             if applicable_nsrt.option != gt_param_option:
                 continue
-
-            # if "{NOT-On(block1:block, block3:block), ((0:block).pose_z<=[idx 3]0.282)(block0:block), ((0:block).pose_z<=[idx 1]0.342)(block0:block), ((0:block).pose_z<=[idx 0]0.461)(block0:block), NOT-On(block0:block, block1:block), ((0:robot).fingers<=[idx 0]0.5)(robby:robot), NOT-On(block3:block, block2:block), ((0:block).pose_z<=[idx 3]0.282)(block3:block), ((0:block).pose_z<=[idx 1]0.342)(block1:block), ((0:block).pose_z<=[idx 1]0.342)(block3:block), NOT-OnTable(block2:block), OnTable(block0:block), Forall[1:block].[NOT-On(0,1)](block3:block), ((0:block).pose_z<=[idx 3]0.282)(block1:block), NOT-On(block2:block, block3:block), On(block1:block, block0:block), ((0:block).pose_z<=[idx 0]0.461)(block1:block), NOT-((0:block).pose_z<=[idx 3]0.282)(block2:block), Forall[1:block].[NOT-On(0,1)](block0:block), NOT-On(block2:block, block2:block), NOT-On(block2:block, block0:block), Forall[0:block].[NOT-On(0,1)](block1:block), NOT-((0:block).pose_z<=[idx 1]0.342)(block2:block), NOT-Forall[0:block].[((0:block).pose_z<=[idx 1]0.342)(0)](), NOT-On(block0:block, block2:block), OnTable(block3:block), Forall[0:block].[NOT-On(0,1)](block3:block), NOT-Forall[0:block].[NOT-On(0,1)](block0:block), NOT-Forall[1:block].[NOT-On(0,1)](block1:block), NOT-On(block1:block, block1:block), NOT-OnTable(block1:block), Forall[1:block].[NOT-On(0,1)](block2:block), NOT-On(block3:block, block0:block), Forall[0:block].[NOT-On(0,1)](block2:block), NOT-On(block2:block, block1:block), NOT-On(block1:block, block2:block), NOT-On(block0:block, block3:block), NOT-((0:block).pose_z<=[idx 0]0.461)(block2:block), NOT-On(block3:block, block1:block), NOT-On(block0:block, block0:block), NOT-Forall[0:block].[((0:block).pose_z<=[idx 0]0.461)(0)](), NOT-On(block3:block, block3:block), ((0:block).pose_z<=[idx 0]0.461)(block3:block)}" in str(atoms_seq[idx_into_traj]):
-            # if "Stack" in str(gt_param_option):
-            #     import ipdb; ipdb.set_trace()
-
             if applicable_nsrt.option_objs != gt_objects:
                 continue
             if atoms_seq is not None and not \

--- a/predicators/predicate_search_score_functions.py
+++ b/predicators/predicate_search_score_functions.py
@@ -148,7 +148,8 @@ class _OperatorLearningBasedScoreFunction(_PredicateSearchScoreFunction):
                                                | self._initial_predicates),
                                            segmented_trajs,
                                            verify_harmlessness=False,
-                                           verbose=False)
+                                           verbose=False,
+                                           annotations=None)
         except TimeoutError:
             logging.info(
                 "Warning: Operator Learning timed out! Skipping evaluation.")

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -543,6 +543,7 @@ class GlobalSettings:
     grammar_search_grammar_use_diff_features = False
     grammar_search_use_handcoded_debug_grammar = False
     grammar_search_pred_selection_approach = "score_optimization"
+    grammar_search_pred_clusterer = "oracle"
     grammar_search_true_pos_weight = 10
     grammar_search_false_pos_weight = 1
     grammar_search_bf_weight = 1

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -542,6 +542,7 @@ class GlobalSettings:
     grammar_search_grammar_includes_foralls = True
     grammar_search_grammar_use_diff_features = False
     grammar_search_use_handcoded_debug_grammar = False
+    grammar_search_pred_selection_approach = "score_optimization"
     grammar_search_true_pos_weight = 10
     grammar_search_false_pos_weight = 1
     grammar_search_bf_weight = 1

--- a/scripts/skeleton_score_analysis.py
+++ b/scripts/skeleton_score_analysis.py
@@ -155,7 +155,8 @@ def _skeleton_based_score_function(
                                    current_predicate_set,
                                    segmented_trajs,
                                    verify_harmlessness=False,
-                                   verbose=False)
+                                   verbose=False,
+                                   annotations=dataset.annotations)
     strips_ops = [pnad.op for pnad in pnads]
     option_specs = [pnad.option_spec for pnad in pnads]
     per_skeleton_results = []  # shape (num tasks, max skeletons)

--- a/scripts/supercloud/run_predicators_main_experiments.sh
+++ b/scripts/supercloud/run_predicators_main_experiments.sh
@@ -13,24 +13,24 @@ for ENV in ${ALL_ENVS[@]}; do
     # Main approach.
     python $FILE --experiment_id ${ENV}_main_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
 
-    # Ablations.
-    # Note: downrefeval is main but with --sesame_max_skeletons_optimized 1 during evaluation only. We can only run this using `--load_approach` since we don't allow grammar_search_expected_nodes_max_skeletons to be greater than sesame_max_skeletons_optimized during invention.
-    python $FILE --experiment_id ${ENV}_downrefscore_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_expected_nodes_max_skeletons 1 --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
-    python $FILE --experiment_id ${ENV}_noinventallexclude_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
-    python $FILE --experiment_id ${ENV}_noinventnoexclude_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --num_train_tasks $NUM_TRAIN_TASKS
+    # # Ablations.
+    # # Note: downrefeval is main but with --sesame_max_skeletons_optimized 1 during evaluation only. We can only run this using `--load_approach` since we don't allow grammar_search_expected_nodes_max_skeletons to be greater than sesame_max_skeletons_optimized during invention.
+    # python $FILE --experiment_id ${ENV}_downrefscore_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_expected_nodes_max_skeletons 1 --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    # python $FILE --experiment_id ${ENV}_noinventallexclude_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    # python $FILE --experiment_id ${ENV}_noinventnoexclude_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --num_train_tasks $NUM_TRAIN_TASKS
 
-    # Score function baselines.
-    python $FILE --experiment_id ${ENV}_prederror_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function prediction_error --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
-    python $FILE --experiment_id ${ENV}_branchfac_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function branching_factor --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
-    python $FILE --experiment_id ${ENV}_energy_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function lmcut_energy_lookaheaddepth0 --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    # # Score function baselines.
+    # python $FILE --experiment_id ${ENV}_prederror_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function prediction_error --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    # python $FILE --experiment_id ${ENV}_branchfac_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function branching_factor --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    # python $FILE --experiment_id ${ENV}_energy_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function lmcut_energy_lookaheaddepth0 --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
 
-    # Other baselines.
-    python $FILE --experiment_id ${ENV}_random --env $ENV --approach random_options --num_train_tasks 0
-    python $FILE --experiment_id ${ENV}_gnn_shooting_${NUM_TRAIN_TASKS}demo --env $ENV --approach gnn_option_policy --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    # # Other baselines.
+    # python $FILE --experiment_id ${ENV}_random --env $ENV --approach random_options --num_train_tasks 0
+    # python $FILE --experiment_id ${ENV}_gnn_shooting_${NUM_TRAIN_TASKS}demo --env $ENV --approach gnn_option_policy --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
 
-    # Blocks-specific experiments.
-    if [ $ENV = "blocks" ] || [ $ENV = "pybullet_blocks" ]; then
-        python $FILE --experiment_id ${ENV}_mainhadd_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --sesame_task_planning_heuristic hadd --offline_data_task_planning_heuristic lmcut --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
-        python $FILE --experiment_id ${ENV}_noinventnoexcludehadd_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --sesame_task_planning_heuristic hadd --offline_data_task_planning_heuristic lmcut --num_train_tasks $NUM_TRAIN_TASKS
-    fi
+    # # Blocks-specific experiments.
+    # if [ $ENV = "blocks" ] || [ $ENV = "pybullet_blocks" ]; then
+    #     python $FILE --experiment_id ${ENV}_mainhadd_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --sesame_task_planning_heuristic hadd --offline_data_task_planning_heuristic lmcut --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    #     python $FILE --experiment_id ${ENV}_noinventnoexcludehadd_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --sesame_task_planning_heuristic hadd --offline_data_task_planning_heuristic lmcut --num_train_tasks $NUM_TRAIN_TASKS
+    # fi
 done

--- a/scripts/supercloud/run_predicators_main_experiments.sh
+++ b/scripts/supercloud/run_predicators_main_experiments.sh
@@ -3,10 +3,10 @@
 FILE="scripts/supercloud/submit_supercloud_job.py"
 NUM_TRAIN_TASKS="200"
 ALL_ENVS=(
-    "cover"
-    "blocks"
-    "painting"
-    "tools"
+    # "cover"
+    "pybullet_blocks"
+    # "painting"
+    # "tools"
 )
 
 for ENV in ${ALL_ENVS[@]}; do

--- a/scripts/supercloud/run_predicators_main_experiments.sh
+++ b/scripts/supercloud/run_predicators_main_experiments.sh
@@ -11,26 +11,26 @@ ALL_ENVS=(
 
 for ENV in ${ALL_ENVS[@]}; do
     # Main approach.
-    python $FILE --experiment_id ${ENV}_main_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    python $FILE --experiment_id ${ENV}_main_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS --grammar_search_max_predicates 200 --offline_data_method demo+gt_operators --grammar_search_pred_selection_approach clustering --strips_learner oracle_clustering
 
-    # Ablations.
-    # Note: downrefeval is main but with --sesame_max_skeletons_optimized 1 during evaluation only. We can only run this using `--load_approach` since we don't allow grammar_search_expected_nodes_max_skeletons to be greater than sesame_max_skeletons_optimized during invention.
-    python $FILE --experiment_id ${ENV}_downrefscore_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_expected_nodes_max_skeletons 1 --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
-    python $FILE --experiment_id ${ENV}_noinventallexclude_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
-    python $FILE --experiment_id ${ENV}_noinventnoexclude_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --num_train_tasks $NUM_TRAIN_TASKS
+    # # Ablations.
+    # # Note: downrefeval is main but with --sesame_max_skeletons_optimized 1 during evaluation only. We can only run this using `--load_approach` since we don't allow grammar_search_expected_nodes_max_skeletons to be greater than sesame_max_skeletons_optimized during invention.
+    # python $FILE --experiment_id ${ENV}_downrefscore_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_expected_nodes_max_skeletons 1 --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    # python $FILE --experiment_id ${ENV}_noinventallexclude_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    # python $FILE --experiment_id ${ENV}_noinventnoexclude_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --num_train_tasks $NUM_TRAIN_TASKS
 
-    # Score function baselines.
-    python $FILE --experiment_id ${ENV}_prederror_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function prediction_error --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
-    python $FILE --experiment_id ${ENV}_branchfac_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function branching_factor --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
-    python $FILE --experiment_id ${ENV}_energy_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function lmcut_energy_lookaheaddepth0 --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    # # Score function baselines.
+    # python $FILE --experiment_id ${ENV}_prederror_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function prediction_error --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    # python $FILE --experiment_id ${ENV}_branchfac_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function branching_factor --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    # python $FILE --experiment_id ${ENV}_energy_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function lmcut_energy_lookaheaddepth0 --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
 
-    # Other baselines.
-    python $FILE --experiment_id ${ENV}_random --env $ENV --approach random_options --num_train_tasks 0
-    python $FILE --experiment_id ${ENV}_gnn_shooting_${NUM_TRAIN_TASKS}demo --env $ENV --approach gnn_option_policy --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    # # Other baselines.
+    # python $FILE --experiment_id ${ENV}_random --env $ENV --approach random_options --num_train_tasks 0
+    # python $FILE --experiment_id ${ENV}_gnn_shooting_${NUM_TRAIN_TASKS}demo --env $ENV --approach gnn_option_policy --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
 
-    # Blocks-specific experiments.
-    if [ $ENV = "blocks" ] || [ $ENV = "pybullet_blocks" ]; then
-        python $FILE --experiment_id ${ENV}_mainhadd_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --sesame_task_planning_heuristic hadd --offline_data_task_planning_heuristic lmcut --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
-        python $FILE --experiment_id ${ENV}_noinventnoexcludehadd_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --sesame_task_planning_heuristic hadd --offline_data_task_planning_heuristic lmcut --num_train_tasks $NUM_TRAIN_TASKS
-    fi
+    # # Blocks-specific experiments.
+    # if [ $ENV = "blocks" ] || [ $ENV = "pybullet_blocks" ]; then
+    #     python $FILE --experiment_id ${ENV}_mainhadd_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --sesame_task_planning_heuristic hadd --offline_data_task_planning_heuristic lmcut --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    #     python $FILE --experiment_id ${ENV}_noinventnoexcludehadd_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --sesame_task_planning_heuristic hadd --offline_data_task_planning_heuristic lmcut --num_train_tasks $NUM_TRAIN_TASKS
+    # fi
 done

--- a/scripts/supercloud/run_predicators_main_experiments.sh
+++ b/scripts/supercloud/run_predicators_main_experiments.sh
@@ -3,34 +3,34 @@
 FILE="scripts/supercloud/submit_supercloud_job.py"
 NUM_TRAIN_TASKS="200"
 ALL_ENVS=(
-    # "cover"
+    "cover"
     "pybullet_blocks"
-    # "painting"
-    # "tools"
+    "painting"
+    "tools"
 )
 
 for ENV in ${ALL_ENVS[@]}; do
     # Main approach.
-    python $FILE --experiment_id ${ENV}_main_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS --offline_data_method demo+gt_operators --grammar_search_pred_selection_approach clustering --strips_learner oracle_clustering
+    python $FILE --experiment_id ${ENV}_main_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
 
-    # # Ablations.
-    # # Note: downrefeval is main but with --sesame_max_skeletons_optimized 1 during evaluation only. We can only run this using `--load_approach` since we don't allow grammar_search_expected_nodes_max_skeletons to be greater than sesame_max_skeletons_optimized during invention.
-    # python $FILE --experiment_id ${ENV}_downrefscore_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_expected_nodes_max_skeletons 1 --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
-    # python $FILE --experiment_id ${ENV}_noinventallexclude_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
-    # python $FILE --experiment_id ${ENV}_noinventnoexclude_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --num_train_tasks $NUM_TRAIN_TASKS
+    # Ablations.
+    # Note: downrefeval is main but with --sesame_max_skeletons_optimized 1 during evaluation only. We can only run this using `--load_approach` since we don't allow grammar_search_expected_nodes_max_skeletons to be greater than sesame_max_skeletons_optimized during invention.
+    python $FILE --experiment_id ${ENV}_downrefscore_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_expected_nodes_max_skeletons 1 --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    python $FILE --experiment_id ${ENV}_noinventallexclude_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    python $FILE --experiment_id ${ENV}_noinventnoexclude_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --num_train_tasks $NUM_TRAIN_TASKS
 
-    # # Score function baselines.
-    # python $FILE --experiment_id ${ENV}_prederror_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function prediction_error --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
-    # python $FILE --experiment_id ${ENV}_branchfac_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function branching_factor --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
-    # python $FILE --experiment_id ${ENV}_energy_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function lmcut_energy_lookaheaddepth0 --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    # Score function baselines.
+    python $FILE --experiment_id ${ENV}_prederror_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function prediction_error --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    python $FILE --experiment_id ${ENV}_branchfac_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function branching_factor --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    python $FILE --experiment_id ${ENV}_energy_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function lmcut_energy_lookaheaddepth0 --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
 
-    # # Other baselines.
-    # python $FILE --experiment_id ${ENV}_random --env $ENV --approach random_options --num_train_tasks 0
-    # python $FILE --experiment_id ${ENV}_gnn_shooting_${NUM_TRAIN_TASKS}demo --env $ENV --approach gnn_option_policy --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    # Other baselines.
+    python $FILE --experiment_id ${ENV}_random --env $ENV --approach random_options --num_train_tasks 0
+    python $FILE --experiment_id ${ENV}_gnn_shooting_${NUM_TRAIN_TASKS}demo --env $ENV --approach gnn_option_policy --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
 
-    # # Blocks-specific experiments.
-    # if [ $ENV = "blocks" ] || [ $ENV = "pybullet_blocks" ]; then
-    #     python $FILE --experiment_id ${ENV}_mainhadd_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --sesame_task_planning_heuristic hadd --offline_data_task_planning_heuristic lmcut --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
-    #     python $FILE --experiment_id ${ENV}_noinventnoexcludehadd_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --sesame_task_planning_heuristic hadd --offline_data_task_planning_heuristic lmcut --num_train_tasks $NUM_TRAIN_TASKS
-    # fi
+    # Blocks-specific experiments.
+    if [ $ENV = "blocks" ] || [ $ENV = "pybullet_blocks" ]; then
+        python $FILE --experiment_id ${ENV}_mainhadd_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --sesame_task_planning_heuristic hadd --offline_data_task_planning_heuristic lmcut --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+        python $FILE --experiment_id ${ENV}_noinventnoexcludehadd_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --sesame_task_planning_heuristic hadd --offline_data_task_planning_heuristic lmcut --num_train_tasks $NUM_TRAIN_TASKS
+    fi
 done

--- a/scripts/supercloud/run_predicators_main_experiments.sh
+++ b/scripts/supercloud/run_predicators_main_experiments.sh
@@ -11,7 +11,7 @@ ALL_ENVS=(
 
 for ENV in ${ALL_ENVS[@]}; do
     # Main approach.
-    python $FILE --experiment_id ${ENV}_main_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS --offline_data_method demo+gt_operators --grammar_search_pred_selection_approach clustering --strips_learner pnad_search --pnad_search_timeout 1000.0 --disable_harmlessness_check True
+    python $FILE --experiment_id ${ENV}_main_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS --offline_data_method demo+gt_operators --grammar_search_pred_selection_approach clustering --strips_learner oracle_clustering
 
     # # Ablations.
     # # Note: downrefeval is main but with --sesame_max_skeletons_optimized 1 during evaluation only. We can only run this using `--load_approach` since we don't allow grammar_search_expected_nodes_max_skeletons to be greater than sesame_max_skeletons_optimized during invention.

--- a/scripts/supercloud/run_predicators_main_experiments.sh
+++ b/scripts/supercloud/run_predicators_main_experiments.sh
@@ -4,14 +4,14 @@ FILE="scripts/supercloud/submit_supercloud_job.py"
 NUM_TRAIN_TASKS="200"
 ALL_ENVS=(
     "cover"
-    "pybullet_blocks"
+    "blocks"
     "painting"
     "tools"
 )
 
 for ENV in ${ALL_ENVS[@]}; do
     # Main approach.
-    python $FILE --experiment_id ${ENV}_main_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    python $FILE --experiment_id ${ENV}_main_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS --offline_data_method demo+gt_operators --grammar_search_pred_selection_approach clustering --strips_learner pnad_search --pnad_search_timeout 1000.0 --disable_harmlessness_check True
 
     # # Ablations.
     # # Note: downrefeval is main but with --sesame_max_skeletons_optimized 1 during evaluation only. We can only run this using `--load_approach` since we don't allow grammar_search_expected_nodes_max_skeletons to be greater than sesame_max_skeletons_optimized during invention.

--- a/scripts/supercloud/run_predicators_main_experiments.sh
+++ b/scripts/supercloud/run_predicators_main_experiments.sh
@@ -11,26 +11,26 @@ ALL_ENVS=(
 
 for ENV in ${ALL_ENVS[@]}; do
     # Main approach.
-    python $FILE --experiment_id ${ENV}_main_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS --grammar_search_max_predicates 200 --offline_data_method demo+gt_operators --grammar_search_pred_selection_approach clustering --strips_learner oracle_clustering
+    python $FILE --experiment_id ${ENV}_main_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
 
-    # # Ablations.
-    # # Note: downrefeval is main but with --sesame_max_skeletons_optimized 1 during evaluation only. We can only run this using `--load_approach` since we don't allow grammar_search_expected_nodes_max_skeletons to be greater than sesame_max_skeletons_optimized during invention.
-    # python $FILE --experiment_id ${ENV}_downrefscore_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_expected_nodes_max_skeletons 1 --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
-    # python $FILE --experiment_id ${ENV}_noinventallexclude_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
-    # python $FILE --experiment_id ${ENV}_noinventnoexclude_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --num_train_tasks $NUM_TRAIN_TASKS
+    # Ablations.
+    # Note: downrefeval is main but with --sesame_max_skeletons_optimized 1 during evaluation only. We can only run this using `--load_approach` since we don't allow grammar_search_expected_nodes_max_skeletons to be greater than sesame_max_skeletons_optimized during invention.
+    python $FILE --experiment_id ${ENV}_downrefscore_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_expected_nodes_max_skeletons 1 --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    python $FILE --experiment_id ${ENV}_noinventallexclude_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    python $FILE --experiment_id ${ENV}_noinventnoexclude_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --num_train_tasks $NUM_TRAIN_TASKS
 
-    # # Score function baselines.
-    # python $FILE --experiment_id ${ENV}_prederror_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function prediction_error --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
-    # python $FILE --experiment_id ${ENV}_branchfac_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function branching_factor --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
-    # python $FILE --experiment_id ${ENV}_energy_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function lmcut_energy_lookaheaddepth0 --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    # Score function baselines.
+    python $FILE --experiment_id ${ENV}_prederror_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function prediction_error --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    python $FILE --experiment_id ${ENV}_branchfac_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function branching_factor --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    python $FILE --experiment_id ${ENV}_energy_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --grammar_search_score_function lmcut_energy_lookaheaddepth0 --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
 
-    # # Other baselines.
-    # python $FILE --experiment_id ${ENV}_random --env $ENV --approach random_options --num_train_tasks 0
-    # python $FILE --experiment_id ${ENV}_gnn_shooting_${NUM_TRAIN_TASKS}demo --env $ENV --approach gnn_option_policy --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+    # Other baselines.
+    python $FILE --experiment_id ${ENV}_random --env $ENV --approach random_options --num_train_tasks 0
+    python $FILE --experiment_id ${ENV}_gnn_shooting_${NUM_TRAIN_TASKS}demo --env $ENV --approach gnn_option_policy --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
 
-    # # Blocks-specific experiments.
-    # if [ $ENV = "blocks" ] || [ $ENV = "pybullet_blocks" ]; then
-    #     python $FILE --experiment_id ${ENV}_mainhadd_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --sesame_task_planning_heuristic hadd --offline_data_task_planning_heuristic lmcut --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
-    #     python $FILE --experiment_id ${ENV}_noinventnoexcludehadd_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --sesame_task_planning_heuristic hadd --offline_data_task_planning_heuristic lmcut --num_train_tasks $NUM_TRAIN_TASKS
-    # fi
+    # Blocks-specific experiments.
+    if [ $ENV = "blocks" ] || [ $ENV = "pybullet_blocks" ]; then
+        python $FILE --experiment_id ${ENV}_mainhadd_${NUM_TRAIN_TASKS}demo --env $ENV --approach grammar_search_invention --sesame_task_planning_heuristic hadd --offline_data_task_planning_heuristic lmcut --excluded_predicates all --num_train_tasks $NUM_TRAIN_TASKS
+        python $FILE --experiment_id ${ENV}_noinventnoexcludehadd_${NUM_TRAIN_TASKS}demo --env $ENV --approach nsrt_learning --sesame_task_planning_heuristic hadd --offline_data_task_planning_heuristic lmcut --num_train_tasks $NUM_TRAIN_TASKS
+    fi
 done

--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -205,6 +205,12 @@ def test_unary_free_forall_classifier():
 
 
 def test_unrecognized_clusterer():
+    """Tests that a dummy name for the 'clusterer' argument will trigger a
+    failure.
+
+    Note that most of the coverage for the clusterer comes from
+    test_nsrt_learning_approach.py.
+    """
     utils.update_config({
         "env": "cover",
         "segmenter": "atom_changes",

--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -7,12 +7,14 @@ import pytest
 
 from predicators import utils
 from predicators.approaches.grammar_search_invention_approach import \
-    _AttributeDiffCompareClassifier, _create_grammar, \
-    _DataBasedPredicateGrammar, _FeatureDiffInequalitiesPredicateGrammar, \
-    _ForallClassifier, _halving_constant_generator, _NegationClassifier, \
-    _PredicateGrammar, _SingleAttributeCompareClassifier, \
+    GrammarSearchInventionApproach, _AttributeDiffCompareClassifier, \
+    _create_grammar, _DataBasedPredicateGrammar, \
+    _FeatureDiffInequalitiesPredicateGrammar, _ForallClassifier, \
+    _halving_constant_generator, _NegationClassifier, _PredicateGrammar, \
+    _SingleAttributeCompareClassifier, \
     _SingleFeatureInequalitiesPredicateGrammar, _UnaryFreeForallClassifier
 from predicators.envs.cover import CoverEnv
+from predicators.ground_truth_models import get_gt_options
 from predicators.settings import CFG
 from predicators.structs import Action, Dataset, LowLevelTrajectory, Object, \
     Predicate, State, Type
@@ -200,3 +202,33 @@ def test_unary_free_forall_classifier():
     assert str(classifier3) == "NOT-Forall[1:plate_type].[NOT-On(0,1)]"
     assert classifier3.pretty_str() == ("?x:cup_type",
                                         "¬(∀ ?y:plate_type . ¬On(?x, ?y))")
+
+
+def test_unrecognized_clusterer():
+    utils.update_config({
+        "env": "cover",
+        "segmenter": "atom_changes",
+        "grammar_search_pred_selection_approach": "clustering",
+        "grammar_search_pred_clusterer": "NotARealClusterer"
+    })
+    env = CoverEnv()
+    train_task = env.get_train_tasks()[0].task
+    state = train_task.init
+    other_state = state.copy()
+    robby = [o for o in state if o.type.name == "robot"][0]
+    block = [o for o in state if o.name == "block0"][0]
+    state.set(robby, "hand", 0.5)
+    other_state.set(robby, "hand", 0.8)
+    state.set(block, "grasp", -1)
+    other_state.set(block, "grasp", 1)
+    dataset = Dataset([
+        LowLevelTrajectory([state, other_state],
+                           [Action(np.zeros(1, dtype=np.float32))])
+    ])
+    approach = GrammarSearchInventionApproach(env.predicates,
+                                              get_gt_options(env.get_name()),
+                                              env.types, env.action_space,
+                                              [train_task])
+    with pytest.raises(NotImplementedError) as e:
+        approach.learn_from_offline_dataset(dataset)
+    assert "Unrecognized clusterer" in str(e)

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -400,3 +400,20 @@ def test_oracle_strips_and_segmenter_learning():
                    num_train_tasks=1,
                    try_solving=False,
                    additional_settings=additional_settings)
+
+
+def test_predicate_invention_with_oracle_clustering():
+    """Test for predicate invention via clustering assuming access to clusters
+    from ground truth operators."""
+    additional_settings = {
+        "grammar_search_pred_selection_approach": "clustering",
+        "grammar_search_pred_clusterer": "oracle",
+        "segmenter": "option_changes",
+    }
+    _test_approach(env_name="blocks",
+                   num_train_tasks=1,
+                   approach_name="grammar_search_invention",
+                   strips_learner="oracle_clustering",
+                   offline_data_method="demo+gt_operators",
+                   solve_exceptions=ApproachFailure,
+                   additional_settings=additional_settings)

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -595,7 +595,7 @@ def test_repeated_nextto_painting_get_gt_nsrts():
     nsrts = get_gt_nsrts(env.get_name(), env.predicates,
                          get_gt_options(env.get_name()))
     ptables = [nsrt for nsrt in nsrts if nsrt.name.startswith("PlaceOnTable")]
-    assert len(ptables) == 1
+    assert len(ptables) == 2
     ptable = ptables[0]
     opt = ptable.ground([obj0, robby]).sample_option(init, set(), rng)
     assert opt.objects == [robby]

--- a/tests/nsrt_learning/strips_learning/test_backchaining_based_learners.py
+++ b/tests/nsrt_learning/strips_learning/test_backchaining_based_learners.py
@@ -99,7 +99,8 @@ def test_backchaining_strips_learner(approach_name, approach_cls):
     segment2 = Segment(traj2, set(), goal2, Eat)
     learner = approach_cls([traj1, traj2], [task1, task2], {Asleep},
                            [[segment1], [segment2]],
-                           verify_harmlessness=True)
+                           verify_harmlessness=True,
+                           annotations=None)
     pnads = learner.learn()
     # Verify the results are as expected.
     expected_strs = [
@@ -136,7 +137,8 @@ def test_backchaining_strips_learner(approach_name, approach_cls):
     # Create and run the sidelining approach.
     learner = approach_cls([traj3, traj4], [task3, task4], {Asleep, Sad},
                            [[segment3], [segment4]],
-                           verify_harmlessness=True)
+                           verify_harmlessness=True,
+                           annotations=None)
     pnads = learner.learn()
     assert len(pnads) == 1
     expected_str = """STRIPS-Cry0:
@@ -152,7 +154,8 @@ def test_backchaining_strips_learner(approach_name, approach_cls):
         utils.reset_config({"pnad_search_without_del": True})
         learner = approach_cls([traj3, traj4], [task3, task4], {Asleep, Sad},
                                [[segment3], [segment4]],
-                               verify_harmlessness=True)
+                               verify_harmlessness=True,
+                               annotations=None)
         pnads = learner.learn()
         assert len(pnads) == 1
         assert str(pnads[0]) == repr(pnads[0]) == expected_str
@@ -251,14 +254,16 @@ def test_backchaining_strips_learner_order_dependence(approach_name,
         [traj1, traj2, traj3], [task1, task2, task3],
         {RobotAt, LightOn, NotLightOn, LightColorBlue, LightColorRed},
         [[segment1], [segment2], [segment3]],
-        verify_harmlessness=True)
+        verify_harmlessness=True,
+        annotations=None)
     natural_order_pnads = learner.learn()
     # Now, create and run the learner with the 3 demos in the reverse order.
     learner = approach_cls(
         [traj3, traj2, traj1], [task1, task2, task3],
         {RobotAt, LightOn, NotLightOn, LightColorBlue, LightColorRed},
         [[segment3], [segment2], [segment1]],
-        verify_harmlessness=True)
+        verify_harmlessness=True,
+        annotations=None)
     if approach_name == "backchaining":
         # Be sure to reset the segment add effects before doing this.
         learner.reset_all_segment_add_effs()
@@ -561,7 +566,8 @@ def test_backchaining_strips_learner_order_dependence(approach_name,
     learner = approach_cls([traj1, traj2], [task1, task2],
                            preds,
                            segmented_trajs,
-                           verify_harmlessness=True)
+                           verify_harmlessness=True,
+                           annotations=None)
     natural_order_pnads = learner.learn()
     action_space = Box(0, 1, (1, ))
     dataset = [traj1, traj2]
@@ -595,7 +601,8 @@ def test_backchaining_strips_learner_order_dependence(approach_name,
     learner = approach_cls([traj2, traj1], [task2, task1],
                            preds,
                            segmented_trajs,
-                           verify_harmlessness=True)
+                           verify_harmlessness=True,
+                           annotations=None)
     if approach_name == "backchaining":
         # Be sure to reset the segment add effects before doing this.
         learner.reset_all_segment_add_effs()
@@ -827,7 +834,8 @@ def test_keep_effect_data_partitioning(approach_cls):
     learner = approach_cls([traj1, traj2], [task1, task2],
                            predicates,
                            segmented_trajs,
-                           verify_harmlessness=True)
+                           verify_harmlessness=True,
+                           annotations=None)
     output_pnads = learner.learn()
     # There should be exactly 4 output PNADs: 2 for Configure, and 1 for
     # each of TurnOn and Run. One of the Configure operators should have
@@ -1040,7 +1048,8 @@ def test_combinatorial_keep_effect_data_partitioning(approach_name,
                            [task1, task2, task3, task4],
                            predicates,
                            segmented_trajs,
-                           verify_harmlessness=True)
+                           verify_harmlessness=True,
+                           annotations=None)
     output_pnads = learner.learn()
     # We need 6 or 7 PNADs: 3 or 4 for configure, and 1 each for turn on,
     # run, and fix.
@@ -1110,7 +1119,8 @@ def test_combinatorial_keep_effect_data_partitioning(approach_name,
     learner = approach_cls([traj1, traj2, traj3], [task1, task2, task3],
                            predicates,
                            segmented_trajs[:-1],
-                           verify_harmlessness=True)
+                           verify_harmlessness=True,
+                           annotations=None)
     if approach_name == "backchaining":
         learner.reset_all_segment_add_effs()
     output_pnads = learner.learn()
@@ -1206,7 +1216,8 @@ def test_keep_effect_adding_new_variables(approach_cls):
     # Now, run the learner on the demo.
     learner = approach_cls([traj], [task],
                            predicates, [segmented_traj],
-                           verify_harmlessness=True)
+                           verify_harmlessness=True,
+                           annotations=None)
     output_pnads = learner.learn()
 
     # Verify that all the output PNADs are correct. The PNAD for Press should
@@ -1311,7 +1322,8 @@ def test_multi_pass_backchaining(approach_cls, val):
     learner = approach_cls([traj1, traj2, traj3], [task1, task2, task3],
                            predicates,
                            segmented_trajs,
-                           verify_harmlessness=True)
+                           verify_harmlessness=True,
+                           annotations=None)
     # Running this automatically checks that harmlessness passes.
     learned_pnads = learner.learn()
     if val == 0.0:
@@ -1430,7 +1442,8 @@ def test_segment_not_in_datastore(approach_cls):
     learner = approach_cls(trajs, [task0, task1, task2, task3],
                            predicates,
                            segmented_trajs,
-                           verify_harmlessness=True)
+                           verify_harmlessness=True,
+                           annotations=None)
     # Running this automatically checks that harmlessness passes.
     learned_pnads = learner.learn()
     assert len(learned_pnads) == 4
@@ -1620,6 +1633,7 @@ def test_backchaining_randomly_generated(approach_cls, use_single_option,
                            tasks,
                            predicates,
                            segmented_trajs,
-                           verify_harmlessness=True)
+                           verify_harmlessness=True,
+                           annotations=None)
     # Running this automatically checks that harmlessness passes.
     learner.learn()

--- a/tests/nsrt_learning/strips_learning/test_backchaining_based_learners.py
+++ b/tests/nsrt_learning/strips_learning/test_backchaining_based_learners.py
@@ -577,7 +577,8 @@ def test_backchaining_strips_learner_order_dependence(approach_name,
                                                       options,
                                                       action_space,
                                                       ground_atom_dataset,
-                                                      sampler_learner="random")
+                                                      sampler_learner="random",
+                                                      annotations=None)
 
     traj1 = LowLevelTrajectory([
         state1, state2, state3, state4, state5, state6, state7, state8, state9
@@ -613,7 +614,8 @@ def test_backchaining_strips_learner_order_dependence(approach_name,
                                                       options,
                                                       action_space,
                                                       ground_atom_dataset,
-                                                      sampler_learner="random")
+                                                      sampler_learner="random",
+                                                      annotations=None)
 
     # First, check that the two sets of PNADs have the same number of PNADs.
     # (in the case of EffectSearch).
@@ -666,7 +668,8 @@ def testspawn_new_pnad():
     # Create the sidelining approach.
     learner = _MockBackchainingSTRIPSLearner([traj], [task], {Asleep, Happy},
                                              [[segment]],
-                                             verify_harmlessness=True)
+                                             verify_harmlessness=True,
+                                             annotations=None)
     # Normal usage: the PNAD add effects can capture a subset of
     # the necessary_add_effects.
     _, ground_op = learner.find_unification(

--- a/tests/nsrt_learning/strips_learning/test_base_strips_learner.py
+++ b/tests/nsrt_learning/strips_learning/test_base_strips_learner.py
@@ -43,7 +43,8 @@ def test_recompute_datastores_from_segments():
     task = Task(state, set())
     segment = Segment(traj, {Pred([obj])}, {Pred([obj])}, act)
     learner = _MockBaseSTRIPSLearner([traj], [task], {Pred}, [[segment]],
-                                     verify_harmlessness=True)
+                                     verify_harmlessness=True,
+                                     annotations=None)
     with pytest.raises(Exception) as e:
         learner.learn()
     assert "Can't use this" in str(e)

--- a/tests/nsrt_learning/strips_learning/test_clustering_learner.py
+++ b/tests/nsrt_learning/strips_learning/test_clustering_learner.py
@@ -155,7 +155,8 @@ def test_cluster_and_intersect_strips_learner():
     known_option_pnads = learn_strips_operators([known_option_ll_traj],
                                                 None,
                                                 None, [known_option_segments],
-                                                verify_harmlessness=True)
+                                                verify_harmlessness=True,
+                                                annotations=None)
     known_option_ops = [pnad.op for pnad in known_option_pnads]
     assert len(known_option_ops) == 1
     assert str((known_option_ops[0])) == """STRIPS-Op0:
@@ -168,7 +169,8 @@ def test_cluster_and_intersect_strips_learner():
                                                   None,
                                                   None,
                                                   [unknown_option_segments],
-                                                  verify_harmlessness=True)
+                                                  verify_harmlessness=True,
+                                                  annotations=None)
     unknown_option_ops = [pnad.op for pnad in unknown_option_pnads]
     assert len(unknown_option_ops) == 1
     assert str(unknown_option_ops[0]) == """STRIPS-Op0:
@@ -232,7 +234,8 @@ def test_cluster_and_search_strips_learner():
     pnads = learn_strips_operators([traj1, traj2, traj3],
                                    [task1, task2, task3],
                                    preds, [[segment1], [segment2], [segment3]],
-                                   verify_harmlessness=True)
+                                   verify_harmlessness=True,
+                                   annotations=None)
     assert len(pnads) == 2
     op0, op1 = sorted(pnads, key=str)
     assert str(op0) == """STRIPS-Op0:
@@ -261,7 +264,8 @@ def test_cluster_and_search_strips_learner():
     pnads = learn_strips_operators([traj1, traj2, traj3],
                                    [task1, task2, task3],
                                    preds, [[segment1], [segment2], [segment3]],
-                                   verify_harmlessness=True)
+                                   verify_harmlessness=True,
+                                   annotations=None)
     assert len(pnads) == 3
     op0, op1, op2 = sorted(pnads, key=str)
     assert str(op0) == """STRIPS-Op0-0:
@@ -299,7 +303,8 @@ def test_cluster_and_search_strips_learner():
     pnads = learn_strips_operators([traj1, traj2, traj3],
                                    [task1, task2, task3],
                                    preds, [[segment1], [segment2], [segment3]],
-                                   verify_harmlessness=True)
+                                   verify_harmlessness=True,
+                                   annotations=None)
     assert len(pnads) == 2
     op0, op1 = sorted(pnads, key=str)
     assert str(op0) == """STRIPS-Op0-0:

--- a/tests/nsrt_learning/strips_learning/test_oracle_learner.py
+++ b/tests/nsrt_learning/strips_learning/test_oracle_learner.py
@@ -18,7 +18,8 @@ def test_oracle_strips_learner():
     pnads = learn_strips_operators([],
                                    None,
                                    None, [],
-                                   verify_harmlessness=True)
+                                   verify_harmlessness=True,
+                                   annotations=None)
     assert not pnads
     # With sufficiently representative data, all operators should be learned.
     env = create_new_env("blocks")
@@ -33,7 +34,8 @@ def test_oracle_strips_learner():
                                    train_tasks,
                                    env.predicates,
                                    segmented_trajs,
-                                   verify_harmlessness=True)
+                                   verify_harmlessness=True,
+                                   annotations=None)
     assert str(sorted(pnads, key=str)) == """[STRIPS-PickFromTable:
     Parameters: [?block:block, ?robot:robot]
     Preconditions: [Clear(?block:block), GripperOpen(?robot:robot), OnTable(?block:block)]
@@ -80,7 +82,8 @@ def test_oracle_strips_learner():
                                    train_tasks,
                                    env.predicates,
                                    segmented_trajs,
-                                   verify_harmlessness=True)
+                                   verify_harmlessness=True,
+                                   annotations=None)
     assert str(sorted(pnads, key=str)) == """[STRIPS-PickFromTable:
     Parameters: [?block:block, ?robot:robot]
     Preconditions: [Clear(?block:block), GripperOpen(?robot:robot), OnTable(?block:block)]

--- a/tests/nsrt_learning/test_nsrt_learning_main.py
+++ b/tests/nsrt_learning/test_nsrt_learning_main.py
@@ -46,7 +46,8 @@ def test_nsrt_learning_specific_nsrts():
                                         options,
                                         action_space,
                                         ground_atom_dataset,
-                                        sampler_learner="neural")
+                                        sampler_learner="neural",
+                                        annotations=None)
     assert len(nsrts) == 1
     nsrt = nsrts.pop()
     assert str(nsrt) == """NSRT-Op0:
@@ -90,7 +91,8 @@ def test_nsrt_learning_specific_nsrts():
                                         options,
                                         action_space,
                                         ground_atom_dataset,
-                                        sampler_learner="random")
+                                        sampler_learner="random",
+                                        annotations=None)
     assert len(nsrts) == 1
     nsrt = nsrts.pop()
     assert str(nsrt) == """NSRT-Op0:
@@ -139,7 +141,8 @@ def test_nsrt_learning_specific_nsrts():
                                         options,
                                         action_space,
                                         ground_atom_dataset,
-                                        sampler_learner="random")
+                                        sampler_learner="random",
+                                        annotations=None)
     assert len(nsrts) == 2
     expected = {
         "Op0":
@@ -187,7 +190,8 @@ def test_nsrt_learning_specific_nsrts():
                                         options,
                                         action_space,
                                         ground_atom_dataset,
-                                        sampler_learner="random")
+                                        sampler_learner="random",
+                                        annotations=None)
     assert len(nsrts) == 2
     expected = {
         "Op0":
@@ -220,7 +224,8 @@ def test_nsrt_learning_specific_nsrts():
                                         options,
                                         action_space,
                                         ground_atom_dataset,
-                                        sampler_learner="random")
+                                        sampler_learner="random",
+                                        annotations=None)
     assert len(nsrts) == 0
     # Test minimum percent of examples parameter
     utils.update_config({
@@ -233,7 +238,8 @@ def test_nsrt_learning_specific_nsrts():
                                         options,
                                         action_space,
                                         ground_atom_dataset,
-                                        sampler_learner="random")
+                                        sampler_learner="random",
+                                        annotations=None)
     assert len(nsrts) == 0
     # Test max_rejection_sampling_tries = 0
     utils.update_config({
@@ -249,7 +255,8 @@ def test_nsrt_learning_specific_nsrts():
                                         options,
                                         action_space,
                                         ground_atom_dataset,
-                                        sampler_learner="neural")
+                                        sampler_learner="neural",
+                                        annotations=None)
     assert len(nsrts) == 2
     for nsrt in nsrts:
         for _ in range(10):

--- a/tests/nsrt_learning/test_option_learning.py
+++ b/tests/nsrt_learning/test_option_learning.py
@@ -55,7 +55,7 @@ def test_known_options_option_learner():
                                    env.predicates,
                                    segmented_trajs,
                                    verify_harmlessness=True,
-                                   annotations=dataset.annotations)
+                                   annotations=None)
     strips_ops = [pnad.op for pnad in pnads]
     datastores = [pnad.datastore for pnad in pnads]
     assert len(strips_ops) == len(datastores) == 5
@@ -100,7 +100,7 @@ def test_oracle_option_learner_cover():
                                    env.predicates,
                                    segmented_trajs,
                                    verify_harmlessness=True,
-                                   annotations=dataset.annotations)
+                                   annotations=None)
     strips_ops = [pnad.op for pnad in pnads]
     datastores = [pnad.datastore for pnad in pnads]
     assert len(strips_ops) == len(datastores) == 4
@@ -150,7 +150,7 @@ def test_oracle_option_learner_blocks():
                                    env.predicates,
                                    segmented_trajs,
                                    verify_harmlessness=True,
-                                   annotations=dataset.annotations)
+                                   annotations=None)
     strips_ops = [pnad.op for pnad in pnads]
     datastores = [pnad.datastore for pnad in pnads]
     assert len(strips_ops) == len(datastores) == 4

--- a/tests/nsrt_learning/test_option_learning.py
+++ b/tests/nsrt_learning/test_option_learning.py
@@ -54,7 +54,8 @@ def test_known_options_option_learner():
                                    train_tasks,
                                    env.predicates,
                                    segmented_trajs,
-                                   verify_harmlessness=True)
+                                   verify_harmlessness=True,
+                                   annotations=dataset.annotations)
     strips_ops = [pnad.op for pnad in pnads]
     datastores = [pnad.datastore for pnad in pnads]
     assert len(strips_ops) == len(datastores) == 5
@@ -98,7 +99,8 @@ def test_oracle_option_learner_cover():
                                    train_tasks,
                                    env.predicates,
                                    segmented_trajs,
-                                   verify_harmlessness=True)
+                                   verify_harmlessness=True,
+                                   annotations=dataset.annotations)
     strips_ops = [pnad.op for pnad in pnads]
     datastores = [pnad.datastore for pnad in pnads]
     assert len(strips_ops) == len(datastores) == 4
@@ -147,7 +149,8 @@ def test_oracle_option_learner_blocks():
                                    train_tasks,
                                    env.predicates,
                                    segmented_trajs,
-                                   verify_harmlessness=True)
+                                   verify_harmlessness=True,
+                                   annotations=dataset.annotations)
     strips_ops = [pnad.op for pnad in pnads]
     datastores = [pnad.datastore for pnad in pnads]
     assert len(strips_ops) == len(datastores) == 4

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -49,7 +49,7 @@ def test_sesame_plan(sesame_check_expected_atoms, sesame_grounder, expectation,
     task = env_task.task
     option_model = create_option_model(CFG.option_model_name)
     with expectation as e:
-        plan, metrics = sesame_plan(
+        plan, _, metrics = sesame_plan(
             task,
             option_model,
             nsrts,
@@ -333,7 +333,7 @@ def test_sesame_check_static_object_changes():
     env_task = env.get_test_tasks()[0]
     task = env_task.task
     option_model = create_option_model(CFG.option_model_name)
-    plan, _ = sesame_plan(
+    plan, _, _ = sesame_plan(
         task,
         option_model,
         nsrts,
@@ -520,7 +520,7 @@ def test_policy_guided_sesame():
     option_model = create_option_model(CFG.option_model_name)
     # With a trivial policy, we would expect the number of nodes to be the
     # same as it would be if we planned with no policy.
-    unguided_plan, unguided_metrics = sesame_plan(
+    unguided_plan, _, unguided_metrics = sesame_plan(
         task,
         option_model,
         nsrts,
@@ -533,7 +533,7 @@ def test_policy_guided_sesame():
         max_horizon=CFG.horizon,
     )
     trivial_policy = lambda a, o, g: None
-    guided_plan, guided_metrics = sesame_plan(
+    guided_plan, _, guided_metrics = sesame_plan(
         task,
         option_model,
         nsrts,
@@ -580,7 +580,7 @@ def test_policy_guided_sesame():
         block = unrealized_blocks[0]
         return pick_nsrt.ground([block])
 
-    _, metrics = sesame_plan(
+    _, _, metrics = sesame_plan(
         task,
         option_model,
         nsrts,
@@ -610,7 +610,7 @@ def test_policy_guided_sesame():
                 return ground_nsrt
         raise Exception("Should not happen.")  # pragma: no cover
 
-    _, invalid_policy_metrics = sesame_plan(
+    _, _, invalid_policy_metrics = sesame_plan(
         task,
         option_model,
         nsrts,
@@ -670,7 +670,7 @@ def test_sesame_plan_fast_downward():
         task = env_task.task
         option_model = create_option_model(CFG.option_model_name)
         try:
-            plan, metrics = sesame_plan(
+            plan, _, metrics = sesame_plan(
                 task,
                 option_model,
                 nsrts,


### PR DESCRIPTION
Implements a form of predicate invention where we have access to the ground-truth operators and thus can cluster all segments according to these operators. This requires a number of changes
* enabling the last plan to get output by planning (so we can get a list of operators used)
* saving operators used during bilevel planning in `annotations` of a dataset
* Implementing a new predicate invention approach to take advantage of this information
* Implementing a new operator learning approach
Additionally, we had to modify the painting domain slightly to get things to work.

Example command with new functionality:
```
python predicators/main.py --env blocks --approach grammar_search_invention --excluded_predicates all --num_train_tasks 100 --seed 0 --grammar_search_max_predicates 200 --offline_data_method demo+gt_operators --grammar_search_pred_selection_approach clustering --strips_learner oracle_clustering
```

Current supercloud results from this method:
```
AGGREGATED DATA OVER SEEDS:
                             NUM_TRAIN_TASKS    NUM_SOLVED AVG_NUM_PREDS AVG_TEST_TIME  AVG_NODES_CREATED   LEARNING_TIME  NUM_SEEDS
EXPERIMENT_ID                                                                                                                       
cover_main_200demo             200.00 (0.00)  49.20 (0.75)  10.00 (0.00)   0.01 (0.00)        4.88 (0.15)    30.01 (2.06)         10
painting_main_200demo          200.00 (0.00)  49.80 (0.40)  50.00 (0.00)   0.57 (0.11)    858.59 (238.17)   173.18 (7.30)         10
pybullet_blocks_main_200demo   200.00 (0.00)  47.50 (1.63)  14.00 (0.00)   1.02 (0.19)  2641.70 (1192.72)  480.09 (34.00)         10
tools_main_200demo             200.00 (0.00)  49.80 (0.40)  58.00 (0.00)   0.50 (0.08)    925.29 (162.13)   119.00 (2.98)         10
```

vs. original results from AAAI method

```
AGGREGATED DATA OVER SEEDS:
                                              NUM_TRAIN_TASKS    NUM_SOLVED AVG_NUM_PREDS AVG_TEST_TIME  AVG_NODES_CREATED        LEARNING_TIME  NUM_SEEDS
EXPERIMENT_ID                                                                                                                                             
cover_main_200demo                              200.00 (0.00)  49.30 (0.64)   5.90 (0.54)   0.01 (0.00)        4.94 (0.23)       549.25 (69.44)         10
painting_main_200demo                           200.00 (0.00)  49.90 (0.30)  20.80 (1.78)   0.18 (0.04)    402.88 (116.42)  89404.23 (13707.67)         10
pybullet_blocks_main_200demo                    200.00 (0.00)  49.00 (0.77)   7.60 (1.28)   0.54 (0.17)  3997.55 (2237.44)   13717.18 (2739.89)         10
tools_main_200demo                              200.00 (0.00)  45.90 (5.79)  28.00 (5.14)   0.44 (0.30)  1926.29 (1585.43)   19286.83 (3002.72)         10
```

Note the massive improvement in learning times, though the avg_test_time is worse...