### PR TITLE
updates to explorers in preparation for active sampler explorer

### DIFF
--- a/predicators/explorers/base_explorer.py
+++ b/predicators/explorers/base_explorer.py
@@ -8,7 +8,7 @@ from gym.spaces import Box
 
 from predicators.settings import CFG
 from predicators.structs import ExplorationStrategy, ParameterizedOption, \
-    Predicate, Task, Type
+    Predicate, State, Task, Type
 
 
 class BaseExplorer(abc.ABC):
@@ -20,12 +20,14 @@ class BaseExplorer(abc.ABC):
 
     def __init__(self, predicates: Set[Predicate],
                  options: Set[ParameterizedOption], types: Set[Type],
-                 action_space: Box, train_tasks: List[Task]) -> None:
+                 action_space: Box, train_tasks: List[Task],
+                 max_steps_before_termination: int) -> None:
         self._predicates = predicates
         self._options = options
         self._types = types
         self._action_space = action_space
         self._train_tasks = train_tasks
+        self._max_steps_before_termination = max_steps_before_termination
         self._set_seed(CFG.seed)
 
     @classmethod
@@ -34,8 +36,32 @@ class BaseExplorer(abc.ABC):
         """Get the unique name of this explorer."""
         raise NotImplementedError("Override me!")
 
-    @abc.abstractmethod
     def get_exploration_strategy(
+        self,
+        train_task_idx: int,
+        timeout: int,
+    ) -> ExplorationStrategy:
+        """Wrap the base exploration strategy."""
+
+        policy, termination_fn = self._get_exploration_strategy(
+            train_task_idx, timeout)
+
+        # Terminate after the given number of steps.
+        remaining_steps = self._max_steps_before_termination
+
+        def wrapped_termination_fn(state: State) -> bool:
+            nonlocal remaining_steps
+            if termination_fn(state):
+                return True
+            if remaining_steps <= 0:
+                return True
+            remaining_steps -= 1
+            return False
+
+        return policy, wrapped_termination_fn
+
+    @abc.abstractmethod
+    def _get_exploration_strategy(
         self,
         train_task_idx: int,
         timeout: int,

--- a/predicators/explorers/bilevel_planning_explorer.py
+++ b/predicators/explorers/bilevel_planning_explorer.py
@@ -22,10 +22,12 @@ class BilevelPlanningExplorer(BaseExplorer):
 
     def __init__(self, predicates: Set[Predicate],
                  options: Set[ParameterizedOption], types: Set[Type],
-                 action_space: Box, train_tasks: List[Task], nsrts: Set[NSRT],
+                 action_space: Box, train_tasks: List[Task],
+                 max_steps_before_termination: int, nsrts: Set[NSRT],
                  option_model: _OptionModelBase) -> None:
 
-        super().__init__(predicates, options, types, action_space, train_tasks)
+        super().__init__(predicates, options, types, action_space, train_tasks,
+                         max_steps_before_termination)
         self._nsrts = nsrts
         self._option_model = option_model
         self._num_calls = 0

--- a/predicators/explorers/exploit_bilevel_planning_explorer.py
+++ b/predicators/explorers/exploit_bilevel_planning_explorer.py
@@ -18,20 +18,22 @@ class ExploitBilevelPlanningExplorer(BilevelPlanningExplorer):
 
     def __init__(self, predicates: Set[Predicate],
                  options: Set[ParameterizedOption], types: Set[Type],
-                 action_space: Box, train_tasks: List[Task], nsrts: Set[NSRT],
+                 action_space: Box, train_tasks: List[Task],
+                 max_steps_before_termination: int, nsrts: Set[NSRT],
                  option_model: _OptionModelBase) -> None:
         super().__init__(predicates, options, types, action_space, train_tasks,
-                         nsrts, option_model)
+                         max_steps_before_termination, nsrts, option_model)
         # Falls back to random options.
         self._fallback_explorer = RandomOptionsExplorer(
-            predicates, options, types, action_space, train_tasks)
+            predicates, options, types, action_space, train_tasks,
+            max_steps_before_termination)
 
     @classmethod
     def get_name(cls) -> str:
         return "exploit_planning"
 
-    def get_exploration_strategy(self, train_task_idx: int,
-                                 timeout: int) -> ExplorationStrategy:
+    def _get_exploration_strategy(self, train_task_idx: int,
+                                  timeout: int) -> ExplorationStrategy:
         task = self._train_tasks[train_task_idx]
         try:
             return self._solve(task, timeout)

--- a/predicators/explorers/glib_explorer.py
+++ b/predicators/explorers/glib_explorer.py
@@ -26,24 +26,26 @@ class GLIBExplorer(BilevelPlanningExplorer):
 
     def __init__(self, predicates: Set[Predicate],
                  options: Set[ParameterizedOption], types: Set[Type],
-                 action_space: Box, train_tasks: List[Task], nsrts: Set[NSRT],
+                 action_space: Box, train_tasks: List[Task],
+                 max_steps_before_termination: int, nsrts: Set[NSRT],
                  option_model: _OptionModelBase,
                  babble_predicates: Set[Predicate],
                  atom_score_fn: Callable[[Set[GroundAtom]], float]) -> None:
         super().__init__(predicates, options, types, action_space, train_tasks,
-                         nsrts, option_model)
+                         max_steps_before_termination, nsrts, option_model)
         self._babble_predicates = babble_predicates
         self._atom_score_fn = atom_score_fn  # higher is better
         # GLIB falls back to random options.
         self._fallback_explorer = RandomOptionsExplorer(
-            predicates, options, types, action_space, train_tasks)
+            predicates, options, types, action_space, train_tasks,
+            max_steps_before_termination)
 
     @classmethod
     def get_name(cls) -> str:
         return "glib"
 
-    def get_exploration_strategy(self, train_task_idx: int,
-                                 timeout: int) -> ExplorationStrategy:
+    def _get_exploration_strategy(self, train_task_idx: int,
+                                  timeout: int) -> ExplorationStrategy:
         # The goal of the task is ignored.
         task = self._train_tasks[train_task_idx]
         init = task.init

--- a/predicators/explorers/greedy_lookahead_explorer.py
+++ b/predicators/explorers/greedy_lookahead_explorer.py
@@ -26,10 +26,12 @@ class GreedyLookaheadExplorer(BaseExplorer):
     def __init__(
             self, predicates: Set[Predicate],
             options: Set[ParameterizedOption], types: Set[Type],
-            action_space: Box, train_tasks: List[Task], nsrts: Set[NSRT],
+            action_space: Box, train_tasks: List[Task],
+            max_steps_before_termination: int, nsrts: Set[NSRT],
             option_model: _OptionModelBase,
             state_score_fn: Callable[[Set[GroundAtom], State], float]) -> None:
-        super().__init__(predicates, options, types, action_space, train_tasks)
+        super().__init__(predicates, options, types, action_space, train_tasks,
+                         max_steps_before_termination)
         self._nsrts = nsrts
         self._option_model = option_model
         self._state_score_fn = state_score_fn
@@ -38,8 +40,8 @@ class GreedyLookaheadExplorer(BaseExplorer):
     def get_name(cls) -> str:
         return "greedy_lookahead"
 
-    def get_exploration_strategy(self, train_task_idx: int,
-                                 timeout: int) -> ExplorationStrategy:
+    def _get_exploration_strategy(self, train_task_idx: int,
+                                  timeout: int) -> ExplorationStrategy:
         # The goal of the task is ignored.
         task = self._train_tasks[train_task_idx]
         init = task.init

--- a/predicators/explorers/no_explore_explorer.py
+++ b/predicators/explorers/no_explore_explorer.py
@@ -11,8 +11,8 @@ class NoExploreExplorer(BaseExplorer):
     def get_name(cls) -> str:
         return "no_explore"
 
-    def get_exploration_strategy(self, train_task_idx: int,
-                                 timeout: int) -> ExplorationStrategy:
+    def _get_exploration_strategy(self, train_task_idx: int,
+                                  timeout: int) -> ExplorationStrategy:
 
         def policy(_: State) -> Action:
             raise RuntimeError("The policy for no-explore shouldn't be used.")

--- a/predicators/explorers/random_actions_explorer.py
+++ b/predicators/explorers/random_actions_explorer.py
@@ -11,8 +11,8 @@ class RandomActionsExplorer(BaseExplorer):
     def get_name(cls) -> str:
         return "random_actions"
 
-    def get_exploration_strategy(self, train_task_idx: int,
-                                 timeout: int) -> ExplorationStrategy:
+    def _get_exploration_strategy(self, train_task_idx: int,
+                                  timeout: int) -> ExplorationStrategy:
         # Take random actions.
         policy = lambda _: Action(self._action_space.sample())
         # Never terminate (until the interaction budget is exceeded).

--- a/predicators/explorers/random_nsrts_explorer.py
+++ b/predicators/explorers/random_nsrts_explorer.py
@@ -43,17 +43,18 @@ class RandomNSRTsExplorer(BaseExplorer):
     def __init__(self, predicates: Set[Predicate],
                  options: Set[ParameterizedOption], types: Set[Type],
                  action_space: Box, train_tasks: List[Task],
-                 nsrts: Set[NSRT]) -> None:
+                 max_steps_before_termination: int, nsrts: Set[NSRT]) -> None:
 
-        super().__init__(predicates, options, types, action_space, train_tasks)
+        super().__init__(predicates, options, types, action_space, train_tasks,
+                         max_steps_before_termination)
         self._nsrts = nsrts
 
     @classmethod
     def get_name(cls) -> str:
         return "random_nsrts"
 
-    def get_exploration_strategy(self, train_task_idx: int,
-                                 timeout: int) -> ExplorationStrategy:
+    def _get_exploration_strategy(self, train_task_idx: int,
+                                  timeout: int) -> ExplorationStrategy:
         cur_option = DummyOption
         task = self._train_tasks[train_task_idx]
 

--- a/predicators/explorers/random_options_explorer.py
+++ b/predicators/explorers/random_options_explorer.py
@@ -12,8 +12,8 @@ class RandomOptionsExplorer(BaseExplorer):
     def get_name(cls) -> str:
         return "random_options"
 
-    def get_exploration_strategy(self, train_task_idx: int,
-                                 timeout: int) -> ExplorationStrategy:
+    def _get_exploration_strategy(self, train_task_idx: int,
+                                  timeout: int) -> ExplorationStrategy:
         # Take random options, and raise an exception if no applicable option
         # can be found.
 

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -525,6 +525,7 @@ class GlobalSettings:
     active_sampler_learning_n_iter_no_change = 5000
     active_sampler_learning_fitted_q_iters = 5
     active_sampler_learning_num_next_option_samples = 5
+    active_sampler_learning_explore_length_base = 2
 
     # refinement cost estimation parameters
     refinement_estimator = "oracle"  # default refinement cost estimator

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -1475,6 +1475,21 @@ def create_new_variables(
     return new_vars
 
 
+def param_option_to_nsrt(param_option: ParameterizedOption,
+                         nsrts: Set[NSRT]) -> NSRT:
+    """If options and NSRTs are 1:1, then map an option to an NSRT."""
+    nsrt_matches = [n for n in nsrts if n.option == param_option]
+    assert len(nsrt_matches) == 1
+    nsrt = nsrt_matches[0]
+    return nsrt
+
+
+def option_to_ground_nsrt(option: _Option, nsrts: Set[NSRT]) -> _GroundNSRT:
+    """If options and NSRTs are 1:1, then map an option to an NSRT."""
+    nsrt = param_option_to_nsrt(option.parent, nsrts)
+    return nsrt.ground(option.objects)
+
+
 _S = TypeVar("_S", bound=Hashable)  # state in heuristic search
 _A = TypeVar("_A")  # action in heuristic search
 


### PR DESCRIPTION
changes include:
* add a wrapper around explorer's termination functions to allow early termination of an interaction request. this is used by the active sampler learning approach to gradually increase the length of "practice" sessions. early on, before it has seen many tasks from the distribution, it practices for shorter; later, it practices for longer.
* fixes a major bug in the active sampler learning approach that was causing the first learning cycle's data to get thrown out (off by one error in `self._last_seen_segment_traj_idx`)
* move some helper functions into `utils.py`