### PR TITLE
fix bug in active sampler explorer

### DIFF
--- a/predicators/explorers/active_sampler_explorer.py
+++ b/predicators/explorers/active_sampler_explorer.py
@@ -1,8 +1,13 @@
 """An explorer for active sampler learning."""
 
+import glob
 import logging
+import os
+import re
+import time
 from typing import Callable, Dict, Iterator, List, Optional, Set
 
+import dill as pkl
 import numpy as np
 from gym.spaces import Box
 
@@ -44,6 +49,8 @@ class ActiveSamplerExplorer(BaseExplorer):
         self._nsrts = nsrts
         self._ground_op_hist = ground_op_hist
         self._last_executed_nsrt: Optional[_GroundNSRT] = None
+        self._last_executed_option: Optional[_Option] = None
+        self._last_init_option_state: Optional[State] = None
         self._nsrt_to_explorer_sampler = nsrt_to_explorer_sampler
 
     @classmethod
@@ -74,6 +81,7 @@ class ActiveSamplerExplorer(BaseExplorer):
         next_practice_nsrt: Optional[_GroundNSRT] = None
 
         def _option_policy(state: State) -> _Option:
+            logging.info("[Explorer] Option policy called.")
             nonlocal assigned_task_goal_reached, current_policy, \
                 next_practice_nsrt
 
@@ -162,15 +170,22 @@ class ActiveSamplerExplorer(BaseExplorer):
 
         # Wrap the option policy to keep track of the executed NSRTs and if
         # they succeeded, to update the ground_op_hist.
-        self._last_executed_nsrt = None
-
+        initialized = False
         def _wrapped_option_policy(state: State) -> _Option:
+            nonlocal initialized
+            if not initialized:
+                self._last_executed_nsrt = None
+                self._last_executed_option = None
+                self._last_init_option_state = None
+                initialized = True
             # Update ground_op_hist.
             self._update_ground_op_hist(state)
             # Record last executed NSRT.
             option = _option_policy(state)
             ground_nsrt = utils.option_to_ground_nsrt(option, self._nsrts)
             self._last_executed_nsrt = ground_nsrt
+            self._last_executed_option = option
+            self._last_init_option_state = state
             return option
 
         # Finalize policy.
@@ -202,6 +217,39 @@ class ActiveSamplerExplorer(BaseExplorer):
         if last_executed_op not in self._ground_op_hist:
             self._ground_op_hist[last_executed_op] = []
         self._ground_op_hist[last_executed_op].append(success)
+        # Aggressively save data after every single option execution.
+        init_state = self._last_init_option_state
+        assert init_state is not None
+        option = self._last_executed_option
+        assert option is not None
+        objects = option.objects
+        params = option.params
+        sampler_input = utils.construct_active_sampler_input(
+            init_state, objects, params, option.parent)
+        sampler_output = int(success)
+        # Now, we need to get the file location and the max
+        # datapoint id saved at this location.
+        os.makedirs(CFG.data_dir, exist_ok=True)
+        objects_tuple_str = str(tuple(nsrt.objects))
+        objects_tuple_str = objects_tuple_str.strip('()')
+        prefix = f"{CFG.data_dir}/{CFG.env}_{nsrt.name}({objects_tuple_str})_"
+        filepath_template = f"{prefix}*.data"
+        datapoint_id = 0
+        all_saved_files = glob.glob(filepath_template)
+        if all_saved_files:
+            regex_prefix = re.escape(prefix)
+            regex = f"{regex_prefix}(\\d+).data"
+            for filename in all_saved_files:
+                regex_match = re.match(regex, filename)
+                assert regex_match is not None
+                d_id = int(regex_match.groups()[0])
+                datapoint_id = max(datapoint_id, d_id + 1)
+        data = {
+            "datapoint": (sampler_input, sampler_output),
+            "time": time.time()
+        }
+        with open(f"{prefix}{datapoint_id}.data", "wb") as f:
+            pkl.dump(data, f)
 
     def _get_option_policy_for_task(self,
                                     task: Task) -> Callable[[State], _Option]:


### PR DESCRIPTION
this is a pretty bad bug that was causing a bunch of nonsensical sampler data to get recorded (in a certain case described below).

the bug was in `self._last_executed_nsrt` and the other fields not getting properly reset to `None` after each interaction request. I mistakenly believed that `_get_exploration_strategy()` was getting called after each of the N interaction requests per online learning cycle, but that's not true -- it's called N times _before_ the online learning cycle. the whole "request" setup that we have is quite confusing and regrettable, but a larger refactor is not worth it right now.

the reason we didn't encounter this bug earlier is that we were almost always doing `--online_nsrt_learning_requests_per_cycle 1`, in which case the bug doesn't manifest.