### PR TITLE
Ensemble classifier with entropy-based exploration

### DIFF
--- a/predicators/approaches/active_sampler_learning_approach.py
+++ b/predicators/approaches/active_sampler_learning_approach.py
@@ -195,8 +195,7 @@ class ActiveSamplerLearningApproach(OnlineNSRTLearningApproach):
         self._nsrts = new_test_nsrts
         # Re-save the NSRTs now that we've updated them.
         save_path = utils.get_approach_save_path_str()
-        with open(f"{save_path}_{online_learning_cycle}_test.NSRTs",
-                  "wb") as f:
+        with open(f"{save_path}_{online_learning_cycle}.NSRTs", "wb") as f:
             pkl.dump(self._nsrts, f)
 
 

--- a/predicators/approaches/active_sampler_learning_approach.py
+++ b/predicators/approaches/active_sampler_learning_approach.py
@@ -191,7 +191,7 @@ class ActiveSamplerLearningApproach(OnlineNSRTLearningApproach):
         for old_nsrt in self._nsrts:
             if old_nsrt.option not in new_nsrt_options:
                 new_test_nsrts.add(old_nsrt)
-                self._nsrt_to_explorer_sampler[old_nsrt] = old_nsrt._sampler
+                self._nsrt_to_explorer_sampler[old_nsrt] = old_nsrt._sampler  # pylint: disable=protected-access
         self._nsrts = new_test_nsrts
         # Re-save the NSRTs now that we've updated them.
         save_path = utils.get_approach_save_path_str()

--- a/predicators/approaches/active_sampler_learning_approach.py
+++ b/predicators/approaches/active_sampler_learning_approach.py
@@ -175,15 +175,15 @@ class ActiveSamplerLearningApproach(OnlineNSRTLearningApproach):
         # Update the NSRTs.
         new_test_nsrts: Set[NSRT] = set()
         self._nsrt_to_explorer_sampler.clear()
-        for nsrt, samplers in wrapped_samplers.items():
+        for nsrt, (test_sampler, explore_sampler) in wrapped_samplers.items():
             # Create new test NSRT.
             new_test_nsrt = NSRT(nsrt.name, nsrt.parameters,
                                  nsrt.preconditions, nsrt.add_effects,
                                  nsrt.delete_effects, nsrt.ignore_effects,
-                                 nsrt.option, nsrt.option_vars, samplers[0])
+                                 nsrt.option, nsrt.option_vars, test_sampler)
             new_test_nsrts.add(new_test_nsrt)
             # Update the dictionary mapping NSRTs to exploration samplers.
-            self._nsrt_to_explorer_sampler[nsrt] = samplers[1]
+            self._nsrt_to_explorer_sampler[nsrt] = explore_sampler
         # Special case, especially on the first iteration: if there was no
         # data for the sampler, then we didn't learn a wrapped sampler, so
         # we should just use the original NSRT.
@@ -208,6 +208,8 @@ class _WrappedSamplerLearner(abc.ABC):
         self._predicates = predicates
         self._online_learning_cycle = online_learning_cycle
         self._rng = np.random.default_rng(CFG.seed)
+        # We keep track of two samplers per NSRT: one to use at test time
+        # and another to use during exploration/play time.
         self._learned_samplers: Optional[Dict[NSRT, Tuple[NSRTSampler,
                                                           NSRTSampler]]] = None
 

--- a/predicators/approaches/active_sampler_learning_approach.py
+++ b/predicators/approaches/active_sampler_learning_approach.py
@@ -123,7 +123,7 @@ class ActiveSamplerLearningApproach(OnlineNSRTLearningApproach):
                         if o.name == "Place" and just_made_incorrect_pick:
                             continue
 
-                if CFG.active_sampler_learning_model == "myopic_classifier":
+                if CFG.active_sampler_learning_model in ["myopic_classifier", "myopic_classifier_ensemble"]:
                     label: Any = success
                 else:
                     assert CFG.active_sampler_learning_model == "fitted_q"
@@ -289,7 +289,7 @@ class _ClassifierEnsembleWrappedSamplerLearner(_WrappedSamplerLearner):
         y_arr_classifier = np.array(y_classifier)
         classifier = BinaryClassifierEnsemble(
             seed=CFG.seed,
-            ensemble_size=CFG.interactive_num_ensemble_members,
+            ensemble_size=CFG.active_sampler_learning_num_ensemble_members,
             member_cls=MLPBinaryClassifier,
             balance_data=CFG.mlp_classifier_balance_data,
             max_train_iters=CFG.predicate_mlp_classifier_max_itr,

--- a/predicators/approaches/active_sampler_learning_approach.py
+++ b/predicators/approaches/active_sampler_learning_approach.py
@@ -71,17 +71,18 @@ class ActiveSamplerLearningApproach(OnlineNSRTLearningApproach):
         b = CFG.active_sampler_learning_explore_length_base
         max_steps = b**(1 + self._online_learning_cycle)
         preds = self._get_current_predicates()
-        explorer = create_explorer(CFG.explorer,
-                                   preds,
-                                   self._initial_options,
-                                   self._types,
-                                   self._action_space,
-                                   self._train_tasks,
-                                   self._get_current_nsrts(),
-                                   self._option_model,
-                                   ground_op_hist=self._ground_op_hist,
-                                   max_steps_before_termination=max_steps,
-                                   nsrt_to_explorer_sampler=self._nsrt_to_explorer_sampler)
+        explorer = create_explorer(
+            CFG.explorer,
+            preds,
+            self._initial_options,
+            self._types,
+            self._action_space,
+            self._train_tasks,
+            self._get_current_nsrts(),
+            self._option_model,
+            ground_op_hist=self._ground_op_hist,
+            max_steps_before_termination=max_steps,
+            nsrt_to_explorer_sampler=self._nsrt_to_explorer_sampler)
         return explorer
 
     def _learn_nsrts(self, trajectories: List[LowLevelTrajectory],

--- a/predicators/explorers/__init__.py
+++ b/predicators/explorers/__init__.py
@@ -11,7 +11,7 @@ from predicators.explorers.bilevel_planning_explorer import \
 from predicators.option_model import _OptionModelBase
 from predicators.settings import CFG
 from predicators.structs import NSRT, GroundAtom, ParameterizedOption, \
-    Predicate, State, Task, Type, _GroundSTRIPSOperator
+    Predicate, State, Task, Type, _GroundSTRIPSOperator, NSRTSampler
 
 __all__ = ["BaseExplorer"]
 
@@ -33,6 +33,7 @@ def create_explorer(
     state_score_fn: Optional[Callable[[Set[GroundAtom], State], float]] = None,
     max_steps_before_termination: Optional[int] = None,
     ground_op_hist: Optional[Dict[_GroundSTRIPSOperator, List[bool]]] = None,
+    nsrt_to_explorer_sampler: Optional[Dict[NSRT, NSRTSampler]] = None,
 ) -> BaseExplorer:
     """Create an explorer given its name."""
     if max_steps_before_termination is None:
@@ -77,10 +78,11 @@ def create_explorer(
             # Active sampler explorer uses ground_op_hist and no option model.
             elif name == "active_sampler":
                 assert ground_op_hist is not None
+                assert nsrt_to_explorer_sampler is not None
                 explorer = cls(initial_predicates, initial_options, types,
                                action_space, train_tasks,
                                max_steps_before_termination, nsrts,
-                               ground_op_hist)
+                               ground_op_hist, nsrt_to_explorer_sampler)
             else:
                 explorer = cls(initial_predicates, initial_options, types,
                                action_space, train_tasks,

--- a/predicators/explorers/__init__.py
+++ b/predicators/explorers/__init__.py
@@ -10,8 +10,8 @@ from predicators.explorers.bilevel_planning_explorer import \
     BilevelPlanningExplorer
 from predicators.option_model import _OptionModelBase
 from predicators.settings import CFG
-from predicators.structs import NSRT, GroundAtom, ParameterizedOption, \
-    Predicate, State, Task, Type, _GroundSTRIPSOperator, NSRTSampler
+from predicators.structs import NSRT, GroundAtom, NSRTSampler, \
+    ParameterizedOption, Predicate, State, Task, Type, _GroundSTRIPSOperator
 
 __all__ = ["BaseExplorer"]
 

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -526,6 +526,7 @@ class GlobalSettings:
     active_sampler_learning_fitted_q_iters = 5
     active_sampler_learning_num_next_option_samples = 5
     active_sampler_learning_explore_length_base = 2
+    active_sampler_learning_num_ensemble_members = 10
 
     # refinement cost estimation parameters
     refinement_estimator = "oracle"  # default refinement cost estimator

--- a/scripts/configs/active_sampler_learning.yaml
+++ b/scripts/configs/active_sampler_learning.yaml
@@ -1,130 +1,99 @@
 # Active sampler learning experiments.
 
-# # Experiment with random explorer, myopic classifier in bumpy_cover.
-# ---
-# APPROACHES:
-#   random-explore:
-#     NAME: "active_sampler_learning"
-#     FLAGS:
-#       explorer: "random_nsrts"
-# ENVS:
-#   bumpy_cover:
-#     NAME: "bumpy_cover"
-# ARGS:
-#   - "debug"
-# FLAGS:
-#   strips_learner: "oracle"
-#   sampler_learner: "oracle"
-#   bilevel_plan_without_sim: "True"
-#   max_initial_demos: 0
-#   num_train_tasks: 1000
-#   num_test_tasks: 100
-#   max_num_steps_interaction_request: 50
-#   sampler_mlp_classifier_max_itr: 100000
-#   mlp_classifier_balance_data: False
-#   pytorch_train_print_every: 10000
-#   active_sampler_learning_use_teacher: False  # NOTE
-#   online_nsrt_learning_requests_per_cycle: 10  # NOTE
-#   num_online_learning_cycles: 25
-# START_SEED: 123
-# NUM_SEEDS: 10
-
-# # Experiment comparing myopic classifier, fitted Q iteration, and classifier
-# # with teacher.
-# ---
-# APPROACHES:
-#   myopic_classifier:
-#     NAME: "active_sampler_learning"
-#     FLAGS:
-#       active_sampler_learning_model: "myopic_classifier"
-#       active_sampler_learning_use_teacher: False
-#   teacher_classifier:
-#     NAME: "active_sampler_learning"
-#     FLAGS:
-#       active_sampler_learning_model: "myopic_classifier"
-#       active_sampler_learning_use_teacher: True
-#   fitted_q:
-#     NAME: "active_sampler_learning"
-#     FLAGS:
-#       active_sampler_learning_model: "fitted_q"
-#       active_sampler_learning_use_teacher: False
-# ENVS:
-#   bumpy_cover:
-#     NAME: "bumpy_cover"
-#     FLAGS:
-#       bumpy_cover_right_targets: True
-# ARGS:
-#   - "debug"
-# FLAGS:
-#   strips_learner: "oracle"
-#   sampler_learner: "oracle"
-#   bilevel_plan_without_sim: "True"
-#   max_initial_demos: 0
-#   num_train_tasks: 1000
-#   num_test_tasks: 100
-#   max_num_steps_interaction_request: 50
-#   sampler_mlp_classifier_max_itr: 100000
-#   mlp_classifier_balance_data: False
-#   pytorch_train_print_every: 10000
-#   explorer: "random_nsrts"  # NOTE
-#   online_nsrt_learning_requests_per_cycle: 10  # NOTE
-#   num_online_learning_cycles: 25
-# START_SEED: 123
-# NUM_SEEDS: 10
-
-# # Experiment comparing random_nsrts exploration to active_sampler exploration
-# # in the regional bumpy cover environment. Use fewer online learning requests
-# # per cycle because we're only learning the pick bumpy classifier.
-# ---
-# APPROACHES:
-#   main:
-#     NAME: "active_sampler_learning"
-#     FLAGS:
-#       explorer: "active_sampler"
-#   # Random explore baseline
-#   random-explore:
-#     NAME: "active_sampler_learning"
-#     FLAGS:
-#       explorer: "random_nsrts"
-# ENVS:
-#   regional_bumpy_cover:
-#     NAME: "regional_bumpy_cover"
-#     FLAGS:
-#       bumpy_cover_num_bumps: 3
-#       bumpy_cover_spaces_per_bump: 3
-#       bumpy_cover_init_bumpy_prob: 1.0
-#       cover_num_blocks: 10
-#       cover_block_widths: '[0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01]'
-#       cover_num_targets: 10
-#       cover_target_widths: '[0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008]'
-# ARGS:
-#   - "debug"
-# FLAGS:
-#   strips_learner: "oracle"
-#   sampler_learner: "oracle"
-#   bilevel_plan_without_sim: "True"
-#   max_initial_demos: 0
-#   num_train_tasks: 1000
-#   num_test_tasks: 100
-#   max_num_steps_interaction_request: 50
-#   sampler_mlp_classifier_max_itr: 100000
-#   mlp_classifier_balance_data: False
-#   pytorch_train_print_every: 10000
-#   active_sampler_learning_use_teacher: False  # NOTE
-#   online_nsrt_learning_requests_per_cycle: 1  # NOTE
-#   num_online_learning_cycles: 25
-# START_SEED: 123
-# NUM_SEEDS: 10
-
-# Experiment comparing classifier with teacher when a single classifier
-# is trained vs an ensemble.
+# Experiment with random explorer, myopic classifier in bumpy_cover.
 ---
 APPROACHES:
+  random-explore:
+    NAME: "active_sampler_learning"
+    FLAGS:
+      explorer: "random_nsrts"
+ENVS:
+  bumpy_cover:
+    NAME: "bumpy_cover"
+ARGS:
+  - "debug"
+FLAGS:
+  strips_learner: "oracle"
+  sampler_learner: "oracle"
+  bilevel_plan_without_sim: "True"
+  max_initial_demos: 0
+  num_train_tasks: 1000
+  num_test_tasks: 100
+  max_num_steps_interaction_request: 50
+  sampler_mlp_classifier_max_itr: 100000
+  mlp_classifier_balance_data: False
+  pytorch_train_print_every: 10000
+  active_sampler_learning_use_teacher: False  # NOTE
+  online_nsrt_learning_requests_per_cycle: 10  # NOTE
+  num_online_learning_cycles: 25
+START_SEED: 123
+NUM_SEEDS: 10
+
+# Experiment comparing myopic classifier, fitted Q iteration, and classifier
+# with teacher.
+---
+APPROACHES:
+  myopic_classifier:
+    NAME: "active_sampler_learning"
+    FLAGS:
+      active_sampler_learning_model: "myopic_classifier"
+      active_sampler_learning_use_teacher: False
+  teacher_classifier:
+    NAME: "active_sampler_learning"
+    FLAGS:
+      active_sampler_learning_model: "myopic_classifier"
+      active_sampler_learning_use_teacher: True
+  fitted_q:
+    NAME: "active_sampler_learning"
+    FLAGS:
+      active_sampler_learning_model: "fitted_q"
+      active_sampler_learning_use_teacher: False
+ENVS:
+  bumpy_cover:
+    NAME: "bumpy_cover"
+    FLAGS:
+      bumpy_cover_right_targets: True
+ARGS:
+  - "debug"
+FLAGS:
+  strips_learner: "oracle"
+  sampler_learner: "oracle"
+  bilevel_plan_without_sim: "True"
+  max_initial_demos: 0
+  num_train_tasks: 1000
+  num_test_tasks: 100
+  max_num_steps_interaction_request: 50
+  sampler_mlp_classifier_max_itr: 100000
+  mlp_classifier_balance_data: False
+  pytorch_train_print_every: 10000
+  explorer: "random_nsrts"  # NOTE
+  online_nsrt_learning_requests_per_cycle: 10  # NOTE
+  num_online_learning_cycles: 25
+START_SEED: 123
+NUM_SEEDS: 10
+
+# Experiment comparing random_nsrts exploration to active_sampler exploration
+# both with and without an ensemble in the regional bumpy cover environment.
+# Use fewer online learning requests per cycle because we're only learning
+the pick bumpy classifier.
+---
+APPROACHES:
+  # No ensemble approach
   main:
     NAME: "active_sampler_learning"
     FLAGS:
       explorer: "active_sampler"
+  # Approach with ensemble
+  ensemble:
+    NAME: "active_sampler_learning"
+    FLAGS:
+      explorer: "active_sampler"
       active_sampler_learning_model: "myopic_classifier_ensemble"
+  # Random explore baseline
+  random-explore:
+    NAME: "active_sampler_learning"
+    FLAGS:
+      explorer: "random_nsrts"
 ENVS:
   regional_bumpy_cover:
     NAME: "regional_bumpy_cover"

--- a/scripts/configs/active_sampler_learning.yaml
+++ b/scripts/configs/active_sampler_learning.yaml
@@ -120,21 +120,22 @@
 # is trained vs an ensemble.
 ---
 APPROACHES:
-  # teacher_classifier:
-  #   NAME: "active_sampler_learning"
-  #   FLAGS:
-  #     active_sampler_learning_model: "myopic_classifier"
-  #     active_sampler_learning_use_teacher: True
-  teacher_with_ensemble:
+  main:
     NAME: "active_sampler_learning"
     FLAGS:
+      explorer: "active_sampler"
       active_sampler_learning_model: "myopic_classifier_ensemble"
-      active_sampler_learning_use_teacher: True
 ENVS:
-  bumpy_cover:
-    NAME: "bumpy_cover"
+  regional_bumpy_cover:
+    NAME: "regional_bumpy_cover"
     FLAGS:
-      bumpy_cover_right_targets: True
+      bumpy_cover_num_bumps: 3
+      bumpy_cover_spaces_per_bump: 3
+      bumpy_cover_init_bumpy_prob: 1.0
+      cover_num_blocks: 10
+      cover_block_widths: '[0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01]'
+      cover_num_targets: 10
+      cover_target_widths: '[0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008]'
 ARGS:
   - "debug"
 FLAGS:
@@ -148,8 +149,8 @@ FLAGS:
   sampler_mlp_classifier_max_itr: 100000
   mlp_classifier_balance_data: False
   pytorch_train_print_every: 10000
-  explorer: "random_nsrts"  # NOTE
-  online_nsrt_learning_requests_per_cycle: 10  # NOTE
+  active_sampler_learning_use_teacher: False  # NOTE
+  online_nsrt_learning_requests_per_cycle: 1  # NOTE
   num_online_learning_cycles: 25
 START_SEED: 123
 NUM_SEEDS: 10

--- a/scripts/configs/active_sampler_learning.yaml
+++ b/scripts/configs/active_sampler_learning.yaml
@@ -1,76 +1,76 @@
-# Active sampler learning experiments.
+# # Active sampler learning experiments.
 
-# Experiment with random explorer, myopic classifier in bumpy_cover.
----
-APPROACHES:
-  random-explore:
-    NAME: "active_sampler_learning"
-    FLAGS:
-      explorer: "random_nsrts"
-ENVS:
-  bumpy_cover:
-    NAME: "bumpy_cover"
-ARGS:
-  - "debug"
-FLAGS:
-  strips_learner: "oracle"
-  sampler_learner: "oracle"
-  bilevel_plan_without_sim: "True"
-  max_initial_demos: 0
-  num_train_tasks: 1000
-  num_test_tasks: 100
-  max_num_steps_interaction_request: 50
-  sampler_mlp_classifier_max_itr: 100000
-  mlp_classifier_balance_data: False
-  pytorch_train_print_every: 10000
-  active_sampler_learning_use_teacher: False  # NOTE
-  online_nsrt_learning_requests_per_cycle: 10  # NOTE
-  num_online_learning_cycles: 25
-START_SEED: 123
-NUM_SEEDS: 10
+# # Experiment with random explorer, myopic classifier in bumpy_cover.
+# ---
+# APPROACHES:
+#   random-explore:
+#     NAME: "active_sampler_learning"
+#     FLAGS:
+#       explorer: "random_nsrts"
+# ENVS:
+#   bumpy_cover:
+#     NAME: "bumpy_cover"
+# ARGS:
+#   - "debug"
+# FLAGS:
+#   strips_learner: "oracle"
+#   sampler_learner: "oracle"
+#   bilevel_plan_without_sim: "True"
+#   max_initial_demos: 0
+#   num_train_tasks: 1000
+#   num_test_tasks: 100
+#   max_num_steps_interaction_request: 50
+#   sampler_mlp_classifier_max_itr: 100000
+#   mlp_classifier_balance_data: False
+#   pytorch_train_print_every: 10000
+#   active_sampler_learning_use_teacher: False  # NOTE
+#   online_nsrt_learning_requests_per_cycle: 10  # NOTE
+#   num_online_learning_cycles: 25
+# START_SEED: 123
+# NUM_SEEDS: 10
 
-# Experiment comparing myopic classifier, fitted Q iteration, and classifier
-# with teacher.
----
-APPROACHES:
-  myopic_classifier:
-    NAME: "active_sampler_learning"
-    FLAGS:
-      active_sampler_learning_model: "myopic_classifier"
-      active_sampler_learning_use_teacher: False
-  teacher_classifier:
-    NAME: "active_sampler_learning"
-    FLAGS:
-      active_sampler_learning_model: "myopic_classifier"
-      active_sampler_learning_use_teacher: True
-  fitted_q:
-    NAME: "active_sampler_learning"
-    FLAGS:
-      active_sampler_learning_model: "fitted_q"
-      active_sampler_learning_use_teacher: False
-ENVS:
-  bumpy_cover:
-    NAME: "bumpy_cover"
-    FLAGS:
-      bumpy_cover_right_targets: True
-ARGS:
-  - "debug"
-FLAGS:
-  strips_learner: "oracle"
-  sampler_learner: "oracle"
-  bilevel_plan_without_sim: "True"
-  max_initial_demos: 0
-  num_train_tasks: 1000
-  num_test_tasks: 100
-  max_num_steps_interaction_request: 50
-  sampler_mlp_classifier_max_itr: 100000
-  mlp_classifier_balance_data: False
-  pytorch_train_print_every: 10000
-  explorer: "random_nsrts"  # NOTE
-  online_nsrt_learning_requests_per_cycle: 10  # NOTE
-  num_online_learning_cycles: 25
-START_SEED: 123
-NUM_SEEDS: 10
+# # Experiment comparing myopic classifier, fitted Q iteration, and classifier
+# # with teacher.
+# ---
+# APPROACHES:
+#   myopic_classifier:
+#     NAME: "active_sampler_learning"
+#     FLAGS:
+#       active_sampler_learning_model: "myopic_classifier"
+#       active_sampler_learning_use_teacher: False
+#   teacher_classifier:
+#     NAME: "active_sampler_learning"
+#     FLAGS:
+#       active_sampler_learning_model: "myopic_classifier"
+#       active_sampler_learning_use_teacher: True
+#   fitted_q:
+#     NAME: "active_sampler_learning"
+#     FLAGS:
+#       active_sampler_learning_model: "fitted_q"
+#       active_sampler_learning_use_teacher: False
+# ENVS:
+#   bumpy_cover:
+#     NAME: "bumpy_cover"
+#     FLAGS:
+#       bumpy_cover_right_targets: True
+# ARGS:
+#   - "debug"
+# FLAGS:
+#   strips_learner: "oracle"
+#   sampler_learner: "oracle"
+#   bilevel_plan_without_sim: "True"
+#   max_initial_demos: 0
+#   num_train_tasks: 1000
+#   num_test_tasks: 100
+#   max_num_steps_interaction_request: 50
+#   sampler_mlp_classifier_max_itr: 100000
+#   mlp_classifier_balance_data: False
+#   pytorch_train_print_every: 10000
+#   explorer: "random_nsrts"  # NOTE
+#   online_nsrt_learning_requests_per_cycle: 10  # NOTE
+#   num_online_learning_cycles: 25
+# START_SEED: 123
+# NUM_SEEDS: 10
 
 # Experiment comparing random_nsrts exploration to active_sampler exploration
 # in the regional bumpy cover environment. Use fewer online learning requests
@@ -81,11 +81,11 @@ APPROACHES:
     NAME: "active_sampler_learning"
     FLAGS:
       explorer: "active_sampler"
-  # Random explore baseline
-  random-explore:
-    NAME: "active_sampler_learning"
-    FLAGS:
-      explorer: "random_nsrts"
+  # # Random explore baseline
+  # random-explore:
+  #   NAME: "active_sampler_learning"
+  #   FLAGS:
+  #     explorer: "random_nsrts"
 ENVS:
   regional_bumpy_cover:
     NAME: "regional_bumpy_cover"

--- a/scripts/configs/active_sampler_learning.yaml
+++ b/scripts/configs/active_sampler_learning.yaml
@@ -29,74 +29,30 @@
 # START_SEED: 123
 # NUM_SEEDS: 10
 
-# # Experiment comparing myopic classifier, fitted Q iteration, and classifier
-# # with teacher.
-# ---
-# APPROACHES:
-#   myopic_classifier:
-#     NAME: "active_sampler_learning"
-#     FLAGS:
-#       active_sampler_learning_model: "myopic_classifier"
-#       active_sampler_learning_use_teacher: False
-#   teacher_classifier:
-#     NAME: "active_sampler_learning"
-#     FLAGS:
-#       active_sampler_learning_model: "myopic_classifier"
-#       active_sampler_learning_use_teacher: True
-#   fitted_q:
-#     NAME: "active_sampler_learning"
-#     FLAGS:
-#       active_sampler_learning_model: "fitted_q"
-#       active_sampler_learning_use_teacher: False
-# ENVS:
-#   bumpy_cover:
-#     NAME: "bumpy_cover"
-#     FLAGS:
-#       bumpy_cover_right_targets: True
-# ARGS:
-#   - "debug"
-# FLAGS:
-#   strips_learner: "oracle"
-#   sampler_learner: "oracle"
-#   bilevel_plan_without_sim: "True"
-#   max_initial_demos: 0
-#   num_train_tasks: 1000
-#   num_test_tasks: 100
-#   max_num_steps_interaction_request: 50
-#   sampler_mlp_classifier_max_itr: 100000
-#   mlp_classifier_balance_data: False
-#   pytorch_train_print_every: 10000
-#   explorer: "random_nsrts"  # NOTE
-#   online_nsrt_learning_requests_per_cycle: 10  # NOTE
-#   num_online_learning_cycles: 25
-# START_SEED: 123
-# NUM_SEEDS: 10
-
-# Experiment comparing random_nsrts exploration to active_sampler exploration
-# in the regional bumpy cover environment. Use fewer online learning requests
-# per cycle because we're only learning the pick bumpy classifier.
+# Experiment comparing myopic classifier, fitted Q iteration, and classifier
+# with teacher.
 ---
 APPROACHES:
-  main:
+  myopic_classifier:
     NAME: "active_sampler_learning"
     FLAGS:
-      explorer: "active_sampler"
-  # # Random explore baseline
-  # random-explore:
+      active_sampler_learning_model: "myopic_classifier"
+      active_sampler_learning_use_teacher: False
+  # teacher_classifier:
   #   NAME: "active_sampler_learning"
   #   FLAGS:
-  #     explorer: "random_nsrts"
+  #     active_sampler_learning_model: "myopic_classifier"
+  #     active_sampler_learning_use_teacher: True
+  # fitted_q:
+  #   NAME: "active_sampler_learning"
+  #   FLAGS:
+  #     active_sampler_learning_model: "fitted_q"
+  #     active_sampler_learning_use_teacher: False
 ENVS:
-  regional_bumpy_cover:
-    NAME: "regional_bumpy_cover"
+  bumpy_cover:
+    NAME: "bumpy_cover"
     FLAGS:
-      bumpy_cover_num_bumps: 3
-      bumpy_cover_spaces_per_bump: 3
-      bumpy_cover_init_bumpy_prob: 1.0
-      cover_num_blocks: 10
-      cover_block_widths: '[0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01]'
-      cover_num_targets: 10
-      cover_target_widths: '[0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008]'
+      bumpy_cover_right_targets: True
 ARGS:
   - "debug"
 FLAGS:
@@ -110,8 +66,52 @@ FLAGS:
   sampler_mlp_classifier_max_itr: 100000
   mlp_classifier_balance_data: False
   pytorch_train_print_every: 10000
-  active_sampler_learning_use_teacher: False  # NOTE
-  online_nsrt_learning_requests_per_cycle: 1  # NOTE
+  explorer: "random_nsrts"  # NOTE
+  online_nsrt_learning_requests_per_cycle: 10  # NOTE
   num_online_learning_cycles: 25
 START_SEED: 123
 NUM_SEEDS: 10
+
+# # Experiment comparing random_nsrts exploration to active_sampler exploration
+# # in the regional bumpy cover environment. Use fewer online learning requests
+# # per cycle because we're only learning the pick bumpy classifier.
+# ---
+# APPROACHES:
+#   main:
+#     NAME: "active_sampler_learning"
+#     FLAGS:
+#       explorer: "active_sampler"
+#   # Random explore baseline
+#   random-explore:
+#     NAME: "active_sampler_learning"
+#     FLAGS:
+#       explorer: "random_nsrts"
+# ENVS:
+#   regional_bumpy_cover:
+#     NAME: "regional_bumpy_cover"
+#     FLAGS:
+#       bumpy_cover_num_bumps: 3
+#       bumpy_cover_spaces_per_bump: 3
+#       bumpy_cover_init_bumpy_prob: 1.0
+#       cover_num_blocks: 10
+#       cover_block_widths: '[0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01]'
+#       cover_num_targets: 10
+#       cover_target_widths: '[0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008]'
+# ARGS:
+#   - "debug"
+# FLAGS:
+#   strips_learner: "oracle"
+#   sampler_learner: "oracle"
+#   bilevel_plan_without_sim: "True"
+#   max_initial_demos: 0
+#   num_train_tasks: 1000
+#   num_test_tasks: 100
+#   max_num_steps_interaction_request: 50
+#   sampler_mlp_classifier_max_itr: 100000
+#   mlp_classifier_balance_data: False
+#   pytorch_train_print_every: 10000
+#   active_sampler_learning_use_teacher: False  # NOTE
+#   online_nsrt_learning_requests_per_cycle: 1  # NOTE
+#   num_online_learning_cycles: 25
+# START_SEED: 123
+# NUM_SEEDS: 10

--- a/scripts/configs/active_sampler_learning.yaml
+++ b/scripts/configs/active_sampler_learning.yaml
@@ -1,4 +1,4 @@
-# # Active sampler learning experiments.
+# Active sampler learning experiments.
 
 # # Experiment with random explorer, myopic classifier in bumpy_cover.
 # ---
@@ -29,48 +29,48 @@
 # START_SEED: 123
 # NUM_SEEDS: 10
 
-# Experiment comparing myopic classifier, fitted Q iteration, and classifier
-# with teacher.
----
-APPROACHES:
-  myopic_classifier:
-    NAME: "active_sampler_learning"
-    FLAGS:
-      active_sampler_learning_model: "myopic_classifier"
-      active_sampler_learning_use_teacher: False
-  # teacher_classifier:
-  #   NAME: "active_sampler_learning"
-  #   FLAGS:
-  #     active_sampler_learning_model: "myopic_classifier"
-  #     active_sampler_learning_use_teacher: True
-  # fitted_q:
-  #   NAME: "active_sampler_learning"
-  #   FLAGS:
-  #     active_sampler_learning_model: "fitted_q"
-  #     active_sampler_learning_use_teacher: False
-ENVS:
-  bumpy_cover:
-    NAME: "bumpy_cover"
-    FLAGS:
-      bumpy_cover_right_targets: True
-ARGS:
-  - "debug"
-FLAGS:
-  strips_learner: "oracle"
-  sampler_learner: "oracle"
-  bilevel_plan_without_sim: "True"
-  max_initial_demos: 0
-  num_train_tasks: 1000
-  num_test_tasks: 100
-  max_num_steps_interaction_request: 50
-  sampler_mlp_classifier_max_itr: 100000
-  mlp_classifier_balance_data: False
-  pytorch_train_print_every: 10000
-  explorer: "random_nsrts"  # NOTE
-  online_nsrt_learning_requests_per_cycle: 10  # NOTE
-  num_online_learning_cycles: 25
-START_SEED: 123
-NUM_SEEDS: 10
+# # Experiment comparing myopic classifier, fitted Q iteration, and classifier
+# # with teacher.
+# ---
+# APPROACHES:
+#   myopic_classifier:
+#     NAME: "active_sampler_learning"
+#     FLAGS:
+#       active_sampler_learning_model: "myopic_classifier"
+#       active_sampler_learning_use_teacher: False
+#   teacher_classifier:
+#     NAME: "active_sampler_learning"
+#     FLAGS:
+#       active_sampler_learning_model: "myopic_classifier"
+#       active_sampler_learning_use_teacher: True
+#   fitted_q:
+#     NAME: "active_sampler_learning"
+#     FLAGS:
+#       active_sampler_learning_model: "fitted_q"
+#       active_sampler_learning_use_teacher: False
+# ENVS:
+#   bumpy_cover:
+#     NAME: "bumpy_cover"
+#     FLAGS:
+#       bumpy_cover_right_targets: True
+# ARGS:
+#   - "debug"
+# FLAGS:
+#   strips_learner: "oracle"
+#   sampler_learner: "oracle"
+#   bilevel_plan_without_sim: "True"
+#   max_initial_demos: 0
+#   num_train_tasks: 1000
+#   num_test_tasks: 100
+#   max_num_steps_interaction_request: 50
+#   sampler_mlp_classifier_max_itr: 100000
+#   mlp_classifier_balance_data: False
+#   pytorch_train_print_every: 10000
+#   explorer: "random_nsrts"  # NOTE
+#   online_nsrt_learning_requests_per_cycle: 10  # NOTE
+#   num_online_learning_cycles: 25
+# START_SEED: 123
+# NUM_SEEDS: 10
 
 # # Experiment comparing random_nsrts exploration to active_sampler exploration
 # # in the regional bumpy cover environment. Use fewer online learning requests
@@ -115,3 +115,41 @@ NUM_SEEDS: 10
 #   num_online_learning_cycles: 25
 # START_SEED: 123
 # NUM_SEEDS: 10
+
+# Experiment comparing classifier with teacher when a single classifier
+# is trained vs an ensemble.
+---
+APPROACHES:
+  # teacher_classifier:
+  #   NAME: "active_sampler_learning"
+  #   FLAGS:
+  #     active_sampler_learning_model: "myopic_classifier"
+  #     active_sampler_learning_use_teacher: True
+  teacher_with_ensemble:
+    NAME: "active_sampler_learning"
+    FLAGS:
+      active_sampler_learning_model: "myopic_classifier_ensemble"
+      active_sampler_learning_use_teacher: True
+ENVS:
+  bumpy_cover:
+    NAME: "bumpy_cover"
+    FLAGS:
+      bumpy_cover_right_targets: True
+ARGS:
+  - "debug"
+FLAGS:
+  strips_learner: "oracle"
+  sampler_learner: "oracle"
+  bilevel_plan_without_sim: "True"
+  max_initial_demos: 0
+  num_train_tasks: 1000
+  num_test_tasks: 100
+  max_num_steps_interaction_request: 50
+  sampler_mlp_classifier_max_itr: 100000
+  mlp_classifier_balance_data: False
+  pytorch_train_print_every: 10000
+  explorer: "random_nsrts"  # NOTE
+  online_nsrt_learning_requests_per_cycle: 10  # NOTE
+  num_online_learning_cycles: 25
+START_SEED: 123
+NUM_SEEDS: 10

--- a/scripts/plotting/create_active_sampler_learning_plots.py
+++ b/scripts/plotting/create_active_sampler_learning_plots.py
@@ -52,23 +52,27 @@ Y_KEY_AND_LABEL = [
 # The keys of the outer dict are plot titles.
 # The keys of the inner dict are (legend label, marker, df selector).
 PLOT_GROUPS = {
-    "Bumpy Cover": [
-        ("Approach v0", "black", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "bumpy_cover-random-explore" in v)),
-    ],
+    # "Bumpy Cover": [
+    #     ("Approach v0", "black", lambda df: df["EXPERIMENT_ID"].apply(
+    #         lambda v: "bumpy_cover-random-explore" in v)),
+    # ],
+    # "Shifted Bumpy Cover": [
+    #     ("Myopic Classifier", "green", lambda df: df["EXPERIMENT_ID"].apply(
+    #         lambda v: "bumpy_cover-myopic_classifier" in v)),
+    #     ("Fitted Q", "purple", lambda df: df["EXPERIMENT_ID"].apply(
+    #         lambda v: "bumpy_cover-fitted_q" in v)),
+    #     ("Teacher Classifier", "brown", lambda df: df["EXPERIMENT_ID"].apply(
+    #         lambda v: "bumpy_cover-teacher_classifier" in v)),
+    # ],
+    # "Regional Bumpy Cover": [
+    #     ("Active Explore", "blue", lambda df: df["EXPERIMENT_ID"].apply(
+    #         lambda v: "regional_bumpy_cover-main" in v)),
+    #     ("Random Explore", "red", lambda df: df["EXPERIMENT_ID"].apply(
+    #         lambda v: "regional_bumpy_cover-random-explore" in v)),
+    # ],
     "Shifted Bumpy Cover": [
-        ("Myopic Classifier", "green", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "bumpy_cover-myopic_classifier" in v)),
-        ("Fitted Q", "purple", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "bumpy_cover-fitted_q" in v)),
-        ("Teacher Classifier", "brown", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "bumpy_cover-teacher_classifier" in v)),
-    ],
-    "Regional Bumpy Cover": [
-        ("Active Explore", "blue", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "regional_bumpy_cover-main" in v)),
-        ("Random Explore", "red", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "regional_bumpy_cover-random-explore" in v)),
+        ("Myopic Classifier Ensemble", "green", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "bumpy_cover-teacher_with_ensemble" in v)),
     ],
 }
 

--- a/scripts/plotting/create_active_sampler_learning_plots.py
+++ b/scripts/plotting/create_active_sampler_learning_plots.py
@@ -52,27 +52,25 @@ Y_KEY_AND_LABEL = [
 # The keys of the outer dict are plot titles.
 # The keys of the inner dict are (legend label, marker, df selector).
 PLOT_GROUPS = {
-    # "Bumpy Cover": [
-    #     ("Approach v0", "black", lambda df: df["EXPERIMENT_ID"].apply(
-    #         lambda v: "bumpy_cover-random-explore" in v)),
-    # ],
-    # "Shifted Bumpy Cover": [
-    #     ("Myopic Classifier", "green", lambda df: df["EXPERIMENT_ID"].apply(
-    #         lambda v: "bumpy_cover-myopic_classifier" in v)),
-    #     ("Fitted Q", "purple", lambda df: df["EXPERIMENT_ID"].apply(
-    #         lambda v: "bumpy_cover-fitted_q" in v)),
-    #     ("Teacher Classifier", "brown", lambda df: df["EXPERIMENT_ID"].apply(
-    #         lambda v: "bumpy_cover-teacher_classifier" in v)),
-    # ],
-    # "Regional Bumpy Cover": [
-    #     ("Active Explore", "blue", lambda df: df["EXPERIMENT_ID"].apply(
-    #         lambda v: "regional_bumpy_cover-main" in v)),
-    #     ("Random Explore", "red", lambda df: df["EXPERIMENT_ID"].apply(
-    #         lambda v: "regional_bumpy_cover-random-explore" in v)),
-    # ],
+    "Bumpy Cover": [
+        ("Approach v0", "black", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "bumpy_cover-random-explore" in v)),
+    ],
     "Shifted Bumpy Cover": [
-        ("Myopic Classifier Ensemble", "green", lambda df: df["EXPERIMENT_ID"].apply(
-            lambda v: "bumpy_cover-teacher_with_ensemble" in v)),
+        ("Myopic Classifier", "green", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "bumpy_cover-myopic_classifier" in v)),
+        ("Fitted Q", "purple", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "bumpy_cover-fitted_q" in v)),
+        ("Teacher Classifier", "brown", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "bumpy_cover-teacher_classifier" in v)),
+    ],
+    "Regional Bumpy Cover": [
+        ("Active Explore No Ensemble", "blue", lambda df: df["EXPERIMENT_ID"].
+         apply(lambda v: "regional_bumpy_cover-main" in v)),
+        ("Active Explore Ensemble", "green", lambda df: df["EXPERIMENT_ID"].
+         apply(lambda v: "regional_bumpy_cover-ensemble" in v)),
+        ("Random Explore", "red", lambda df: df["EXPERIMENT_ID"].apply(
+            lambda v: "regional_bumpy_cover-random-explore" in v)),
     ],
 }
 

--- a/tests/approaches/test_active_sampler_learning_approach.py
+++ b/tests/approaches/test_active_sampler_learning_approach.py
@@ -14,11 +14,14 @@ from predicators.teacher import Teacher
 
 
 @pytest.mark.parametrize("model_name,right_targets,num_demo",
-                         [("myopic_classifier", False, 0),
+                         [
+                        #   ("myopic_classifier", False, 0),
                           ("myopic_classifier", True, 1),
-                          ("myopic_classifier_ensemble", False, 0),
-                          ("myopic_classifier_ensemble", False, 1),
-                          ("fitted_q", False, 0), ("fitted_q", True, 0)])
+                        #   ("myopic_classifier_ensemble", False, 0),
+                        #   ("myopic_classifier_ensemble", False, 1),
+                        #   ("fitted_q", False, 0), ("fitted_q", True, 0)
+                          ]
+                        )
 def test_active_sampler_learning_approach(model_name, right_targets, num_demo):
     """Test for ActiveSamplerLearningApproach class, entire pipeline."""
     utils.reset_config({
@@ -66,6 +69,15 @@ def test_active_sampler_learning_approach(model_name, right_targets, num_demo):
     approach.load(online_learning_cycle=0)
     with pytest.raises(FileNotFoundError):
         approach.load(online_learning_cycle=1)
+    if num_demo > 0:
+        for i in range(3):
+            interaction_requests = approach.get_interaction_requests()
+            teacher = Teacher(train_tasks)
+            interaction_results, _ = _generate_interaction_results(
+                env, teacher, interaction_requests, i)
+            approach.learn_from_interaction_results(interaction_results)
+            approach.load(online_learning_cycle=i)
+
     for task in env.get_test_tasks():
         policy = approach.solve(task, timeout=CFG.timeout)
         # We won't fully check the policy here because we don't want

--- a/tests/approaches/test_active_sampler_learning_approach.py
+++ b/tests/approaches/test_active_sampler_learning_approach.py
@@ -13,15 +13,15 @@ from predicators.structs import Dataset
 from predicators.teacher import Teacher
 
 
-@pytest.mark.parametrize("model_name,right_targets,num_demo",
-                         [
-                        #   ("myopic_classifier", False, 0),
-                          ("myopic_classifier", True, 1),
-                        #   ("myopic_classifier_ensemble", False, 0),
-                        #   ("myopic_classifier_ensemble", False, 1),
-                        #   ("fitted_q", False, 0), ("fitted_q", True, 0)
-                          ]
-                        )
+@pytest.mark.parametrize(
+    "model_name,right_targets,num_demo",
+    [
+        #   ("myopic_classifier", False, 0),
+        ("myopic_classifier", True, 1),
+        #   ("myopic_classifier_ensemble", False, 0),
+        #   ("myopic_classifier_ensemble", False, 1),
+        #   ("fitted_q", False, 0), ("fitted_q", True, 0)
+    ])
 def test_active_sampler_learning_approach(model_name, right_targets, num_demo):
     """Test for ActiveSamplerLearningApproach class, entire pipeline."""
     utils.reset_config({
@@ -69,14 +69,6 @@ def test_active_sampler_learning_approach(model_name, right_targets, num_demo):
     approach.load(online_learning_cycle=0)
     with pytest.raises(FileNotFoundError):
         approach.load(online_learning_cycle=1)
-    if num_demo > 0:
-        for i in range(3):
-            interaction_requests = approach.get_interaction_requests()
-            teacher = Teacher(train_tasks)
-            interaction_results, _ = _generate_interaction_results(
-                env, teacher, interaction_requests, i)
-            approach.learn_from_interaction_results(interaction_results)
-            approach.load(online_learning_cycle=i)
 
     for task in env.get_test_tasks():
         policy = approach.solve(task, timeout=CFG.timeout)

--- a/tests/approaches/test_active_sampler_learning_approach.py
+++ b/tests/approaches/test_active_sampler_learning_approach.py
@@ -13,15 +13,12 @@ from predicators.structs import Dataset
 from predicators.teacher import Teacher
 
 
-@pytest.mark.parametrize(
-    "model_name,right_targets,num_demo",
-    [
-        #   ("myopic_classifier", False, 0),
-        #   ("myopic_classifier", True, 1),
-        #   ("myopic_classifier_ensemble", False, 0),
-        ("myopic_classifier_ensemble", False, 1),
-        #   ("fitted_q", False, 0), ("fitted_q", True, 0)
-    ])
+@pytest.mark.parametrize("model_name,right_targets,num_demo",
+                         [("myopic_classifier", False, 0),
+                          ("myopic_classifier", True, 1),
+                          ("myopic_classifier_ensemble", False, 0),
+                          ("myopic_classifier_ensemble", False, 1),
+                          ("fitted_q", False, 0), ("fitted_q", True, 0)])
 def test_active_sampler_learning_approach(model_name, right_targets, num_demo):
     """Test for ActiveSamplerLearningApproach class, entire pipeline."""
     utils.reset_config({

--- a/tests/approaches/test_active_sampler_learning_approach.py
+++ b/tests/approaches/test_active_sampler_learning_approach.py
@@ -13,13 +13,12 @@ from predicators.structs import Dataset
 from predicators.teacher import Teacher
 
 
-@pytest.mark.parametrize(
-    "model_name,right_targets,num_demo",
-    [("myopic_classifier", False, 0),
-     ("myopic_classifier", True, 1),
-     ("myopic_classifier_ensemble", False, 0),
-     ("myopic_classifier_ensemble", False, 1),
-     ("fitted_q", False, 0), ("fitted_q", True, 0)])
+@pytest.mark.parametrize("model_name,right_targets,num_demo",
+                         [("myopic_classifier", False, 0),
+                          ("myopic_classifier", True, 1),
+                          ("myopic_classifier_ensemble", False, 0),
+                          ("myopic_classifier_ensemble", False, 1),
+                          ("fitted_q", False, 0), ("fitted_q", True, 0)])
 def test_active_sampler_learning_approach(model_name, right_targets, num_demo):
     """Test for ActiveSamplerLearningApproach class, entire pipeline."""
     utils.reset_config({
@@ -67,7 +66,6 @@ def test_active_sampler_learning_approach(model_name, right_targets, num_demo):
     approach.load(online_learning_cycle=0)
     with pytest.raises(FileNotFoundError):
         approach.load(online_learning_cycle=1)
-
     for task in env.get_test_tasks():
         policy = approach.solve(task, timeout=CFG.timeout)
         # We won't fully check the policy here because we don't want

--- a/tests/approaches/test_active_sampler_learning_approach.py
+++ b/tests/approaches/test_active_sampler_learning_approach.py
@@ -13,10 +13,15 @@ from predicators.structs import Dataset
 from predicators.teacher import Teacher
 
 
-@pytest.mark.parametrize("model_name,right_targets,num_demo",
-                         [("myopic_classifier", False, 0),
-                          ("myopic_classifier", True, 1),
-                          ("fitted_q", False, 0), ("fitted_q", True, 0)])
+@pytest.mark.parametrize(
+    "model_name,right_targets,num_demo",
+    [
+        #   ("myopic_classifier", False, 0),
+        #   ("myopic_classifier", True, 1),
+        #   ("myopic_classifier_ensemble", False, 0),
+        ("myopic_classifier_ensemble", False, 1),
+        #   ("fitted_q", False, 0), ("fitted_q", True, 0)
+    ])
 def test_active_sampler_learning_approach(model_name, right_targets, num_demo):
     """Test for ActiveSamplerLearningApproach class, entire pipeline."""
     utils.reset_config({
@@ -41,6 +46,7 @@ def test_active_sampler_learning_approach(model_name, right_targets, num_demo):
         "active_sampler_learning_fitted_q_iters": 2,
         "active_sampler_learning_num_next_option_samples": 2,
         "bumpy_cover_right_targets": right_targets,
+        "active_sampler_learning_num_ensemble_members": 2,
     })
     env = BumpyCoverEnv()
     train_tasks = [t.task for t in env.get_train_tasks()]

--- a/tests/approaches/test_active_sampler_learning_approach.py
+++ b/tests/approaches/test_active_sampler_learning_approach.py
@@ -15,13 +15,11 @@ from predicators.teacher import Teacher
 
 @pytest.mark.parametrize(
     "model_name,right_targets,num_demo",
-    [
-        #   ("myopic_classifier", False, 0),
-        ("myopic_classifier", True, 1),
-        #   ("myopic_classifier_ensemble", False, 0),
-        #   ("myopic_classifier_ensemble", False, 1),
-        #   ("fitted_q", False, 0), ("fitted_q", True, 0)
-    ])
+    [("myopic_classifier", False, 0),
+     ("myopic_classifier", True, 1),
+     ("myopic_classifier_ensemble", False, 0),
+     ("myopic_classifier_ensemble", False, 1),
+     ("fitted_q", False, 0), ("fitted_q", True, 0)])
 def test_active_sampler_learning_approach(model_name, right_targets, num_demo):
     """Test for ActiveSamplerLearningApproach class, entire pipeline."""
     utils.reset_config({

--- a/tests/explorers/test_active_sampler_explorer.py
+++ b/tests/explorers/test_active_sampler_explorer.py
@@ -1,10 +1,12 @@
 """Test cases for the active_sampler explorer class."""
+from typing import Dict
 
 from predicators import utils
 from predicators.envs.cover import RegionalBumpyCoverEnv
 from predicators.explorers import create_explorer
 from predicators.ground_truth_models import get_gt_nsrts, get_gt_options
 from predicators.option_model import _OracleOptionModel
+from predicators.structs import NSRT, NSRTSampler
 
 
 def test_active_sampler_explorer():
@@ -24,16 +26,21 @@ def test_active_sampler_explorer():
     option_model = _OracleOptionModel(env)
     train_tasks = [t.task for t in env.get_train_tasks()]
     ground_op_hist = {}
-    explorer = create_explorer("active_sampler",
-                               env.predicates,
-                               get_gt_options(env.get_name()),
-                               env.types,
-                               env.action_space,
-                               train_tasks,
-                               nsrts,
-                               option_model,
-                               ground_op_hist=ground_op_hist,
-                               max_steps_before_termination=2)
+    nsrt_to_explorer_sampler: Dict[NSRT, NSRTSampler] = {}
+    for nsrt in nsrts:
+        nsrt_to_explorer_sampler[nsrt] = nsrt.sampler
+    explorer = create_explorer(
+        "active_sampler",
+        env.predicates,
+        get_gt_options(env.get_name()),
+        env.types,
+        env.action_space,
+        train_tasks,
+        nsrts,
+        option_model,
+        ground_op_hist=ground_op_hist,
+        max_steps_before_termination=2,
+        nsrt_to_explorer_sampler=nsrt_to_explorer_sampler)
     task_idx = 0
     policy, term_fn = explorer.get_exploration_strategy(task_idx, 500)
     task = train_tasks[0]
@@ -68,15 +75,20 @@ def test_active_sampler_explorer():
     option_model = _OracleOptionModel(env)
     train_tasks = [t.task for t in env.get_train_tasks()]
     ground_op_hist = {}
-    explorer = create_explorer("active_sampler",
-                               env.predicates,
-                               get_gt_options(env.get_name()),
-                               env.types,
-                               env.action_space,
-                               train_tasks,
-                               nsrts,
-                               option_model,
-                               ground_op_hist=ground_op_hist)
+    nsrt_to_explorer_sampler: Dict[NSRT, NSRTSampler] = {}
+    for nsrt in nsrts:
+        nsrt_to_explorer_sampler[nsrt] = nsrt.sampler
+    explorer = create_explorer(
+        "active_sampler",
+        env.predicates,
+        get_gt_options(env.get_name()),
+        env.types,
+        env.action_space,
+        train_tasks,
+        nsrts,
+        option_model,
+        ground_op_hist=ground_op_hist,
+        nsrt_to_explorer_sampler=nsrt_to_explorer_sampler)
     task_idx = 0
     policy, term_fn = explorer.get_exploration_strategy(task_idx, 500)
     task = train_tasks[0]


### PR DESCRIPTION
Includes new ensemble learner approach for active learning. Example command:
```
python predicators/main.py --env bumpy_cover --approach active_sampler_learning --strips_learner oracle --sampler_learner oracle --bilevel_plan_without_sim True --max_initial_demos 0 --num_train_tasks 1000 --num_test_tasks 100 --max_num_steps_interaction_request 50 --sampler_mlp_classifier_max_itr 100000 --mlp_classifier_balance_data False --pytorch_train_print_every 10000 --explorer random_nsrts --online_nsrt_learning_requests_per_cycle 10 --num_online_learning_cycles 25 --active_sampler_learning_model myopic_classifier_ensemble --active_sampler_learning_use_teacher True --bumpy_cover_right_targets True --seed 123
```

 ![Screenshot from 2023-06-26 14-21-09](https://github.com/Learning-and-Intelligent-Systems/predicators/assets/12446934/2e840385-7073-42ff-9487-f897999e0d44)