### PR TITLE
flag to offset target allowed hand region in bumpy cover

### DIFF
--- a/predicators/envs/cover.py
+++ b/predicators/envs/cover.py
@@ -1082,7 +1082,10 @@ class BumpyCoverEnv(CoverEnvRegrasp):
                     (state.get(block, "pose") - state.get(block, "width") / 2,
                      state.get(block, "pose") + state.get(block, "width") / 2))
         for targ in state.get_objects(self._target_type):
-            hand_regions.append(
-                (state.get(targ, "pose") - state.get(targ, "width") / 10,
-                 state.get(targ, "pose") + state.get(targ, "width") / 10))
+            center = state.get(targ, "pose")
+            if CFG.bumpy_cover_left_targets:
+                center -= 5 * state.get(targ, "width") / 8
+            left = center - state.get(targ, "width") / 2
+            right = center + state.get(targ, "width") / 2
+            hand_regions.append((left, right))
         return hand_regions

--- a/predicators/envs/cover.py
+++ b/predicators/envs/cover.py
@@ -1083,8 +1083,8 @@ class BumpyCoverEnv(CoverEnvRegrasp):
                      state.get(block, "pose") + state.get(block, "width") / 2))
         for targ in state.get_objects(self._target_type):
             center = state.get(targ, "pose")
-            if CFG.bumpy_cover_left_targets:
-                center -= 5 * state.get(targ, "width") / 8
+            if CFG.bumpy_cover_right_targets:
+                center += 3 * state.get(targ, "width") / 4
             left = center - state.get(targ, "width") / 2
             right = center + state.get(targ, "width") / 2
             hand_regions.append((left, right))

--- a/predicators/ground_truth_models/cover/nsrts.py
+++ b/predicators/ground_truth_models/cover/nsrts.py
@@ -264,6 +264,7 @@ class CoverGroundTruthNSRTFactory(GroundTruthNSRTFactory):
                     assert len(objs) == 2
                     t = objs[-1]
                 assert t.is_instance(target_type)
+                # TODO
                 lb = float(state.get(t, "pose") - state.get(t, "width") / 10)
                 lb = max(lb, 0.0)
                 ub = float(state.get(t, "pose") + state.get(t, "width") / 10)

--- a/predicators/ground_truth_models/cover/nsrts.py
+++ b/predicators/ground_truth_models/cover/nsrts.py
@@ -264,10 +264,18 @@ class CoverGroundTruthNSRTFactory(GroundTruthNSRTFactory):
                     assert len(objs) == 2
                     t = objs[-1]
                 assert t.is_instance(target_type)
-                # TODO
-                lb = float(state.get(t, "pose") - state.get(t, "width") / 10)
+                if env_name == "bumpy_cover":
+                    center = float(state.get(t, "pose"))
+                    if CFG.bumpy_cover_right_targets:
+                        center += 3 * state.get(t, "width") / 4
+                    lb = center - state.get(t, "width") / 2
+                    ub = center + state.get(t, "width") / 2
+                else:
+                    lb = float(
+                        state.get(t, "pose") - state.get(t, "width") / 10)
+                    ub = float(
+                        state.get(t, "pose") + state.get(t, "width") / 10)
                 lb = max(lb, 0.0)
-                ub = float(state.get(t, "pose") + state.get(t, "width") / 10)
                 ub = min(ub, 1.0)
                 return np.array(rng.uniform(lb, ub, size=(1, )),
                                 dtype=np.float32)

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -66,6 +66,7 @@ class GlobalSettings:
     # bumpy cover env parameters
     bumpy_cover_num_bumps = 3
     bumpy_cover_spaces_per_bump = 10
+    bumpy_cover_left_targets = False
 
     # blocks env parameters
     blocks_num_blocks_train = [3, 4]

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -66,7 +66,7 @@ class GlobalSettings:
     # bumpy cover env parameters
     bumpy_cover_num_bumps = 3
     bumpy_cover_spaces_per_bump = 10
-    bumpy_cover_left_targets = False
+    bumpy_cover_right_targets = False
 
     # blocks env parameters
     blocks_num_blocks_train = [3, 4]

--- a/tests/approaches/test_oracle_approach.py
+++ b/tests/approaches/test_oracle_approach.py
@@ -108,6 +108,15 @@ EXTRA_ARGS_ORACLE_APPROACH["cover_multistep_options"] = [
         "sesame_max_samples_per_step": 1
     },
 ]
+EXTRA_ARGS_ORACLE_APPROACH["bumpy_cover"] = [
+    {
+        "bumpy_cover_right_targets": True,
+        "sesame_max_samples_per_step": 100,
+    },
+    {
+        "bumpy_cover_right_targets": False,
+    },
+]
 EXTRA_ARGS_ORACLE_APPROACH["cluttered_table"] = [
     {
         "cluttered_table_num_cans_train": 3,


### PR DESCRIPTION
the purpose of this flag is to test whether we can learn samplers that are aware of the task distribution. in particular, the pick grasp sampler should favor picking on the right side of blocks if it is only possible to place on the right side of targets.