### PR TITLE
remove broken lifelong learning flag

### DIFF
--- a/predicators/main.py
+++ b/predicators/main.py
@@ -245,7 +245,6 @@ def _generate_interaction_results(
             request.train_task_idx,
             request.termination_function,
             max_num_steps=CFG.max_num_steps_interaction_request,
-            do_env_reset=(not CFG.online_learning_lifelong),
             exceptions_to_break_on={
                 utils.EnvironmentFailure, utils.OptionExecutionFailure,
                 utils.RequestActPolicyFailure

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -507,7 +507,6 @@ class GlobalSettings:
     # online NSRT learning parameters
     online_nsrt_learning_requests_per_cycle = 10
     online_learning_max_novelty_count = 0
-    online_learning_lifelong = False
 
     # refinement cost estimation parameters
     refinement_estimator = "oracle"  # default refinement cost estimator


### PR DESCRIPTION
the flag is broken because the environment is never reset during training (not even once at the beginning). it's also not possible to periodically evaluate the agent if we use just one long training interaction.