### PR TITLE
Fix pnad search backchaining

### DIFF
--- a/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
+++ b/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
@@ -48,6 +48,8 @@ class _BackChainingPNADSearchOperator(_PNADSearchOperator):
         if uncovered_segment is not None:
             while uncovered_segment is not None and \
                 new_heuristic_val >= init_heuristic_val:
+                covered_segments = [t[0] for p in ret_pnads_list for t in p.datastore]
+                assert uncovered_segment not in covered_segments
                 # We will need to induce an operator to cover this
                 # segment, and thus it must have some necessary add effects.
                 new_pnad = self._learner.spawn_new_pnad(uncovered_segment)

--- a/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
+++ b/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
@@ -339,7 +339,7 @@ class PNADSearchSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
             segment = segmented_traj[t]
             segment.necessary_add_effects = necessary_image - atoms_seq[t]
             candidate_pnads = pnads.copy()
-            while True:
+            while len(candidate_pnads) >= 0:
                 pnad, var_to_obj = self._find_best_matching_pnad_and_sub(
                     segment, objects, candidate_pnads)
                 # If no match found, terminate.
@@ -356,9 +356,11 @@ class PNADSearchSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                 self._update_pnad_seg_to_keep_effs(pnad, necessary_image,
                                                    ground_op, obj_to_var,
                                                    segment)
-                # Check if we're missing something in the necessary image.
+                # If we are not missing anything in the necessary image, we can
+                # extend the chain.
                 if necessary_image.issubset(next_atoms):
                     break
+                # See if a different pnad matches.
                 candidate_pnads.remove(pnad)
             # Extend the chain.
             operator_chain.append(ground_op)

--- a/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
+++ b/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
@@ -359,21 +359,22 @@ class PNADSearchSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                 # If we are not missing anything in the necessary image, we can
                 # extend the chain.
                 if necessary_image.issubset(next_atoms):
+                    operator_chain.append(ground_op)
+                    # Update necessary_image for this timestep. It no longer
+                    # needs to include the ground add effects of this PNAD, but
+                    # must now include its ground preconditions.
+                    necessary_image = necessary_image.copy()
+                    necessary_image -= {
+                        a.ground(var_to_obj)
+                        for a in pnad.op.add_effects
+                    }
+                    necessary_image |= {
+                        a.ground(var_to_obj)
+                        for a in pnad.op.preconditions
+                    }
                     break
+
                 # See if a different pnad matches.
                 candidate_pnads.remove(pnad)
-            # Extend the chain.
-            operator_chain.append(ground_op)
-            # Update necessary_image for this timestep. It no longer
-            # needs to include the ground add effects of this PNAD, but
-            # must now include its ground preconditions.
-            necessary_image = necessary_image.copy()
-            necessary_image -= {
-                a.ground(var_to_obj)
-                for a in pnad.op.add_effects
-            }
-            necessary_image |= {
-                a.ground(var_to_obj)
-                for a in pnad.op.preconditions
-            }
+
         return operator_chain

--- a/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
+++ b/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
@@ -48,7 +48,9 @@ class _BackChainingPNADSearchOperator(_PNADSearchOperator):
         if uncovered_segment is not None:
             while uncovered_segment is not None and \
                 new_heuristic_val >= init_heuristic_val:
-                covered_segments = [t[0] for p in ret_pnads_list for t in p.datastore]
+                covered_segments = [
+                    t[0] for p in ret_pnads_list for t in p.datastore
+                ]
                 assert uncovered_segment not in covered_segments
                 # We will need to induce an operator to cover this
                 # segment, and thus it must have some necessary add effects.
@@ -361,8 +363,7 @@ class PNADSearchSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                 # Check if we're missing something in the necessary image.
                 if necessary_image.issubset(next_atoms):
                     break
-                else:
-                    candidate_pnads.remove(pnad)
+                candidate_pnads.remove(pnad)
             # Extend the chain.
             operator_chain.append(ground_op)
             # Update necessary_image for this timestep. It no longer

--- a/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
+++ b/predicators/nsrt_learning/strips_learning/pnad_search_learner.py
@@ -48,41 +48,11 @@ class _BackChainingPNADSearchOperator(_PNADSearchOperator):
         if uncovered_segment is not None:
             while uncovered_segment is not None and \
                 new_heuristic_val >= init_heuristic_val:
-                print("_BackChainingPNADSearchOperator discovered another uncovered segment.")
-                covered_segments = [
-                    t[0] for p in ret_pnads_list for t in p.datastore
-                ]
-                for ll_traj, seg_traj in zip(self._trajectories,
-                                                 self._segmented_trajs):
-                    if uncovered_segment in seg_traj:
-                        ddd_goal = self._train_tasks[ll_traj.train_task_idx].goal
-                        break
-                assert ddd_goal is not None
-                for pr in ret_pnads_list:
-                    for seg, sub in pr.datastore:
-                        if uncovered_segment == seg:
-                            objs = list(uncovered_segment.states[0].data.keys())
-                            block0 = [o for o in objs if o.name == "block0"][0]
-                            block1 = [o for o in objs if o.name == "block1"][0]
-                            target0 = [o for o in objs if o.name == "target0"][0]
-                            target1 = [o for o in objs if o.name == "target1"][0]
-                            ddd = [
-                                pr.op.ground((block0, target0, target1)),
-                                pr.op.ground((block0, target1, target0)),
-                                pr.op.ground((block1, target0, target1)),
-                                pr.op.ground((block1, target1, target0))
-                            ]
-                            import pdb; pdb.set_trace()
-                            temp_segment = self._get_first_uncovered_segment2(ret_pnads_list, uncovered_segment, ddd, ddd_goal)
-                            import pdb; pdb.set_trace()
-                assert uncovered_segment not in covered_segments
                 # We will need to induce an operator to cover this
                 # segment, and thus it must have some necessary add effects.
-                print("Length of current pnads before appending: ", len(ret_pnads_list))
                 new_pnad = self._learner.spawn_new_pnad(uncovered_segment)
                 ret_pnads_list = self._append_new_pnad_and_keep_effects(
                     new_pnad, ret_pnads_list)
-                print("Length of current pnads after appending: ", len(ret_pnads_list))
                 ret_pnads = frozenset(pnad.copy() for pnad in ret_pnads_list)
                 new_heuristic_val = self._associated_heuristic(ret_pnads)
                 uncovered_segment = self._get_first_uncovered_segment(
@@ -170,56 +140,6 @@ class _BackChainingPNADSearchOperator(_PNADSearchOperator):
                     t = (len(seg_traj) - 1) - len(op_chain)
                     assert t >= 0
                     segment = seg_traj[t]
-                    return segment
-        return None
-
-    def _get_first_uncovered_segment2(
-        self,
-        pnads: List[PNAD], uncovered_segment: Segment, oppen: List[_GroundSTRIPSOperator], ddd_goal: Set[GroundAtom]
-    ) -> Optional[Segment]:
-        # Find the first uncovered segment. Do this in a kind of breadth-first
-        # backward search over trajectories.
-        # Compute all the chains once up front.
-        max_chain_len, backchaining_results = self._get_backchaining_results(
-            pnads)
-        # Now look for an uncovered segment. If one cannot be found, this
-        # method will automatically return None.
-        for depth in range(max_chain_len + 1):
-            for seg_traj, op_chain in backchaining_results:
-                if not (len(op_chain) > depth
-                        or len(op_chain) == len(seg_traj)):
-                    # We found an uncovered transition: we now need to return
-                    # the information necessary to induce a new operator to
-                    # cover it.
-                    # The timestep of the uncovered transition is the number of
-                    # segments - 1 - (numer of actions in our backchained plan)
-                    t = (len(seg_traj) - 1) - len(op_chain)
-                    assert t >= 0
-                    segment = seg_traj[t]
-                    print("AT THIS LOCATION HAHA")
-                    # for aaa in sorted(op_chain[0].preconditions):
-                    #     print(aaa)
-
-                    # end_atoms = utils.apply_operator(op_chain[0], utils.apply_operator(oppen, seg_traj[-2].init_atoms))
-                    # goal_met = ddd_goal.issubset(end_atoms)
-                    chain = self._learner.backchain2(seg_traj, pnads, ddd_goal, oppen)
-
-
-                    print("final check: ")
-                    initial = seg_traj[-2].init_atoms
-                    i = 0
-                    assert oppen[i].preconditions.issubset(seg_traj[0].init_atoms)
-                    n1 = utils.apply_operator(oppen[i], seg_traj[0].init_atoms)
-                    assert op_chain[1].preconditions.issubset(n1)
-                    n2 = utils.apply_operator(op_chain[1], n1)
-                    assert op_chain[0].preconditions.issubset(n2)
-                    n3 = utils.apply_operator(op_chain[0], n2)
-                    assert ddd_goal.issubset(n3)
-
-                    import pdb; pdb.set_trace()
-
-
-
                     return segment
         return None
 
@@ -370,8 +290,7 @@ class PNADSearchSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                                              check_goal=lambda _: False,
                                              get_successors=get_successors,
                                              heuristic=heuristic,
-                                             # verbose=self._verbose,
-                                             verbose=True,
+                                             verbose=self._verbose,
                                              timeout=CFG.pnad_search_timeout)
 
         # Extract the best PNADs set.
@@ -455,61 +374,4 @@ class PNADSearchSTRIPSLearner(GeneralToSpecificSTRIPSLearner):
                 a.ground(var_to_obj)
                 for a in pnad.op.preconditions
             }
-        return operator_chain
-
-    def backchain2(self, segmented_traj: List[Segment], pnads: List[PNAD],
-                  traj_goal: Set[GroundAtom], oppen: List[_GroundSTRIPSOperator]) -> List[_GroundSTRIPSOperator]:
-        """Returns chain of ground operators in REVERSE order."""
-        print("In backchain2.")
-        operator_chain: List[_GroundSTRIPSOperator] = []
-        atoms_seq = utils.segment_trajectory_to_atoms_sequence(segmented_traj)
-        objects = set(segmented_traj[0].states[0])
-        assert traj_goal.issubset(atoms_seq[-1])
-        necessary_image = set(traj_goal)
-        for t in range(len(atoms_seq) - 2, -1, -1):
-            segment = segmented_traj[t]
-            segment.necessary_add_effects = necessary_image - atoms_seq[t]
-            candidate_pnads = pnads.copy()
-            while True:
-                pnad, var_to_obj = self._find_best_matching_pnad_and_sub(
-                    segment, objects, candidate_pnads)
-                # If no match found, terminate.
-                if pnad is None:
-                    print("No matching pnad found.")
-                    import pdb; pdb.set_trace()
-                    return operator_chain
-                print("Best matching pnad: ", pnad.op.name)
-                assert var_to_obj is not None
-                obj_to_var = {v: k for k, v in var_to_obj.items()}
-                assert len(var_to_obj) == len(obj_to_var)
-                ground_op = pnad.op.ground(
-                    tuple(var_to_obj[var] for var in pnad.op.parameters))
-                next_atoms = utils.apply_operator(ground_op,
-                                                  segment.init_atoms)
-                # Update the PNAD's seg_to_keep_effs_sub dict.
-                self._update_pnad_seg_to_keep_effs(pnad, necessary_image,
-                                                   ground_op, obj_to_var,
-                                                   segment)
-                # Check if we're missing something in the necessary image.
-                if necessary_image.issubset(next_atoms):
-                    break
-                print(f"{pnad.op.name} does not satisfy necessary image check.")
-                print("Substitution that was tried: ", ground_op.objects, ground_op)
-                candidate_pnads.remove(pnad)
-            # Extend the chain.
-            operator_chain.append(ground_op)
-            # Update necessary_image for this timestep. It no longer
-            # needs to include the ground add effects of this PNAD, but
-            # must now include its ground preconditions.
-            necessary_image = necessary_image.copy()
-            necessary_image -= {
-                a.ground(var_to_obj)
-                for a in pnad.op.add_effects
-            }
-            necessary_image |= {
-                a.ground(var_to_obj)
-                for a in pnad.op.preconditions
-            }
-        print("At end of backchain2.")
-        import pdb; pdb.set_trace()
         return operator_chain


### PR DESCRIPTION
`pnad_search` with predicate invention by oracle clustering enters an infinite loop in the blocks environment due to an issue with the backchaining implementation. This happens because `PNADSearchSTRIPSLearner.backchain` only tries the _single_ best matching pnad for a given segment – if that pnad doesn't satisfy the necessary atoms check, it does not check if any other pnads would work. In the specific example where this issue arises, `pnad_search` repeatedly uncovers the same segment over and over: a pnad (`STRIPS-Pick8`) covers a particular segment and has this segment in its datastore, but `PNADSearchSTRIPSLearner.backchain` continues to identify this segment as an uncovered segment. This happens because in the search for the first uncovered segment, when backchaining, it only tries the single best matching pnad `STRIPS-Pick9`, and when that pnad fails the necessary atoms check, it does not try`STRIPS-Pick8`, which would work to extend the chain further. The simple and obvious fix is to try all pnads, in order of "best matching". 

You can observe this issue by running `python predicators/main.py --env blocks --excluded_predicates all --approach grammar_search_invention --num_train_tasks 200 --seed 0 --grammar_search_max_predicates 200 --grammar_search_pred_clusterer oracle --grammar_search_pred_selection_approach clustering --strips_learner pnad_search --pnad_search_timeout 1200 --offline_data_method demo+gt_operators` on branch `master`. 

After the small change in this PR, this same command gets 48/50 in blocks. 

To make sure this doesn't break anything, I will report back with results from supercloud, on both (1) predicate invention via score optimization (from the original predicate invention paper) and (2) predicate invention via oracle clustering. 

I'm surprised this issue hasn't surfaced earlier – it seems like it could be a common occurence. 