### PR TITLE
Gets `ActiveSamplerLearningApproach` working for right_targets

### DIFF
--- a/predicators/approaches/active_sampler_learning_approach.py
+++ b/predicators/approaches/active_sampler_learning_approach.py
@@ -107,33 +107,34 @@ class ActiveSamplerLearningApproach(OnlineNSRTLearningApproach):
 
     def _update_sampler_data(self) -> None:
         new_trajs = self._segmented_trajs[self._last_seen_segment_traj_idx:]
-        just_made_incorrect_pick = False
         for segmented_traj in new_trajs:
             self._last_seen_segment_traj_idx += 1
+            just_made_incorrect_pick = False
             for segment in segmented_traj:
                 s = segment.states[0]
                 o = segment.get_option()
                 ns = segment.states[-1]
                 success = self._check_option_success(o, segment)
-
-                if CFG.env == "bumpy_cover" and CFG.bumpy_cover_right_targets:
-                    # In bumpy cover with the 'bumpy_cover_right_targets'
-                    # flag set, picking from the left is bad and can potentially
-                    # lead to failures to place. We will say that picking from
-                    # left fails, and also skip adding all the subsequent
-                    # 'Place' actions.
-                    if o.name == "Pick":
-                        block = o.objects[0]
-                        block_center = s.get(block, "pose")
-                        block_width = s.get(block, "width")
-                        if block_center - block_width < o.params[
-                                0] < block_center:
-                            success = False
-                            just_made_incorrect_pick = True
-                        elif success:
-                            just_made_incorrect_pick = False
-                    if o.name == "Place" and just_made_incorrect_pick:
-                        continue
+                assert CFG.env == "bumpy_cover"
+                if CFG.active_sampler_learning_use_teacher:
+                    if CFG.bumpy_cover_right_targets:
+                        # In bumpy cover with the 'bumpy_cover_right_targets'
+                        # flag set, picking from the left is bad and can
+                        # potentially lead to failures to place. We will
+                        # say that picking from left fails, and also skip
+                        # adding all the subsequent 'Place' actions.
+                        if o.name == "Pick":
+                            block = o.objects[0]
+                            block_center = s.get(block, "pose")
+                            block_width = s.get(block, "width")
+                            if block_center - block_width < o.params[
+                                    0] < block_center:
+                                success = False
+                                just_made_incorrect_pick = True
+                            elif success:
+                                just_made_incorrect_pick = False
+                        if o.name == "Place" and just_made_incorrect_pick:
+                            continue
 
                 if CFG.active_sampler_learning_model == "myopic_classifier":
                     label: Any = success

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -517,6 +517,7 @@ class GlobalSettings:
 
     # active sampler learning parameters
     active_sampler_learning_model = "myopic_classifier"
+    active_sampler_learning_use_teacher = True
     active_sampler_learning_num_samples = 100
     active_sampler_learning_score_gamma = 0.5
     active_sampler_learning_n_iter_no_change = 5000

--- a/tests/approaches/test_active_sampler_learning_approach.py
+++ b/tests/approaches/test_active_sampler_learning_approach.py
@@ -4,6 +4,7 @@ import pytest
 from predicators import utils
 from predicators.approaches.active_sampler_learning_approach import \
     ActiveSamplerLearningApproach
+from predicators.approaches.base_approach import ApproachFailure
 from predicators.datasets import create_dataset
 from predicators.envs.cover import BumpyCoverEnv
 from predicators.ground_truth_models import get_gt_options
@@ -13,8 +14,11 @@ from predicators.structs import Dataset
 from predicators.teacher import Teacher
 
 
-@pytest.mark.parametrize("model_name", ["myopic_classifier", "fitted_q"])
-def test_active_sampler_learning_approach(model_name):
+@pytest.mark.parametrize("model_name,right_targets",
+                         [("myopic_classifier", False),
+                          ("myopic_classifier", True), ("fitted_q", False),
+                          ("fitted_q", True)])
+def test_active_sampler_learning_approach(model_name, right_targets):
     """Test for ActiveSamplerLearningApproach class, entire pipeline."""
     utils.reset_config({
         "env": "bumpy_cover",
@@ -35,6 +39,7 @@ def test_active_sampler_learning_approach(model_name):
         "active_sampler_learning_num_samples": 5,
         "active_sampler_learning_fitted_q_iters": 2,
         "active_sampler_learning_num_next_option_samples": 2,
+        "bumpy_cover_right_targets": right_targets,
     })
     env = BumpyCoverEnv()
     train_tasks = [t.task for t in env.get_train_tasks()]
@@ -58,9 +63,13 @@ def test_active_sampler_learning_approach(model_name):
     with pytest.raises(FileNotFoundError):
         approach.load(online_learning_cycle=1)
     for task in env.get_test_tasks():
-        policy = approach.solve(task, timeout=CFG.timeout)
-        # We won't fully check the policy here because we don't want tests to
-        # have to train very good models, since that would be slow. But we will
-        # test that the policy at least produces an action.
-        action = policy(task.init)
-        assert env.action_space.contains(action.arr)
+        try:
+            policy = approach.solve(task, timeout=CFG.timeout)
+            # We won't fully check the policy here because we don't want
+            # tests to have to train very good models, since that would
+            # be slow. But we will test that the policy at least produces
+            # an action.
+            action = policy(task.init)
+            assert env.action_space.contains(action.arr)
+        except ApproachFailure as e:
+            assert "Planning ran out of skeletons!" in str(e)


### PR DESCRIPTION
Previously, we were creating datasets for active sampler learning for bumpy cover such that a sample is deemed 'successful' if the corresponding ground NSRT's effects are achieved. This works as long as `bumpy_cover_right_targets` is False. We now amend the sampler dataset creation to handle this.

Command:
```
python predicators/main.py --approach active_sampler_learning         --env bumpy_cover         --seed 0         --strips_learner oracle         --sampler_learner oracle         --sampler_disable_classifier True         --bilevel_plan_without_sim True         --offline_data_bilevel_plan_without_sim False         --explorer random_nsrts         --max_initial_demos 1         --num_train_tasks 1000         --num_test_tasks 100         --max_num_steps_interaction_request 15    --bumpy_cover_num_bumps 2         --bumpy_cover_spaces_per_bump 1         --sampler_mlp_classifier_max_itr 1000000         --pytorch_train_print_every 10000 --online_nsrt_learning_requests_per_cycle 10 --bumpy_cover_right_targets True
```

Previously, this command would get ~35% success rate. With these changes, it gets up to about 65%.

![bumpy_cover_num_online_transitions_perc_solved](https://github.com/Learning-and-Intelligent-Systems/predicators/assets/12446934/f17040b5-5d6d-43c4-bb02-4d05c5fbd684)

