### PR TITLE
fix mujoco import error on supercloud

### DIFF
--- a/predicators/envs/kitchen.py
+++ b/predicators/envs/kitchen.py
@@ -11,7 +11,7 @@ try:
     from mujoco_kitchen.kitchen_envs import OBS_ELEMENT_INDICES
     from mujoco_kitchen.utils import make_env
     _MJKITCHEN_IMPORTED = True
-except ImportError:
+except (ImportError, RuntimeError):
     _MJKITCHEN_IMPORTED = False
 from predicators import utils
 from predicators.envs import BaseEnv

--- a/predicators/ground_truth_models/kitchen/options.py
+++ b/predicators/ground_truth_models/kitchen/options.py
@@ -8,7 +8,7 @@ from gym.spaces import Box
 try:
     from mujoco_kitchen.utils import primitive_and_params_to_primitive_action
     _MJKITCHEN_IMPORTED = True
-except ImportError:
+except (ImportError, RuntimeError):
     _MJKITCHEN_IMPORTED = False
 from predicators.envs.kitchen import KitchenEnv
 from predicators.ground_truth_models import GroundTruthOptionFactory


### PR DESCRIPTION
a RuntimeError is raised on supercloud when running non-mujoco configs