### PR TITLE
make it possible to run active sampler learning without any demonstrations

### DIFF
--- a/predicators/approaches/active_sampler_learning_approach.py
+++ b/predicators/approaches/active_sampler_learning_approach.py
@@ -21,7 +21,7 @@ Bumpy cover easy:
         --explorer random_nsrts \
         --max_initial_demos 0 \
         --num_train_tasks 1000 \
-        --num_test_tasks 10 \
+        --num_test_tasks 100 \
         --max_num_steps_interaction_request 4 \
         --bumpy_cover_num_bumps 2 \
         --bumpy_cover_spaces_per_bump 1
@@ -38,7 +38,7 @@ Bumpy cover with shifted targets:
         --explorer random_nsrts \
         --max_initial_demos 0 \
         --num_train_tasks 1000 \
-        --num_test_tasks 10 \
+        --num_test_tasks 100 \
         --max_num_steps_interaction_request 4 \
         --bumpy_cover_num_bumps 2 \
         --bumpy_cover_spaces_per_bump 1 \
@@ -332,6 +332,10 @@ class _FittedQWrappedSamplerLearner(_WrappedSamplerLearner):
         if self._nsrt_score_fns is None:
             return 0.0  # initialize to 0.0
         ground_nsrt = _option_to_ground_nsrt(option, self._nsrts)
+        # Special case: we haven't seen any data for the parent NSRT, so we
+        # haven't learned a score function for it.
+        if ground_nsrt.parent not in self._nsrt_score_fns:
+            return 0.0
         score_fn = self._nsrt_score_fns[ground_nsrt.parent]
         return score_fn(state, ground_nsrt.objects, [option.params])[0]
 

--- a/predicators/approaches/active_sampler_learning_approach.py
+++ b/predicators/approaches/active_sampler_learning_approach.py
@@ -19,7 +19,7 @@ Bumpy cover easy:
         --bilevel_plan_without_sim True \
         --offline_data_bilevel_plan_without_sim False \
         --explorer random_nsrts \
-        --max_initial_demos 1 \
+        --max_initial_demos 0 \
         --num_train_tasks 1000 \
         --num_test_tasks 10 \
         --max_num_steps_interaction_request 4 \
@@ -36,7 +36,7 @@ Bumpy cover with shifted targets:
         --bilevel_plan_without_sim True \
         --offline_data_bilevel_plan_without_sim False \
         --explorer random_nsrts \
-        --max_initial_demos 1 \
+        --max_initial_demos 0 \
         --num_train_tasks 1000 \
         --num_test_tasks 10 \
         --max_num_steps_interaction_request 4 \
@@ -157,6 +157,13 @@ class ActiveSamplerLearningApproach(OnlineNSRTLearningApproach):
                             nsrt.ignore_effects, nsrt.option, nsrt.option_vars,
                             sampler)
             new_nsrts.add(new_nsrt)
+        # Special case, especially on the first iteration: if there was no
+        # data for the sampler, then we didn't learn a wrapped sampler, so
+        # we should just use the original NSRT.
+        new_nsrt_options = {n.option for n in new_nsrts}
+        for old_nsrt in self._nsrts:
+            if old_nsrt.option not in new_nsrt_options:
+                new_nsrts.add(old_nsrt)
         self._nsrts = new_nsrts
         # Re-save the NSRTs now that we've updated them.
         save_path = utils.get_approach_save_path_str()

--- a/predicators/approaches/active_sampler_learning_approach.py
+++ b/predicators/approaches/active_sampler_learning_approach.py
@@ -44,6 +44,7 @@ Bumpy cover with shifted targets:
         --bumpy_cover_spaces_per_bump 1 \
         --bumpy_cover_right_targets True
 """
+from __future__ import annotations
 
 import abc
 import logging
@@ -56,7 +57,7 @@ from gym.spaces import Box
 from predicators import utils
 from predicators.approaches.online_nsrt_learning_approach import \
     OnlineNSRTLearningApproach
-from predicators.ml_models import MLPBinaryClassifier
+from predicators.ml_models import MLPBinaryClassifier, MLPRegressor
 from predicators.settings import CFG
 from predicators.structs import NSRT, Array, GroundAtom, LowLevelTrajectory, \
     NSRTSampler, Object, ParameterizedOption, Predicate, Segment, State, \
@@ -65,6 +66,7 @@ from predicators.structs import NSRT, Array, GroundAtom, LowLevelTrajectory, \
 # Dataset for sampler learning: includes (s, option, s', label) per param opt.
 _OptionSamplerDataset = List[Tuple[State, _Option, State, Any]]
 _SamplerDataset = Dict[ParameterizedOption, _OptionSamplerDataset]
+_ScoreFn = Callable[[State, Sequence[Object], List[Array]], List[float]]
 
 
 class ActiveSamplerLearningApproach(OnlineNSRTLearningApproach):
@@ -111,10 +113,13 @@ class ActiveSamplerLearningApproach(OnlineNSRTLearningApproach):
                 s = segment.states[0]
                 o = segment.get_option()
                 ns = segment.states[-1]
-
-                # Forthcoming implementations may change the label here.
                 success = self._check_option_success(o, segment)
-                label = success
+
+                if CFG.active_sampler_learning_model == "myopic_classifier":
+                    label: Any = success
+                else:
+                    assert CFG.active_sampler_learning_model == "fitted_q"
+                    label = 0.0 if success else -1.0
 
                 # Store transition per ParameterizedOption. Don't store by
                 # NSRT because those change as we re-learn.
@@ -131,10 +136,15 @@ class ActiveSamplerLearningApproach(OnlineNSRTLearningApproach):
     def _learn_wrapped_samplers(self,
                                 online_learning_cycle: Optional[int]) -> None:
         """Update the NSRTs in place."""
-        # Forthcoming approaches may use a different learner.
-        learner = _ClassifierWrappedSamplerLearner(
-            self._get_current_nsrts(), self._get_current_predicates(),
-            online_learning_cycle)
+        if CFG.active_sampler_learning_model == "myopic_classifier":
+            learner: _WrappedSamplerLearner = _ClassifierWrappedSamplerLearner(
+                self._get_current_nsrts(), self._get_current_predicates(),
+                online_learning_cycle)
+        else:
+            assert CFG.active_sampler_learning_model == "fitted_q"
+            learner = _FittedQWrappedSamplerLearner(
+                self._get_current_nsrts(), self._get_current_predicates(),
+                online_learning_cycle)
         # Fit with the current data.
         learner.learn(self._sampler_data)
         wrapped_samplers = learner.get_samplers()
@@ -165,31 +175,32 @@ class _WrappedSamplerLearner(abc.ABC):
         self._rng = np.random.default_rng(CFG.seed)
         self._learned_samplers: Optional[Dict[NSRT, NSRTSampler]] = None
 
-    @abc.abstractmethod
     def learn(self, data: _SamplerDataset) -> None:
         """Fit all of the samplers."""
+        new_samplers: Dict[NSRT, NSRTSampler] = {}
+        for param_opt, nsrt_data in data.items():
+            nsrt = _param_option_to_nsrt(param_opt, self._nsrts)
+            logging.info(f"Fitting wrapped sampler for {nsrt.name}...")
+            new_samplers[nsrt] = self._learn_nsrt_sampler(nsrt_data, nsrt)
+        self._learned_samplers = new_samplers
 
     def get_samplers(self) -> Dict[NSRT, NSRTSampler]:
         """Expose the fitted samplers, organized by NSRTs."""
         assert self._learned_samplers is not None
         return self._learned_samplers
 
+    @abc.abstractmethod
+    def _learn_nsrt_sampler(self, nsrt_data: _OptionSamplerDataset,
+                            nsrt: NSRT) -> NSRTSampler:
+        """Learn the sampler for a single NSRT and return it."""
+
 
 class _ClassifierWrappedSamplerLearner(_WrappedSamplerLearner):
     """Using boolean class labels on transitions, learn a classifier, and then
     use the probability of predicting True to select parameters."""
 
-    def learn(self, data: _SamplerDataset) -> None:
-        # Learn the sampler for each NSRT independently.
-        new_samplers: Dict[NSRT, NSRTSampler] = {}
-        for param_opt, nsrt_data in data.items():
-            nsrt = _param_option_to_nsrt(param_opt, self._nsrts)
-            new_samplers[nsrt] = self._learn_nsrt_sampler(nsrt_data, nsrt)
-        self._learned_samplers = new_samplers
-
     def _learn_nsrt_sampler(self, nsrt_data: _OptionSamplerDataset,
                             nsrt: NSRT) -> NSRTSampler:
-        logging.info(f"Fitting wrapped sampler classifier for {nsrt.name}...")
         X_classifier: List[List[Array]] = []
         y_classifier: List[int] = []
         for state, option, _, label in nsrt_data:
@@ -236,6 +247,123 @@ class _ClassifierWrappedSamplerLearner(_WrappedSamplerLearner):
         return wrapped_sampler
 
 
+class _FittedQWrappedSamplerLearner(_WrappedSamplerLearner):
+    """Perform fitted Q iteration to learn all samplers from batch data."""
+
+    def __init__(self, nsrts: Set[NSRT], predicates: Set[Predicate],
+                 online_learning_cycle: Optional[int]) -> None:
+        super().__init__(nsrts, predicates, online_learning_cycle)
+        self._nsrt_score_fns: Optional[Dict[NSRT, _ScoreFn]] = None
+        self._next_nsrt_score_fns: Dict[NSRT, _ScoreFn] = {}
+
+    def learn(self, data: _SamplerDataset) -> None:
+        # Override parent so that the learning loop is run for multiple iters.
+        for it in range(CFG.active_sampler_learning_fitted_q_iters):
+            logging.info(f"Starting fitted Q learning iter {it}")
+            # Run one iteration of learning. Calls _learn_nsrt_sampler().
+            super().learn(data)
+            # Update the score functions now that all children are processed.
+            self._nsrt_score_fns = self._next_nsrt_score_fns
+
+    def _learn_nsrt_sampler(self, nsrt_data: _OptionSamplerDataset,
+                            nsrt: NSRT) -> NSRTSampler:
+        # Build targets.
+        gamma = CFG.active_sampler_learning_score_gamma
+        num_a_samp = CFG.active_sampler_learning_num_next_option_samples
+        targets: List[float] = []
+        for _, _, ns, r in nsrt_data:
+            # Sample actions to estimate Q in infinite action space.
+            next_as = self._sample_options_from_state(ns, num=num_a_samp)
+            next_q = max(self._predict(ns, na) for na in next_as)
+            # NOTE: there is no terminal state because we're in a lifelong
+            # (reset-free) setup.
+            target = r + gamma * next_q
+            targets.append(target)
+        # Build regressor dataset.
+        regressor_data = [(s, a, ns, target)
+                          for (s, a, ns, _), target in zip(nsrt_data, targets)]
+        # Run regression.
+        regressor = self._fit_regressor(regressor_data)
+        # Save the sampler regressor for external analysis.
+        approach_save_path = utils.get_approach_save_path_str()
+        save_path = f"{approach_save_path}_{nsrt.name}_" + \
+            f"{self._online_learning_cycle}.sampler_regressor"
+        with open(save_path, "wb") as f:
+            pkl.dump(regressor, f)
+        logging.info(f"Saved sampler regressor to {save_path}.")
+        # Wrap and return sampler.
+        base_sampler = nsrt._sampler  # pylint: disable=protected-access
+        score_fn = _regressor_to_score_fn(regressor, nsrt)
+        # Save the score function for use in later target computation.
+        self._next_nsrt_score_fns[nsrt] = score_fn
+        wrapped_sampler = _wrap_sampler(base_sampler, score_fn)
+        return wrapped_sampler
+
+    def _predict(self, state: State, option: _Option) -> float:
+        """Predict Q(s, a)."""
+        if self._nsrt_score_fns is None:
+            return 0.0  # initialize to 0.0
+        ground_nsrt = _option_to_ground_nsrt(option, self._nsrts)
+        score_fn = self._nsrt_score_fns[ground_nsrt.parent]
+        return score_fn(state, ground_nsrt.objects, [option.params])[0]
+
+    def _sample_options_from_state(self,
+                                   state: State,
+                                   num: int = 1) -> List[_Option]:
+        """Use NSRTs to sample options in the current state."""
+        # Create all applicable ground NSRTs.
+        ground_nsrts: List[_GroundNSRT] = []
+        for nsrt in sorted(self._nsrts):
+            ground_nsrts.extend(utils.all_ground_nsrts(nsrt, list(state)))
+
+        sampled_options: List[_Option] = []
+        for _ in range(num):
+            # Sample an applicable NSRT.
+            ground_nsrt = utils.sample_applicable_ground_nsrt(
+                state, ground_nsrts, self._predicates, self._rng)
+            assert ground_nsrt is not None
+            assert all(a.holds for a in ground_nsrt.preconditions)
+
+            # Sample an option.
+            option = ground_nsrt.sample_option(
+                state,
+                goal=set(),  # goal not used
+                rng=self._rng)
+            assert option.initiable(state)
+            sampled_options.append(option)
+
+        return sampled_options
+
+    def _fit_regressor(self, nsrt_data: _OptionSamplerDataset) -> MLPRegressor:
+        X_regressor: List[List[Array]] = []
+        y_regressor: List[Array] = []
+        for state, option, _, target in nsrt_data:
+            objects = option.objects
+            params = option.params
+            # input is state features and option parameters
+            X_regressor.append([np.array(1.0)])  # start with bias term
+            for obj in objects:
+                X_regressor[-1].extend(state[obj])
+            X_regressor[-1].extend(params)
+            assert not CFG.sampler_learning_use_goals
+            y_regressor.append(np.array([target]))
+        X_arr_regressor = np.array(X_regressor)
+        y_arr_regressor = np.array(y_regressor)
+        regressor = MLPRegressor(
+            seed=CFG.seed,
+            hid_sizes=CFG.mlp_regressor_hid_sizes,
+            max_train_iters=CFG.mlp_regressor_max_itr,
+            clip_gradients=CFG.mlp_regressor_clip_gradients,
+            clip_value=CFG.mlp_regressor_gradient_clip_value,
+            learning_rate=CFG.learning_rate,
+            weight_decay=CFG.weight_decay,
+            use_torch_gpu=CFG.use_torch_gpu,
+            train_print_every=CFG.pytorch_train_print_every,
+            n_iter_no_change=CFG.active_sampler_learning_n_iter_no_change)
+        regressor.fit(X_arr_regressor, y_arr_regressor)
+        return regressor
+
+
 # Helper functions.
 def _param_option_to_nsrt(param_option: ParameterizedOption,
                           nsrts: Set[NSRT]) -> NSRT:
@@ -254,7 +382,7 @@ def _option_to_ground_nsrt(option: _Option, nsrts: Set[NSRT]) -> _GroundNSRT:
 
 def _wrap_sampler(
     base_sampler: NSRTSampler,
-    score_fn: Callable[[State, Sequence[Object], List[Array]], List[float]]
+    score_fn: _ScoreFn,
 ) -> NSRTSampler:
     """Create a wrapped sampler that uses a score function to select among
     candidates from a base sampler."""
@@ -273,10 +401,9 @@ def _wrap_sampler(
     return _sample
 
 
-def _classifier_to_score_fn(
-    classifier: MLPBinaryClassifier, nsrt: NSRT
-) -> Callable[[State, Sequence[Object], List[Array]], List[float]]:
-    """Use predict_proba() to produce scores."""
+def _vector_score_fn_to_score_fn(vector_fn: Callable[[Array], float],
+                                 nsrt: NSRT) -> _ScoreFn:
+    """Helper for _classifier_to_score_fn() and _regressor_to_score_fn()."""
 
     def _score_fn(state: State, objects: Sequence[Object],
                   param_lst: List[Array]) -> List[float]:
@@ -286,7 +413,17 @@ def _classifier_to_score_fn(
             x_lst.extend(state[sub[var]])
         assert not CFG.sampler_learning_use_goals
         x = np.array(x_lst)
-        scores = [classifier.predict_proba(np.r_[x, p]) for p in param_lst]
+        scores = [vector_fn(np.r_[x, p]) for p in param_lst]
         return scores
 
     return _score_fn
+
+
+def _classifier_to_score_fn(classifier: MLPBinaryClassifier,
+                            nsrt: NSRT) -> _ScoreFn:
+    return _vector_score_fn_to_score_fn(classifier.predict_proba, nsrt)
+
+
+def _regressor_to_score_fn(regressor: MLPRegressor, nsrt: NSRT) -> _ScoreFn:
+    fn = lambda v: regressor.predict(v)[0]
+    return _vector_score_fn_to_score_fn(fn, nsrt)

--- a/predicators/nsrt_learning/nsrt_learning_main.py
+++ b/predicators/nsrt_learning/nsrt_learning_main.py
@@ -105,7 +105,13 @@ def learn_nsrts_from_data(
     del ground_atom_dataset
 
     # STEP 3: Learn options (option_learning.py) and update PNADs.
-    _learn_pnad_options(pnads, known_options, action_space)  # in-place update
+    # In the special case where all NSRT learning components are oracle, skip
+    # this step, because there may be empty PNADs, and option learning assumes
+    # in several places that the PNADs are not empty.
+    if CFG.strips_learner != "oracle" or CFG.sampler_learner != "oracle" or \
+       CFG.option_learner != "no_learning":
+        # Updates the PNADs in-place.
+        _learn_pnad_options(pnads, known_options, action_space)
 
     # STEP 4: Learn samplers (sampler_learning.py) and update PNADs.
     _learn_pnad_samplers(pnads, sampler_learner)  # in-place update

--- a/predicators/nsrt_learning/strips_learning/oracle_learner.py
+++ b/predicators/nsrt_learning/strips_learning/oracle_learner.py
@@ -27,6 +27,13 @@ class OracleSTRIPSLearner(BaseSTRIPSLearner):
                 option_spec = (DummyOption.parent, [])
             pnads.append(PNAD(nsrt.op, datastore, option_spec))
         self._recompute_datastores_from_segments(pnads)
+        # If we are using oracle sampler and option learning in addition to
+        # oracle strips learning, then we do not need to filter out PNADs with
+        # no data. But if we are sampler learning, we do need to filter,
+        # because sampler learning will crash if there are PNADs without data.
+        if CFG.sampler_learner == "oracle" and \
+           CFG.option_learner == "no_learning":
+            return pnads
         # Filter out any pnad that has an empty datastore. This can occur when
         # using non-standard settings with environments that cause certain
         # operators to be unnecessary. For example, in painting, when using

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -516,7 +516,12 @@ class GlobalSettings:
     online_learning_max_novelty_count = 0
 
     # active sampler learning parameters
+    active_sampler_learning_model = "myopic_classifier"
     active_sampler_learning_num_samples = 100
+    active_sampler_learning_score_gamma = 0.5
+    active_sampler_learning_n_iter_no_change = 5000
+    active_sampler_learning_fitted_q_iters = 5
+    active_sampler_learning_num_next_option_samples = 5
 
     # refinement cost estimation parameters
     refinement_estimator = "oracle"  # default refinement cost estimator

--- a/tests/approaches/test_active_sampler_learning_approach.py
+++ b/tests/approaches/test_active_sampler_learning_approach.py
@@ -16,7 +16,7 @@ from predicators.teacher import Teacher
 @pytest.mark.parametrize("model_name,right_targets,num_demo",
                          [("myopic_classifier", False, 0),
                           ("myopic_classifier", True, 1),
-                          ("fitted_q", False, 0), ("fitted_q", True, 1)])
+                          ("fitted_q", False, 0), ("fitted_q", True, 0)])
 def test_active_sampler_learning_approach(model_name, right_targets, num_demo):
     """Test for ActiveSamplerLearningApproach class, entire pipeline."""
     utils.reset_config({

--- a/tests/approaches/test_active_sampler_learning_approach.py
+++ b/tests/approaches/test_active_sampler_learning_approach.py
@@ -30,6 +30,7 @@ def test_active_sampler_learning_approach(model_name):
         "sampler_mlp_classifier_max_itr": 10,
         "mlp_regressor_max_itr": 10,
         "num_train_tasks": 3,
+        "max_initial_demos": 0,
         "num_test_tasks": 1,
         "explorer": "random_nsrts",
         "active_sampler_learning_num_samples": 5,

--- a/tests/approaches/test_active_sampler_learning_approach.py
+++ b/tests/approaches/test_active_sampler_learning_approach.py
@@ -13,11 +13,13 @@ from predicators.structs import Dataset
 from predicators.teacher import Teacher
 
 
-def test_active_sampler_learning_approach():
+@pytest.mark.parametrize("model_name", ["myopic_classifier", "fitted_q"])
+def test_active_sampler_learning_approach(model_name):
     """Test for ActiveSamplerLearningApproach class, entire pipeline."""
     utils.reset_config({
         "env": "bumpy_cover",
         "approach": "active_sampler_learning",
+        "active_sampler_learning_model": model_name,
         "timeout": 10,
         "strips_learner": "oracle",
         "sampler_learner": "oracle",
@@ -26,9 +28,13 @@ def test_active_sampler_learning_approach():
         "max_num_steps_interaction_request": 4,
         "online_nsrt_learning_requests_per_cycle": 1,
         "sampler_mlp_classifier_max_itr": 10,
+        "mlp_regressor_max_itr": 10,
         "num_train_tasks": 3,
         "num_test_tasks": 1,
         "explorer": "random_nsrts",
+        "active_sampler_learning_num_samples": 5,
+        "active_sampler_learning_fitted_q_iters": 2,
+        "active_sampler_learning_num_next_option_samples": 2,
     })
     env = BumpyCoverEnv()
     train_tasks = [t.task for t in env.get_train_tasks()]

--- a/tests/approaches/test_active_sampler_learning_approach.py
+++ b/tests/approaches/test_active_sampler_learning_approach.py
@@ -13,11 +13,11 @@ from predicators.structs import Dataset
 from predicators.teacher import Teacher
 
 
-@pytest.mark.parametrize("model_name,right_targets",
-                         [("myopic_classifier", False),
-                          ("myopic_classifier", True), ("fitted_q", False),
-                          ("fitted_q", True)])
-def test_active_sampler_learning_approach(model_name, right_targets):
+@pytest.mark.parametrize("model_name,right_targets,num_demo",
+                         [("myopic_classifier", False, 0),
+                          ("myopic_classifier", True, 1),
+                          ("fitted_q", False, 0), ("fitted_q", True, 1)])
+def test_active_sampler_learning_approach(model_name, right_targets, num_demo):
     """Test for ActiveSamplerLearningApproach class, entire pipeline."""
     utils.reset_config({
         "env": "bumpy_cover",
@@ -33,7 +33,7 @@ def test_active_sampler_learning_approach(model_name, right_targets):
         "sampler_mlp_classifier_max_itr": 10,
         "mlp_regressor_max_itr": 10,
         "num_train_tasks": 3,
-        "max_initial_demos": 0,
+        "max_initial_demos": num_demo,
         "num_test_tasks": 1,
         "explorer": "random_nsrts",
         "active_sampler_learning_num_samples": 5,

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -316,6 +316,19 @@ def test_oracle_samplers():
                    num_train_tasks=3)
 
 
+def test_full_oracle_no_data():
+    """Test NSRTLearningApproach with oracle everything and no data."""
+    # Oracle sampler learning should work (and be fast) in cover and blocks.
+    # We can even check that the policy succeeds!
+    _test_approach(env_name="cover",
+                   approach_name="nsrt_learning",
+                   strips_learner="oracle",
+                   sampler_learner="oracle",
+                   offline_data_method="demo",
+                   check_solution=True,
+                   num_train_tasks=0)
+
+
 def test_degenerate_mlp_sampler_learning():
     """Tests for NSRTLearningApproach() with a degenerate MLP sampler."""
     _test_approach(env_name="cover",


### PR DESCRIPTION
overdue!

this command leads to 97/100

```
python predicators/main.py --approach active_sampler_learning         --env bumpy_cover         --seed 0         --strips_learner oracle         --sampler_learner oracle         --sampler_disable_classifier True         --bilevel_plan_without_sim True         --offline_data_bilevel_plan_without_sim False         --explorer random_nsrts         --max_initial_demos 0         --num_train_tasks 1000         --num_test_tasks 100         --max_num_steps_interaction_request 15    --bumpy_cover_num_bumps 2         --bumpy_cover_spaces_per_bump 1         --sampler_mlp_classifier_max_itr 1000000         --pytorch_train_print_every 10000 --online_nsrt_learning_requests_per_cycle 10
``