### PR TITLE
make options and operators 1:1 in bumpy cover env

### DIFF
--- a/predicators/ground_truth_models/cover/__init__.py
+++ b/predicators/ground_truth_models/cover/__init__.py
@@ -1,7 +1,8 @@
 """Ground-truth models for cover environment and variants."""
 
 from .nsrts import CoverGroundTruthNSRTFactory
-from .options import CoverGroundTruthOptionFactory, \
+from .options import BumpyCoverGroundTruthOptionFactory, \
+    CoverGroundTruthOptionFactory, \
     CoverMultiStepOptionsGroundTruthOptionFactory, \
     CoverTypedOptionsGroundTruthOptionFactory, \
     PyBulletCoverGroundTruthOptionFactory
@@ -10,5 +11,6 @@ __all__ = [
     "CoverGroundTruthOptionFactory", "CoverGroundTruthNSRTFactory",
     "CoverMultiStepOptionsGroundTruthOptionFactory",
     "CoverTypedOptionsGroundTruthOptionFactory",
-    "PyBulletCoverGroundTruthOptionFactory"
+    "PyBulletCoverGroundTruthOptionFactory",
+    "BumpyCoverGroundTruthOptionFactory"
 ]

--- a/predicators/ground_truth_models/cover/nsrts.py
+++ b/predicators/ground_truth_models/cover/nsrts.py
@@ -44,9 +44,10 @@ class CoverGroundTruthNSRTFactory(GroundTruthNSRTFactory):
 
         # Options
         if env_name in ("cover", "pybullet_cover", "cover_hierarchical_types",
-                        "cover_regrasp", "cover_handempty", "bumpy_cover"):
+                        "cover_regrasp", "cover_handempty"):
             PickPlace = options["PickPlace"]
-        elif env_name in ("cover_typed_options", "cover_multistep_options"):
+        elif env_name in ("cover_typed_options", "cover_multistep_options",
+                          "bumpy_cover"):
             Pick, Place = options["Pick"], options["Place"]
 
         nsrts = set()
@@ -69,9 +70,12 @@ class CoverGroundTruthNSRTFactory(GroundTruthNSRTFactory):
         delete_effects = {LiftedAtom(HandEmpty, handempty_predicate_args)}
 
         if env_name in ("cover", "pybullet_cover", "cover_hierarchical_types",
-                        "cover_regrasp", "cover_handempty", "bumpy_cover"):
+                        "cover_regrasp", "cover_handempty"):
             option = PickPlace
             option_vars = []
+        elif env_name == "bumpy_cover":
+            option = Pick
+            option_vars = [block]
         elif env_name == "cover_typed_options":
             option = Pick
             option_vars = [block]
@@ -185,9 +189,12 @@ class CoverGroundTruthNSRTFactory(GroundTruthNSRTFactory):
             delete_effects.add(LiftedAtom(Clear, [target]))
 
         if env_name in ("cover", "pybullet_cover", "cover_hierarchical_types",
-                        "cover_regrasp", "cover_handempty", "bumpy_cover"):
+                        "cover_regrasp", "cover_handempty"):
             option = PickPlace
             option_vars = []
+        elif env_name == "bumpy_cover":
+            option = Place
+            option_vars = [block, target]
         elif env_name == "cover_typed_options":
             option = Place
             option_vars = [target]

--- a/predicators/ground_truth_models/cover/options.py
+++ b/predicators/ground_truth_models/cover/options.py
@@ -25,7 +25,7 @@ class CoverGroundTruthOptionFactory(GroundTruthOptionFactory):
     def get_env_names(cls) -> Set[str]:
         return {
             "cover", "cover_regrasp", "cover_handempty",
-            "cover_hierarchical_types", "bumpy_cover"
+            "cover_hierarchical_types"
         }
 
     @classmethod
@@ -44,6 +44,41 @@ class CoverGroundTruthOptionFactory(GroundTruthOptionFactory):
                                                            0, 1, (1, )))
 
         return {PickPlace}
+
+
+class BumpyCoverGroundTruthOptionFactory(GroundTruthOptionFactory):
+    """Ground-truth options for the bumpy cover environment."""
+
+    @classmethod
+    def get_env_names(cls) -> Set[str]:
+        return {"bumpy_cover"}
+
+    @classmethod
+    def get_options(cls, env_name: str, types: Dict[str, Type],
+                    predicates: Dict[str, Predicate],
+                    action_space: Box) -> Set[ParameterizedOption]:
+
+        def _policy(state: State, memory: Dict, objects: Sequence[Object],
+                    params: Array) -> Action:
+            del state, memory, objects  # unused
+            return Action(params)  # action is simply the parameter
+
+        block_type = types["block"]
+        target_type = types["target"]
+
+        Pick = utils.SingletonParameterizedOption("Pick",
+                                                  _policy,
+                                                  types=[block_type],
+                                                  params_space=Box(
+                                                      0, 1, (1, )))
+
+        Place = utils.SingletonParameterizedOption(
+            "Place",
+            _policy,
+            types=[block_type, target_type],
+            params_space=Box(0, 1, (1, )))
+
+        return {Pick, Place}
 
 
 class CoverTypedOptionsGroundTruthOptionFactory(GroundTruthOptionFactory):


### PR DESCRIPTION
in the sampler learning work, it is convenient implementation-wise to assume a 1:1 relationship between options and operators. we don't need this assumption conceptually; it is just a convenience.