### PR TITLE
bilevel plan no sim: differentiate offline data collection from main

### DIFF
--- a/predicators/approaches/bilevel_planning_approach.py
+++ b/predicators/approaches/bilevel_planning_approach.py
@@ -8,7 +8,7 @@ import abc
 import os
 import sys
 import time
-from typing import Any, Callable, List, Set, Tuple
+from typing import Any, Callable, List, Optional, Set, Tuple
 
 from gym.spaces import Box
 
@@ -34,16 +34,19 @@ class BilevelPlanningApproach(BaseApproach):
                  action_space: Box,
                  train_tasks: List[Task],
                  task_planning_heuristic: str = "default",
-                 max_skeletons_optimized: int = -1) -> None:
+                 max_skeletons_optimized: int = -1,
+                 bilevel_plan_without_sim: Optional[bool] = None) -> None:
         super().__init__(initial_predicates, initial_options, types,
                          action_space, train_tasks)
         if task_planning_heuristic == "default":
             task_planning_heuristic = CFG.sesame_task_planning_heuristic
         if max_skeletons_optimized == -1:
             max_skeletons_optimized = CFG.sesame_max_skeletons_optimized
+        if bilevel_plan_without_sim is None:
+            bilevel_plan_without_sim = CFG.bilevel_plan_without_sim
         self._task_planning_heuristic = task_planning_heuristic
         self._max_skeletons_optimized = max_skeletons_optimized
-        self._plan_without_sim = CFG.bilevel_plan_without_sim
+        self._plan_without_sim = bilevel_plan_without_sim
         self._option_model = create_option_model(CFG.option_model_name)
         self._num_calls = 0
         self._last_plan: List[_Option] = []  # used if plan WITH sim

--- a/predicators/approaches/oracle_approach.py
+++ b/predicators/approaches/oracle_approach.py
@@ -6,7 +6,7 @@ truth NSRTs. If an NSRT's option is not included, that NSRT will not be
 generated at all.
 """
 
-from typing import List, Set
+from typing import List, Optional, Set
 
 from gym.spaces import Box
 
@@ -28,10 +28,11 @@ class OracleApproach(BilevelPlanningApproach):
                  action_space: Box,
                  train_tasks: List[Task],
                  task_planning_heuristic: str = "default",
-                 max_skeletons_optimized: int = -1) -> None:
+                 max_skeletons_optimized: int = -1,
+                 bilevel_plan_without_sim: Optional[bool] = None) -> None:
         super().__init__(initial_predicates, initial_options, types,
                          action_space, train_tasks, task_planning_heuristic,
-                         max_skeletons_optimized)
+                         max_skeletons_optimized, bilevel_plan_without_sim)
         self._nsrts = get_gt_nsrts(CFG.env, self._initial_predicates,
                                    self._initial_options)
 

--- a/predicators/datasets/demo_only.py
+++ b/predicators/datasets/demo_only.py
@@ -140,7 +140,8 @@ def _generate_demonstrations(env: BaseEnv, train_tasks: List[Task],
             env.action_space,
             train_tasks,
             task_planning_heuristic=CFG.offline_data_task_planning_heuristic,
-            max_skeletons_optimized=CFG.offline_data_max_skeletons_optimized)
+            max_skeletons_optimized=CFG.offline_data_max_skeletons_optimized,
+            bilevel_plan_without_sim=CFG.offline_data_bilevel_plan_without_sim)
     else:  # pragma: no cover
         # Disable all built-in keyboard shortcuts.
         keymaps = {k for k in plt.rcParams if k.startswith("keymap.")}
@@ -154,6 +155,10 @@ def _generate_demonstrations(env: BaseEnv, train_tasks: List[Task],
         annotations = []
     num_tasks = min(len(train_tasks), CFG.max_initial_demos)
     rng = np.random.default_rng(CFG.seed)
+    if CFG.offline_data_bilevel_plan_without_sim is None:
+        bilevel_plan_without_sim = CFG.bilevel_plan_without_sim
+    else:
+        bilevel_plan_without_sim = CFG.offline_data_bilevel_plan_without_sim
     for idx, task in enumerate(train_tasks):
         if idx < train_tasks_start_idx:  # ignore demos before this index
             continue
@@ -172,7 +177,7 @@ def _generate_demonstrations(env: BaseEnv, train_tasks: List[Task],
                 # the policy is actually a plan under the hood, and we
                 # can retrieve it with get_last_plan(). We do this
                 # because we want to run the full plan.
-                if CFG.bilevel_plan_without_sim:
+                if bilevel_plan_without_sim:
                     last_nsrt_plan = oracle_approach.get_last_nsrt_plan()
                     policy = utils.nsrt_plan_to_greedy_policy(
                         last_nsrt_plan, task.goal, rng)

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -421,6 +421,8 @@ class GlobalSettings:
     offline_data_max_skeletons_optimized = -1
     # Number of replays used when offline_data_method is replay-based.
     offline_data_num_replays = 500
+    # Default to bilevel_plan_without_sim.
+    offline_data_bilevel_plan_without_sim = None
 
     # teacher dataset parameters
     # Number of positive examples and negative examples per predicate.

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -173,7 +173,23 @@ def test_demo_dataset():
     train_tasks = [t.task for t in env.get_train_tasks()]
     options = parse_config_included_options(env)
     dataset = create_dataset(env, train_tasks, options)
-    assert len(dataset.trajectories) > 0
+    assert 0 < len(dataset.trajectories) < 5
+    # Use bilevel planning to collect data, but don't use otherwise.
+    utils.reset_config({
+        "env": "cover",
+        "approach": "nsrt_learning",
+        "offline_data_method": "demo",
+        "offline_data_planning_timeout": 500,
+        "num_train_tasks": 5,
+        "option_learner": "arbitrary_dummy",
+        "bilevel_plan_without_sim": True,
+        "offline_data_bilevel_plan_without_sim": False,
+    })
+    env = CoverEnv()
+    train_tasks = [t.task for t in env.get_train_tasks()]
+    options = parse_config_included_options(env)
+    dataset = create_dataset(env, train_tasks, options)
+    assert len(dataset.trajectories) == 5
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
in environments where we do have a simulator implemented, we may still want to use bilevel planning to collect demonstrations for convenience, even if we otherwise will assume that no simulator exists during training and evaluation.