### PR TITLE
bumpy cover environment

### DIFF
--- a/.predicators_pylintrc
+++ b/.predicators_pylintrc
@@ -10,7 +10,7 @@ extension-pkg-whitelist=numpy,pybullet,torch,tensorflow,pyrealsense2
 ignore=CVS
 
 # Add paths to the blacklist.
-ignore-paths=predicators/envs/assets,predicators/third_party
+ignore-paths=predicators/envs/assets,predicators/third_party,venv
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 strict_equality = True
 disallow_untyped_calls = True
 warn_unreachable = True
-exclude = (predicators/envs/assets|predicators/third_party)
+exclude = (predicators/envs/assets|predicators/third_party|venv)
 
 [mypy-predicators.*]
 disallow_untyped_defs = True

--- a/predicators/ground_truth_models/cover/nsrts.py
+++ b/predicators/ground_truth_models/cover/nsrts.py
@@ -18,7 +18,7 @@ class CoverGroundTruthNSRTFactory(GroundTruthNSRTFactory):
         return {
             "cover", "cover_hierarchical_types", "cover_typed_options",
             "cover_regrasp", "cover_multistep_options", "pybullet_cover",
-            "cover_handempty"
+            "cover_handempty", "bumpy_cover"
         }
 
     @staticmethod
@@ -44,7 +44,7 @@ class CoverGroundTruthNSRTFactory(GroundTruthNSRTFactory):
 
         # Options
         if env_name in ("cover", "pybullet_cover", "cover_hierarchical_types",
-                        "cover_regrasp", "cover_handempty"):
+                        "cover_regrasp", "cover_handempty", "bumpy_cover"):
             PickPlace = options["PickPlace"]
         elif env_name in ("cover_typed_options", "cover_multistep_options"):
             Pick, Place = options["Pick"], options["Place"]
@@ -69,7 +69,7 @@ class CoverGroundTruthNSRTFactory(GroundTruthNSRTFactory):
         delete_effects = {LiftedAtom(HandEmpty, handempty_predicate_args)}
 
         if env_name in ("cover", "pybullet_cover", "cover_hierarchical_types",
-                        "cover_regrasp", "cover_handempty"):
+                        "cover_regrasp", "cover_handempty", "bumpy_cover"):
             option = PickPlace
             option_vars = []
         elif env_name == "cover_typed_options":
@@ -146,7 +146,7 @@ class CoverGroundTruthNSRTFactory(GroundTruthNSRTFactory):
                     ub = float(state.get(b, "width") / 2)
                 elif env_name in ("cover", "pybullet_cover",
                                   "cover_hierarchical_types", "cover_regrasp",
-                                  "cover_handempty"):
+                                  "cover_handempty", "bumpy_cover"):
                     lb = float(
                         state.get(b, "pose") - state.get(b, "width") / 2)
                     lb = max(lb, 0.0)
@@ -179,13 +179,13 @@ class CoverGroundTruthNSRTFactory(GroundTruthNSRTFactory):
             LiftedAtom(Covers, [block, target])
         }
         delete_effects = {LiftedAtom(Holding, holding_predicate_args)}
-        if env_name == "cover_regrasp":
+        if env_name in ("cover_regrasp", "bumpy_cover"):
             Clear = predicates["Clear"]
             preconditions.add(LiftedAtom(Clear, [target]))
             delete_effects.add(LiftedAtom(Clear, [target]))
 
         if env_name in ("cover", "pybullet_cover", "cover_hierarchical_types",
-                        "cover_regrasp", "cover_handempty"):
+                        "cover_regrasp", "cover_handempty", "bumpy_cover"):
             option = PickPlace
             option_vars = []
         elif env_name == "cover_typed_options":

--- a/predicators/ground_truth_models/cover/options.py
+++ b/predicators/ground_truth_models/cover/options.py
@@ -25,7 +25,7 @@ class CoverGroundTruthOptionFactory(GroundTruthOptionFactory):
     def get_env_names(cls) -> Set[str]:
         return {
             "cover", "cover_regrasp", "cover_handempty",
-            "cover_hierarchical_types"
+            "cover_hierarchical_types", "bumpy_cover"
         }
 
     @classmethod

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -63,6 +63,10 @@ class GlobalSettings:
     cover_multistep_bimodal_goal = False
     cover_multistep_goal_conditioned_sampling = False  # assumes one goal
 
+    # bumpy cover env parameters
+    bumpy_cover_num_bumps = 3
+    bumpy_cover_spaces_per_bump = 10
+
     # blocks env parameters
     blocks_num_blocks_train = [3, 4]
     blocks_num_blocks_test = [5, 6]

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -14,8 +14,9 @@ from predicators.envs.blocks import BlocksEnv
 from predicators.envs.cluttered_table import ClutteredTableEnv, \
     ClutteredTablePlaceEnv
 from predicators.envs.coffee import CoffeeEnv
-from predicators.envs.cover import CoverEnv, CoverEnvHierarchicalTypes, \
-    CoverEnvRegrasp, CoverEnvTypedOptions, CoverMultistepOptions
+from predicators.envs.cover import BumpyCoverEnv, CoverEnv, \
+    CoverEnvHierarchicalTypes, CoverEnvRegrasp, CoverEnvTypedOptions, \
+    CoverMultistepOptions
 from predicators.envs.doors import DoorsEnv
 from predicators.envs.exit_garage import ExitGarageEnv
 from predicators.envs.narrow_passage import NarrowPassageEnv
@@ -46,7 +47,7 @@ _PDDL_ENV_MODULE_PATH = predicators.envs.pddl_env.__name__
 ENV_NAME_AND_CLS = [
     ("cover", CoverEnv), ("cover_typed_options", CoverEnvTypedOptions),
     ("cover_hierarchical_types", CoverEnvHierarchicalTypes),
-    ("cover_regrasp", CoverEnvRegrasp),
+    ("cover_regrasp", CoverEnvRegrasp), ("bumpy_cover", BumpyCoverEnv),
     ("cover_multistep_options", CoverMultistepOptions),
     ("cluttered_table", ClutteredTableEnv),
     ("cluttered_table_place", ClutteredTablePlaceEnv), ("blocks", BlocksEnv),


### PR DESCRIPTION
a variation on the cover environment where some blocks are "bumpy", making them harder to grasp. concretely, bumps are implemented as fine-grained and sparse allowed hand regions. see the video below. this environment is intended for developing sampler learning approaches.

example:
```
python predicators/main.py --approach oracle --env bumpy_cover --seed 0 --num_test_tasks 3 --make_test_videos
```

https://github.com/Learning-and-Intelligent-Systems/predicators/assets/2816502/78e54a5f-38c5-4645-a086-42aa5fbcfc58



