### PR TITLE
fix two bugs related to segmentation in active sampler learning

### DIFF
--- a/predicators/explorers/active_sampler_explorer.py
+++ b/predicators/explorers/active_sampler_explorer.py
@@ -175,9 +175,8 @@ class ActiveSamplerExplorer(BaseExplorer):
             # Record last executed NSRT.
             option = _option_policy(state)
             ground_nsrt = utils.option_to_ground_nsrt(option, self._nsrts)
-            logging.info(
-                f"[Explorer] Starting NSRT: {ground_nsrt.name}{ground_nsrt.objects}"
-            )
+            logging.info(f"[Explorer] Starting NSRT: {ground_nsrt.name}"
+                         f"{ground_nsrt.objects}")
             self._last_executed_nsrt = ground_nsrt
             return option
 

--- a/predicators/explorers/active_sampler_explorer.py
+++ b/predicators/explorers/active_sampler_explorer.py
@@ -189,8 +189,9 @@ class ActiveSamplerExplorer(BaseExplorer):
         def _wrapped_policy(state: State) -> Action:
             try:
                 return policy(state)
-            except utils.ExceptionWithInfo as e:
-                # About to terminate.
+            except utils.OptionTimeoutFailure as e:
+                # If the option was cut off due to max_option_steps, then
+                # we consider the option to be terminated.
                 self._update_ground_op_hist(state)
                 raise e
 

--- a/predicators/main.py
+++ b/predicators/main.py
@@ -505,7 +505,7 @@ def _run_episode(
                 observations.append(obs)
             except Exception as e:
                 if exceptions_to_break_on is not None and \
-                   type(e) in exceptions_to_break_on:
+                   any(issubclass(type(e), c) for c in exceptions_to_break_on):
                     if monitor_observed:
                         exception_raised_in_step = True
                     break

--- a/predicators/nsrt_learning/segmentation.py
+++ b/predicators/nsrt_learning/segmentation.py
@@ -96,7 +96,14 @@ def _segment_with_option_changes(
         # option's terminal function to check if it completed, or see if the
         # termination was due to max_num_steps_option_rollout.
         if t == len(traj.actions) - 1:
-            if t >= CFG.max_num_steps_option_rollout - 1:
+            # Calculate the number of steps since the option changed.
+            backward_t = t
+            while backward_t > 0:
+                if traj.actions[backward_t - 1].get_option() is not option_t:
+                    break
+                backward_t -= 1
+            option_duration = t - backward_t + 1
+            if option_duration >= CFG.max_num_steps_option_rollout:
                 return True
             return option_t.terminal(traj.states[t + 1])
         return option_t is not traj.actions[t + 1].get_option()

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -1125,6 +1125,10 @@ class OptionExecutionFailure(ExceptionWithInfo):
     """An exception raised by an option policy in the course of execution."""
 
 
+class OptionTimeoutFailure(OptionExecutionFailure):
+    """A special kind of option execution failure due to an exceeded budget."""
+
+
 class RequestActPolicyFailure(ExceptionWithInfo):
     """An exception raised by an acting policy in a request when it fails to
     produce an action, which terminates the interaction."""
@@ -1169,13 +1173,13 @@ def option_policy_to_policy(
 
         if max_option_steps is not None and \
             num_cur_option_steps >= max_option_steps:
-            raise OptionExecutionFailure(
+            raise OptionTimeoutFailure(
                 "Exceeded max option steps.",
                 info={"last_failed_option": last_option})
 
         if last_state is not None and \
             raise_error_on_repeated_state and state.allclose(last_state):
-            raise OptionExecutionFailure(
+            raise OptionTimeoutFailure(
                 "Encountered repeated state.",
                 info={"last_failed_option": last_option})
         last_state = state


### PR DESCRIPTION
first, the change I made in https://github.com/Learning-and-Intelligent-Systems/predicators/pull/1499 was just completely wrong. it was looking at the time step in the entire trajectory to determine whether the current option has exceeded the max horizon.

second, the ground op history (for sampler learning) inside the active sampler explorer was not recording data in the case where the episode is terminated due to the max option horizon.

before these changes, there were discrepancies between the number of data per operator reported by the active sampler explorer versus the number reported within the approach for sampler learning. the numbers are consistent after these fixes.