### PR TITLE
change kitchen backend

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -89,5 +89,5 @@ ignore_missing_imports = True
 [mypy-gym_sokoban.*]
 ignore_missing_imports = True
 
-[mypy-mujoco_kitchen.*]
+[mypy-gymnasium_robotics.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -89,5 +89,8 @@ ignore_missing_imports = True
 [mypy-gym_sokoban.*]
 ignore_missing_imports = True
 
+[mypy-gymnasium.*]
+ignore_missing_imports = True
+
 [mypy-gymnasium_robotics.*]
 ignore_missing_imports = True

--- a/predicators/envs/kitchen.py
+++ b/predicators/envs/kitchen.py
@@ -50,7 +50,7 @@ class KitchenEnv(BaseEnv):
     light_on_thresh = -0.4  # light is On if less than this threshold
 
     obj_name_to_pre_push_dpos = {
-        "kettle": (0.0, -0.3, -0.25),  # need to push from behind kettle
+        "kettle": (0.0, -0.3, -0.3),  # need to push from behind kettle
         "knob3": (-0.2, -0.2, -0.2),  # need to push from left to right
         "light": (0.1, 0.05, -0.2),  # need to push from right to left
     }

--- a/predicators/envs/kitchen.py
+++ b/predicators/envs/kitchen.py
@@ -50,7 +50,7 @@ class KitchenEnv(BaseEnv):
     light_on_thresh = -0.4  # light is On if less than this threshold
 
     obj_name_to_pre_push_dpos = {
-        "kettle": (0.0, -0.3, -0.15),  # need to push from behind kettle
+        "kettle": (0.0, -0.3, -0.12),  # need to push from behind kettle
         "knob4": (-0.08, -0.12, 0.05),  # need to push from left to right
         "light": (0.1, 0.05, -0.2),  # need to push from right to left
     }

--- a/predicators/envs/kitchen.py
+++ b/predicators/envs/kitchen.py
@@ -44,14 +44,14 @@ class KitchenEnv(BaseEnv):
     gripper_type = Type("gripper", ["x", "y", "z", "qw", "qx", "qy", "qz"])
     object_type = Type("obj", ["x", "y", "z", "angle"])
 
-    at_atol = 0.01  # tolerance for At classifier
+    at_atol = 0.2  # tolerance for At classifier
     ontop_atol = 0.15  # tolerance for OnTop classifier
     on_angle_thresh = -0.8  # dial is On if less than this threshold
     light_on_thresh = -0.4  # light is On if less than this threshold
 
     obj_name_to_pre_push_dpos = {
         "kettle": (0.0, -0.3, -0.3),  # need to push from behind kettle
-        "knob4": (-0.08, -0.12, -0.15),  # need to push from left to right
+        "knob4": (-0.08, -0.12, 0.05),  # need to push from left to right
         "light": (0.1, 0.05, -0.2),  # need to push from right to left
     }
 
@@ -124,10 +124,7 @@ Install from https://github.com/SiddarGu/Gymnasium-Robotics.git"
                action: Optional[Action] = None,
                caption: Optional[str] = None) -> Video:
         assert caption is None
-        arr: Image = self._gym_env.render(
-            'rgb_array',
-            imwidth=CFG.kitchen_camera_size,
-            imheight=CFG.kitchen_camera_size)  # type: ignore
+        arr: Image = self._gym_env.render()  # type: ignore
         return [arr]
 
     @property

--- a/predicators/envs/kitchen.py
+++ b/predicators/envs/kitchen.py
@@ -51,7 +51,7 @@ class KitchenEnv(BaseEnv):
 
     obj_name_to_pre_push_dpos = {
         "kettle": (0.0, -0.3, -0.3),  # need to push from behind kettle
-        "knob3": (-0.2, -0.2, -0.2),  # need to push from left to right
+        "knob3": (-0.2, -0.125, -0.18),  # need to push from left to right
         "light": (0.1, 0.05, -0.2),  # need to push from right to left
     }
 

--- a/predicators/envs/kitchen.py
+++ b/predicators/envs/kitchen.py
@@ -50,7 +50,7 @@ class KitchenEnv(BaseEnv):
     light_on_thresh = -0.4  # light is On if less than this threshold
 
     obj_name_to_pre_push_dpos = {
-        "kettle": (0.0, -0.3, -0.3),  # need to push from behind kettle
+        "kettle": (0.0, -0.3, -0.15),  # need to push from behind kettle
         "knob4": (-0.08, -0.12, 0.05),  # need to push from left to right
         "light": (0.1, 0.05, -0.2),  # need to push from right to left
     }

--- a/predicators/envs/kitchen.py
+++ b/predicators/envs/kitchen.py
@@ -56,7 +56,7 @@ class KitchenEnv(BaseEnv):
 
     def __init__(self, use_gui: bool = True) -> None:
         super().__init__(use_gui)
-        assert _MJKITCHEN_IMPORTED, "Failed to import mujoco_kitchen. \
+        assert _MJKITCHEN_IMPORTED, "Failed to import kitchen gym env. \
 Install from https://github.com/SiddarGu/Gymnasium-Robotics.git"
 
         # Predicates

--- a/predicators/envs/kitchen.py
+++ b/predicators/envs/kitchen.py
@@ -215,8 +215,8 @@ Install from https://github.com/SiddarGu/Gymnasium-Robotics.git"
         light = Object("light", self.object_type)
         goal_desc = self._current_task.goal_description
         kettle_on_burner = self._OnTop_holds(state, [kettle, burner])
-        knob_turned_on = self._On_holds(state, [knob])
-        light_turned_on = self._On_holds(state, [light])
+        knob_turned_on = self.On_holds(state, [knob])
+        light_turned_on = self.On_holds(state, [light])
         if goal_desc == ("Move the kettle to the back burner and turn it on; "
                          "also turn on the light"):
             return kettle_on_burner and knob_turned_on and light_turned_on
@@ -289,10 +289,10 @@ Install from https://github.com/SiddarGu/Gymnasium-Robotics.git"
                                obj1, "z") > state.get(obj2, "z")
 
     @classmethod
-    def _On_holds(cls,
-                  state: State,
-                  objects: Sequence[Object],
-                  thresh_pad: float = 0.0) -> bool:
+    def On_holds(cls,
+                 state: State,
+                 objects: Sequence[Object],
+                 thresh_pad: float = 0.0) -> bool:
         obj = objects[0]
         if "knob" in obj.name:
             return state.get(obj, "angle") < cls.on_angle_thresh - thresh_pad
@@ -310,5 +310,5 @@ Install from https://github.com/SiddarGu/Gymnasium-Robotics.git"
                       self._At_holds),
             Predicate("OnTop", [self.object_type, self.object_type],
                       self._OnTop_holds),
-            Predicate("TurnedOn", [self.object_type], self._On_holds),
+            Predicate("TurnedOn", [self.object_type], self.On_holds),
         ]

--- a/predicators/envs/kitchen.py
+++ b/predicators/envs/kitchen.py
@@ -51,7 +51,7 @@ class KitchenEnv(BaseEnv):
 
     obj_name_to_pre_push_dpos = {
         "kettle": (0.0, -0.3, -0.3),  # need to push from behind kettle
-        "knob3": (-0.2, -0.125, -0.18),  # need to push from left to right
+        "knob4": (-0.08, -0.12, -0.15),  # need to push from left to right
         "light": (0.1, 0.05, -0.2),  # need to push from right to left
     }
 
@@ -209,7 +209,7 @@ Install from https://github.com/SiddarGu/Gymnasium-Robotics.git"
             self._current_observation["state_info"])
         kettle = Object("kettle", self.object_type)
         burner = Object("burner4", self.object_type)
-        knob = Object("knob3", self.object_type)
+        knob = Object("knob4", self.object_type)
         light = Object("light", self.object_type)
         goal_desc = self._current_task.goal_description
         kettle_on_burner = self._OnTop_holds(state, [kettle, burner])
@@ -289,7 +289,7 @@ Install from https://github.com/SiddarGu/Gymnasium-Robotics.git"
     @classmethod
     def _On_holds(cls, state: State, objects: Sequence[Object]) -> bool:
         obj = objects[0]
-        if obj.name in ["knob3", "knob2"]:
+        if "knob" in obj.name:
             return state.get(obj, "angle") < cls.on_angle_thresh
         if obj.name == "light":
             return state.get(obj, "x") < cls.light_on_thresh

--- a/predicators/envs/kitchen.py
+++ b/predicators/envs/kitchen.py
@@ -59,6 +59,10 @@ class KitchenEnv(BaseEnv):
         assert _MJKITCHEN_IMPORTED, "Failed to import kitchen gym env. \
 Install from https://github.com/SiddarGu/Gymnasium-Robotics.git"
 
+        if use_gui:
+            assert not CFG.make_test_videos or CFG.make_failure_videos, \
+                "Turn off --use_gui to make videos in kitchen env"
+
         # Predicates
         self._At, self._OnTop, self._TurnedOn = self.get_goal_at_predicates()
 
@@ -293,6 +297,7 @@ Install from https://github.com/SiddarGu/Gymnasium-Robotics.git"
                  state: State,
                  objects: Sequence[Object],
                  thresh_pad: float = 0.0) -> bool:
+        """Made public for use in ground-truth options."""
         obj = objects[0]
         if "knob" in obj.name:
             return state.get(obj, "angle") < cls.on_angle_thresh - thresh_pad

--- a/predicators/envs/kitchen.py
+++ b/predicators/envs/kitchen.py
@@ -46,12 +46,12 @@ class KitchenEnv(BaseEnv):
 
     at_atol = 0.2  # tolerance for At classifier
     ontop_atol = 0.15  # tolerance for OnTop classifier
-    on_angle_thresh = -0.8  # dial is On if less than this threshold
+    on_angle_thresh = -0.4  # dial is On if less than this threshold
     light_on_thresh = -0.4  # light is On if less than this threshold
 
     obj_name_to_pre_push_dpos = {
         "kettle": (0.0, -0.3, -0.12),  # need to push from behind kettle
-        "knob4": (-0.08, -0.12, 0.05),  # need to push from left to right
+        "knob4": (-0.1, -0.15, 0.05),  # need to push from left to right
         "light": (0.1, 0.05, -0.2),  # need to push from right to left
     }
 

--- a/predicators/envs/kitchen.py
+++ b/predicators/envs/kitchen.py
@@ -52,7 +52,7 @@ class KitchenEnv(BaseEnv):
     obj_name_to_pre_push_dpos = {
         "kettle": (0.0, -0.3, -0.12),  # need to push from behind kettle
         "knob4": (-0.1, -0.15, 0.05),  # need to push from left to right
-        "light": (0.1, 0.05, -0.2),  # need to push from right to left
+        "light": (0.1, -0.05, 0.0),  # need to push from right to left
     }
 
     def __init__(self, use_gui: bool = True) -> None:

--- a/predicators/envs/kitchen.py
+++ b/predicators/envs/kitchen.py
@@ -9,6 +9,7 @@ from gym.spaces import Box
 
 try:
     import gymnasium as mujoco_kitchen_gym
+    from gymnasium_robotics.utils.mujoco_utils import get_joint_qpos, get_site_xpos
     _MJKITCHEN_IMPORTED = True
 except (ImportError, RuntimeError):
     _MJKITCHEN_IMPORTED = False
@@ -18,6 +19,23 @@ from predicators.settings import CFG
 from predicators.structs import Action, EnvironmentTask, Image, Object, \
     Observation, Predicate, State, Type, Video
 
+_TRACKED_SITES = [
+    "hinge_site1", "hinge_site2", "kettle_site", "microhandle_site",
+    "knob1_site", "knob2_site", "knob3_site", "knob4_site",
+    "light_site", "slide_site", "EEF"
+]
+
+_TRACKED_SITE_TO_JOINT = {
+    "knob1_site": "knob_Joint_1",
+    "knob2_site": "knob_Joint_2",
+    "knob3_site": "knob_Joint_3",
+    "knob4_site": "knob_Joint_4"
+}
+
+_TRACKED_BODIES = [
+    "Burner 1", "Burner 2", "Burner 3", "Burner 4"
+]
+
 
 class KitchenEnv(BaseEnv):
     """Kitchen environment wrapping dm_control Kitchen."""
@@ -25,13 +43,13 @@ class KitchenEnv(BaseEnv):
     gripper_type = Type("gripper", ["x", "y", "z"])
     object_type = Type("obj", ["x", "y", "z", "angle"])
 
-    at_atol = 0.2  # tolerance for At classifier
+    at_atol = 0.01  # tolerance for At classifier
     ontop_atol = 0.15  # tolerance for OnTop classifier
     on_angle_thresh = -0.8  # dial is On if less than this threshold
     light_on_thresh = -0.4  # light is On if less than this threshold
 
     obj_name_to_pre_push_dpos = {
-        "kettle": (0.125, -0.3, -0.25),  # need to push from behind kettle
+        "kettle": (0.0, -0.3, -0.25),  # need to push from behind kettle
         "knob3": (-0.2, 0.0, -0.2),  # need to push from left to right
         "light": (0.1, 0.05, -0.2),  # need to push from right to left
     }
@@ -62,28 +80,14 @@ Install from https://github.com/SiddarGu/Gymnasium-Robotics.git"
 
     def get_object_centric_state_info(self) -> Dict[str, Any]:
         """Parse State into Object Centric State."""
-        import ipdb; ipdb.set_trace()
-        state = self._gym_env.env.get_env_state()[0]
         state_info = {}
-        for key, val in OBS_ELEMENT_INDICES.items():
-            state_info[key] = [state[i] for i in val]
-        important_sites = [
-            "hinge_site1", "hinge_site2", "kettle_site", "microhandle_site",
-            "knob1_site", "knob2_site", "knob3_site", "knob4_site",
-            "light_site", "slide_site", "end_effector"
-        ]
-        for site in important_sites:
-            state_info[site] = copy.deepcopy(self._gym_env.get_site_xpos(site))
-            # Potentially can get this ^ from state
-        # Add oven burner plate locations
-        burner_poses = {
-            "burner1_site": [-0.3, 0.3, 0.629],
-            "burner2_site": [-0.3, 0.8, 0.629],
-            "burner3_site": [0.204, 0.8, 0.629],
-            "burner4_site": [0.206, 0.3, 0.629]
-        }
-        for name, pose in burner_poses.items():
-            state_info[name] = pose
+        for site in _TRACKED_SITES:
+            state_info[site] = get_site_xpos(self._gym_env.model, self._gym_env.data, site).copy()
+        for joint in _TRACKED_SITE_TO_JOINT.values():
+            state_info[joint] = get_joint_qpos(self._gym_env.model, self._gym_env.data, joint).copy()
+        for body in _TRACKED_BODIES:
+            body_id = self._gym_env.robot_env.model_names.body_name2id[body]
+            state_info[body] = self._gym_env.data.xpos[body_id].copy()
         return state_info
 
     @classmethod
@@ -161,19 +165,10 @@ Install from https://github.com/SiddarGu/Gymnasium-Robotics.git"
     @classmethod
     def state_info_to_state(cls, state_info: Dict[str, Any]) -> State:
         """Get state from state info dictionary."""
-        assert "end_effector" in state_info  # sanity check
+        assert "EEF" in state_info  # sanity check
         state_dict = {}
         for key, val in state_info.items():
-            if "_site" in key:
-                obj_name = key.replace("_site", "")
-                obj = Object(obj_name, cls.object_type)
-                state_dict[obj] = {
-                    "x": val[0],
-                    "y": val[1],
-                    "z": val[2],
-                    "angle": 0
-                }
-            elif key == "end_effector":
+            if key == "EEF":
                 obj = Object("gripper", cls.gripper_type)
                 state_dict[obj] = {
                     "x": val[0],
@@ -181,13 +176,22 @@ Install from https://github.com/SiddarGu/Gymnasium-Robotics.git"
                     "z": val[2],
                     "angle": 0
                 }
-        for key, val in state_info.items():
-            if key == "bottom left burner":
-                obj = Object("knob2", cls.object_type)
-                state_dict[obj]["angle"] = val[0]
-            elif key == "top left burner":
-                obj = Object("knob3", cls.object_type)
-                state_dict[obj]["angle"] = val[0]
+            elif key in _TRACKED_SITE_TO_JOINT.values():
+                continue  # used below
+            else:
+                obj_name = key.replace("_site", "").replace(" ", "").lower()
+                obj = Object(obj_name, cls.object_type)
+                if key in _TRACKED_SITE_TO_JOINT:
+                    joint = _TRACKED_SITE_TO_JOINT[key]
+                    angle = state_info[joint][0]
+                else:
+                    angle = 0
+                state_dict[obj] = {
+                    "x": val[0],
+                    "y": val[1],
+                    "z": val[2],
+                    "angle": angle
+                }
         state = utils.create_state_from_dict(state_dict)
         return state
 
@@ -195,7 +199,7 @@ Install from https://github.com/SiddarGu/Gymnasium-Robotics.git"
         state = self.state_info_to_state(
             self._current_observation["state_info"])
         kettle = Object("kettle", self.object_type)
-        burner = Object("burner2", self.object_type)
+        burner = Object("burner4", self.object_type)
         knob = Object("knob3", self.object_type)
         light = Object("light", self.object_type)
         goal_desc = self._current_task.goal_description

--- a/predicators/ground_truth_models/kitchen/nsrts.py
+++ b/predicators/ground_truth_models/kitchen/nsrts.py
@@ -60,13 +60,7 @@ class KitchenGroundTruthNSRTFactory(GroundTruthNSRTFactory):
             gripper, obj = objs
             params = np.array(KitchenEnv.get_pre_push_delta_pos(obj),
                               dtype=np.float32)
-            # NOTE: this is a legitimately hard function to hand-write. I could
-            # not figure out how to do it in a state-independent way.
-            if CFG.kitchen_use_perfect_samplers:
-                if state.get(gripper, "x") > -0.15 or state.get(gripper,
-                                                                "z") < 2.0:
-                    params[2] += 0.2
-            else:
+            if not CFG.kitchen_use_perfect_samplers:
                 params[0] += rng.uniform(-0.5, 0.5)
             return params
 

--- a/predicators/ground_truth_models/kitchen/nsrts.py
+++ b/predicators/ground_truth_models/kitchen/nsrts.py
@@ -56,8 +56,8 @@ class KitchenGroundTruthNSRTFactory(GroundTruthNSRTFactory):
         def moveto_sampler(state: State, goal: Set[GroundAtom],
                            rng: np.random.Generator,
                            objs: Sequence[Object]) -> Array:
-            del goal  # unused
-            gripper, obj = objs
+            del state, goal  # unused
+            _, obj = objs
             params = np.array(KitchenEnv.get_pre_push_delta_pos(obj),
                               dtype=np.float32)
             if not CFG.kitchen_use_perfect_samplers:

--- a/predicators/ground_truth_models/kitchen/options.py
+++ b/predicators/ground_truth_models/kitchen/options.py
@@ -39,7 +39,6 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
         object_type = types["obj"]
 
         # Predicates
-        TurnedOn = predicates["TurnedOn"]
         OnTop = predicates["OnTop"]
 
         options: Set[ParameterizedOption] = set()
@@ -193,7 +192,7 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
             del memory, params  # unused
             _, obj = objects
             # Use a more stringent threshold to avoid numerical issues.
-            return KitchenEnv._On_holds(state, [obj], thresh_pad=0.01)
+            return KitchenEnv.On_holds(state, [obj], thresh_pad=0.01)
 
         PushObjTurnOnLeftRight = ParameterizedOption(
             "PushObjTurnOnLeftRight",

--- a/predicators/ground_truth_models/kitchen/options.py
+++ b/predicators/ground_truth_models/kitchen/options.py
@@ -176,7 +176,9 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
                                            params: Array) -> Action:
             del state, objects  # unused
             sign = memory["sign"]
-            arr = np.array([sign * params[0], 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+            # Also push a little bit forward. TODO factor out.
+            forward_mag = 1e-1
+            arr = np.array([sign * params[0], forward_mag, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
             return Action(arr)
 
         def _PushObjTurnOnLeftRight_terminal(state: State, memory: Dict,

--- a/predicators/ground_truth_models/kitchen/options.py
+++ b/predicators/ground_truth_models/kitchen/options.py
@@ -5,11 +5,6 @@ from typing import Dict, Sequence, Set
 import numpy as np
 from gym.spaces import Box
 
-try:
-    from mujoco_kitchen.utils import primitive_and_params_to_primitive_action
-    _MJKITCHEN_IMPORTED = True
-except (ImportError, RuntimeError):
-    _MJKITCHEN_IMPORTED = False
 from predicators.envs.kitchen import KitchenEnv
 from predicators.ground_truth_models import GroundTruthOptionFactory
 from predicators.structs import Action, Array, GroundAtom, Object, \
@@ -27,7 +22,6 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
     def get_options(cls, env_name: str, types: Dict[str, Type],
                     predicates: Dict[str, Predicate],
                     action_space: Box) -> Set[ParameterizedOption]:
-        assert _MJKITCHEN_IMPORTED
 
         # Types
         gripper_type = types["gripper"]
@@ -52,14 +46,6 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
             oz = state.get(obj, "z")
             target_pose = params + (ox, oy, oz)
             memory["target_pose"] = target_pose
-            # We always move backward for 8 steps before executing the move.
-            # Ideally we would move to a home position, but it's not possible
-            # to do that reliably with end effector control. Moving for 8 steps
-            # seems to work well enough for now, but it's likely that this will
-            # need to be improved in the future as we add more skills,
-            # especially considering that 5 and 10 backward steps don't work,
-            # indicating that this is very fickle.
-            memory["reset_count"] = 8
             return True
 
         def _MoveTo_policy(state: State, memory: Dict,
@@ -69,16 +55,7 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
             gx = state.get(gripper, "x")
             gy = state.get(gripper, "y")
             gz = state.get(gripper, "z")
-            if memory["reset_count"] > 0:
-                arr = primitive_and_params_to_primitive_action(
-                    "move_backward", [1.0])
-                memory["reset_count"] -= 1
-            else:
-                target_pose = memory["target_pose"]
-                delta_ee = target_pose - (gx, gy, gz)
-                delta_ee = np.clip(delta_ee, -max_delta_mag, max_delta_mag)
-                arr = primitive_and_params_to_primitive_action(
-                    "move_delta_ee_pose", delta_ee)
+            import ipdb; ipdb.set_trace()
             return Action(arr)
 
         def _MoveTo_terminal(state: State, memory: Dict,
@@ -110,8 +87,7 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
                                         objects: Sequence[Object],
                                         params: Array) -> Action:
             del state, memory, objects  # unused
-            arr = primitive_and_params_to_primitive_action(
-                "move_forward", params)
+            import ipdb; ipdb.set_trace()
             return Action(arr)
 
         def _PushObjOnObjForward_terminal(state: State, memory: Dict,
@@ -159,8 +135,7 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
                                            params: Array) -> Action:
             del state, objects  # unused
             direction = memory["direction"]
-            arr = primitive_and_params_to_primitive_action(
-                f"move_{direction}", params)
+            import ipdb; ipdb.set_trace()
             return Action(arr)
 
         def _PushObjTurnOnLeftRight_terminal(state: State, memory: Dict,

--- a/predicators/ground_truth_models/kitchen/options.py
+++ b/predicators/ground_truth_models/kitchen/options.py
@@ -41,7 +41,7 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
 
         options: Set[ParameterizedOption] = set()
 
-        max_delta_mag = 0.1  # don't move more than this per step
+        max_delta_mag = 1.0  # don't move more than this per step
 
         # MoveTo
         def _MoveTo_initiable(state: State, memory: Dict,

--- a/predicators/ground_truth_models/kitchen/options.py
+++ b/predicators/ground_truth_models/kitchen/options.py
@@ -20,6 +20,8 @@ except (ImportError, RuntimeError):
 class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
     """Ground-truth options for the Kitchen environment."""
 
+    moveto_tol = 0.01
+
     @classmethod
     def get_env_names(cls) -> Set[str]:
         return {"kitchen"}
@@ -79,7 +81,7 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
             if not memory["has_reset"]:
                 if np.allclose((gx, gy, gz),
                                memory["reset_pose"],
-                               atol=KitchenEnv.at_atol):
+                               atol=cls.moveto_tol):
                     target_pose = memory["target_pose"]
                     target_quat = memory["target_quat"]
                     memory["has_reset"] = True
@@ -108,7 +110,7 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
             gz = state.get(gripper, "z")
             return np.allclose((gx, gy, gz),
                                memory["target_pose"],
-                               atol=KitchenEnv.at_atol)
+                               atol=cls.moveto_tol)
 
         MoveTo = ParameterizedOption(
             "MoveTo",
@@ -139,7 +141,7 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
             # Stronger check to deal with case where push release leads object
             # to be no longer OnTop.
             return state.get(
-                obj, "y") > state.get(obj2, "y") - KitchenEnv.at_atol / 2
+                obj, "y") > state.get(obj2, "y") - cls.moveto_tol / 2
 
         PushObjOnObjForward = ParameterizedOption(
             "PushObjOnObjForward",

--- a/predicators/ground_truth_models/kitchen/options.py
+++ b/predicators/ground_truth_models/kitchen/options.py
@@ -57,7 +57,7 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
             oz = state.get(obj, "z")
             target_pose = params + (ox, oy, oz)
             memory["target_pose"] = target_pose
-            # TODO add comment
+            # Turn the knobs by pushing from a "side grasp" position.
             if "knob" in obj.name:
                 memory["target_quat"] = euler2quat(
                     [-np.pi / 2, 0.0, -np.pi / 2])
@@ -180,7 +180,7 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
                                            params: Array) -> Action:
             del state, objects  # unused
             sign = memory["sign"]
-            # Also push a little bit forward. TODO factor out.
+            # Also push a little bit forward.
             forward_mag = 1e-1
             arr = np.array(
                 [sign * params[0], forward_mag, 0.0, 0.0, 0.0, 0.0, 0.0],

--- a/predicators/ground_truth_models/kitchen/options.py
+++ b/predicators/ground_truth_models/kitchen/options.py
@@ -54,7 +54,11 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
             oz = state.get(obj, "z")
             target_pose = params + (ox, oy, oz)
             memory["target_pose"] = target_pose
-            memory["target_quat"] = euler2quat([-np.pi, 0.0, -np.pi / 2])  # TODO make conditional
+            # TODO add comment
+            if target_pose[2] > 2.0:
+                memory["target_quat"] = euler2quat([-np.pi / 2, 0.0, -np.pi / 2])
+            else:
+                memory["target_quat"] = euler2quat([-np.pi, 0.0, -np.pi / 2])
             memory["reset_pose"] = np.array([0.0, 0.3, 2.0], dtype=np.float32)
             memory["reset_quat"] = euler2quat([-np.pi, 0.0, -np.pi / 2])
             memory["has_reset"] = False
@@ -84,7 +88,7 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
                     target_quat = memory["reset_quat"]
             else:
                 target_pose = memory["target_pose"]
-                target_quat = memory["reset_quat"]
+                target_quat = memory["target_quat"]
             dx, dy, dz = np.subtract(target_pose, (gx, gy, gz))
             target_euler = quat2euler(target_quat)
             droll, dpitch, dyaw = subtract_euler(target_euler, current_euler)

--- a/predicators/ground_truth_models/kitchen/options.py
+++ b/predicators/ground_truth_models/kitchen/options.py
@@ -163,18 +163,18 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
             ox = state.get(obj, "x")
             gx = state.get(gripper, "x")
             if gx > ox:
-                direction = "left"
+                sign = -1
             else:
-                direction = "right"
-            memory["direction"] = direction
+                sign = 1
+            memory["sign"] = sign
             return True
 
         def _PushObjTurnOnLeftRight_policy(state: State, memory: Dict,
                                            objects: Sequence[Object],
                                            params: Array) -> Action:
             del state, objects  # unused
-            direction = memory["direction"]
-            import ipdb; ipdb.set_trace()
+            sign = memory["sign"]
+            arr = np.array([sign * params[0], 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
             return Action(arr)
 
         def _PushObjTurnOnLeftRight_terminal(state: State, memory: Dict,

--- a/predicators/ground_truth_models/kitchen/options.py
+++ b/predicators/ground_truth_models/kitchen/options.py
@@ -57,7 +57,7 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
             target_pose = params + (ox, oy, oz)
             memory["target_pose"] = target_pose
             # TODO add comment
-            if target_pose[2] > 2.0:
+            if "knob" in obj.name:
                 memory["target_quat"] = euler2quat([-np.pi / 2, 0.0, -np.pi / 2])
             else:
                 memory["target_quat"] = euler2quat([-np.pi, 0.0, -np.pi / 2])

--- a/predicators/ground_truth_models/kitchen/options.py
+++ b/predicators/ground_truth_models/kitchen/options.py
@@ -42,7 +42,7 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
 
         assert _MJKITCHEN_IMPORTED, "See kitchen.py"
 
-        # Need to define these here because uses may not have euler2quat.
+        # Need to define these here because users may not have euler2quat.
         down_quat = euler2quat((-np.pi, 0.0, -np.pi / 2))
         # End effector facing forward (e.g., toward the knobs.)
         fwd_quat = euler2quat((-np.pi / 2, 0.0, -np.pi / 2))

--- a/predicators/perception/kitchen_perceiver.py
+++ b/predicators/perception/kitchen_perceiver.py
@@ -19,7 +19,7 @@ class KitchenPerceiver(BasePerceiver):
         TurnedOn = KitchenEnv.get_goal_at_predicates(KitchenEnv)[2]
         object_type = KitchenEnv.object_type
         kettle = Object("kettle", object_type)
-        knob = Object("knob3", object_type)
+        knob = Object("knob4", object_type)
         burner = Object("burner4", object_type)
         light = Object("light", object_type)
         goal_desc = env_task.goal_description

--- a/predicators/perception/kitchen_perceiver.py
+++ b/predicators/perception/kitchen_perceiver.py
@@ -20,7 +20,7 @@ class KitchenPerceiver(BasePerceiver):
         object_type = KitchenEnv.object_type
         kettle = Object("kettle", object_type)
         knob = Object("knob3", object_type)
-        burner = Object("burner2", object_type)
+        burner = Object("burner4", object_type)
         light = Object("light", object_type)
         goal_desc = env_task.goal_description
         if goal_desc == ("Move the kettle to the back burner and turn it on; "

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -317,7 +317,6 @@ class GlobalSettings:
 
     # kitchen env parameters
     kitchen_use_perfect_samplers = False
-    kitchen_camera_size = 512
     kitchen_goals = "all"
 
     # parameters for random options approach

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -617,6 +617,7 @@ class GlobalSettings:
                     "pybullet_blocks": 1000,
                     "doors": 1000,
                     "coffee": 1000,
+                    "kitchen": 1000,
                     # For the very simple touch point environment, restrict
                     # the horizon to be shorter.
                     "touch_point": 15,

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,7 @@ setup(
         "seaborn",
         "smepy@git+https://github.com/sebdumancic/structure_mapping.git",
         "pg3@git+https://github.com/tomsilver/pg3.git",
-        "gym_sokoban@git+https://github.com/Learning-and-Intelligent-Systems/gym-sokoban.git",  # pylint: disable=line-too-long
-        "gymnasium@git+https://github.com/SiddarGu/Gymnasium-Robotics.git",
+        "gym_sokoban@git+https://github.com/Learning-and-Intelligent-Systems/gym-sokoban.git"  # pylint: disable=line-too-long
     ],
     include_package_data=True,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(
         "seaborn",
         "smepy@git+https://github.com/sebdumancic/structure_mapping.git",
         "pg3@git+https://github.com/tomsilver/pg3.git",
-        "gym_sokoban@git+https://github.com/Learning-and-Intelligent-Systems/gym-sokoban.git"  # pylint: disable=line-too-long
+        "gym_sokoban@git+https://github.com/Learning-and-Intelligent-Systems/gym-sokoban.git",  # pylint: disable=line-too-long
+        "gymnasium@git+https://github.com/SiddarGu/Gymnasium-Robotics.git",
     ],
     include_package_data=True,
     extras_require={

--- a/tests/envs/test_kitchen.py
+++ b/tests/envs/test_kitchen.py
@@ -95,7 +95,7 @@ def test_kitchen():
     gripper = obj_name_to_obj["gripper"]
     knob3 = obj_name_to_obj["knob3"]
     kettle = obj_name_to_obj["kettle"]
-    burner2 = obj_name_to_obj["burner2"]
+    burner4 = obj_name_to_obj["burner4"]
     light = obj_name_to_obj["light"]
 
     def _run_ground_nsrt(ground_nsrt, state):
@@ -121,8 +121,8 @@ def test_kitchen():
     move_to_knob3_nsrt = MoveTo.ground([gripper, knob3])
     push_knob3_nsrt = PushObjTurnOnLeftRight.ground([gripper, knob3])
     move_to_kettle_nsrt = MoveTo.ground([gripper, kettle])
-    push_kettle_on_burner2_nsrt = PushObjOnObjForward.ground(
-        [gripper, kettle, burner2])
+    push_kettle_on_burner4_nsrt = PushObjOnObjForward.ground(
+        [gripper, kettle, burner4])
 
     # Test moving to and turning on the light.
     obs = env.reset("test", 0)
@@ -139,8 +139,8 @@ def test_kitchen():
     state = _run_ground_nsrt(move_to_knob3_nsrt, state)
     state = _run_ground_nsrt(push_knob3_nsrt, state)
     state = _run_ground_nsrt(move_to_kettle_nsrt, state)
-    state = _run_ground_nsrt(push_kettle_on_burner2_nsrt, state)
-    assert OnTop([kettle, burner2]).holds(state)
+    state = _run_ground_nsrt(push_kettle_on_burner4_nsrt, state)
+    assert OnTop([kettle, burner4]).holds(state)
     assert TurnedOn([knob3]).holds(state)
 
     # Test reverse order: moving to and pushing the kettle, then moving to and
@@ -149,10 +149,10 @@ def test_kitchen():
     state = env.state_info_to_state(obs["state_info"])
     assert state.allclose(init_state)
     state = _run_ground_nsrt(move_to_kettle_nsrt, state)
-    state = _run_ground_nsrt(push_kettle_on_burner2_nsrt, state)
+    state = _run_ground_nsrt(push_kettle_on_burner4_nsrt, state)
     state = _run_ground_nsrt(move_to_knob3_nsrt, state)
     state = _run_ground_nsrt(push_knob3_nsrt, state)
-    assert OnTop([kettle, burner2]).holds(state)
+    assert OnTop([kettle, burner4]).holds(state)
     assert TurnedOn([knob3]).holds(state)
 
     # Test light, kettle, then knob.
@@ -162,10 +162,10 @@ def test_kitchen():
     state = _run_ground_nsrt(move_to_light_nsrt, state)
     state = _run_ground_nsrt(push_light_nsrt, state)
     state = _run_ground_nsrt(move_to_kettle_nsrt, state)
-    state = _run_ground_nsrt(push_kettle_on_burner2_nsrt, state)
+    state = _run_ground_nsrt(push_kettle_on_burner4_nsrt, state)
     state = _run_ground_nsrt(move_to_knob3_nsrt, state)
     state = _run_ground_nsrt(push_knob3_nsrt, state)
-    assert OnTop([kettle, burner2]).holds(state)
+    assert OnTop([kettle, burner4]).holds(state)
     assert TurnedOn([knob3]).holds(state)
     assert TurnedOn([light]).holds(state)
 
@@ -178,7 +178,7 @@ def test_kitchen():
     state = _run_ground_nsrt(move_to_light_nsrt, state)
     state = _run_ground_nsrt(push_light_nsrt, state)
     state = _run_ground_nsrt(move_to_kettle_nsrt, state)
-    state = _run_ground_nsrt(push_kettle_on_burner2_nsrt, state)
-    assert OnTop([kettle, burner2]).holds(state)
+    state = _run_ground_nsrt(push_kettle_on_burner4_nsrt, state)
+    assert OnTop([kettle, burner4]).holds(state)
     assert TurnedOn([knob3]).holds(state)
     assert TurnedOn([light]).holds(state)

--- a/tests/envs/test_kitchen.py
+++ b/tests/envs/test_kitchen.py
@@ -124,16 +124,16 @@ def test_kitchen():
     push_kettle_on_burner4_nsrt = PushObjOnObjForward.ground(
         [gripper, kettle, burner4])
 
-    # Test moving to and pushing knob4, then moving to and pushing the kettle.
-    obs = env.reset("test", 0)
-    state = env.state_info_to_state(obs["state_info"])
-    assert state.allclose(init_state)
-    state = _run_ground_nsrt(move_to_knob4_nsrt, state)
-    state = _run_ground_nsrt(push_knob4_nsrt, state)
-    state = _run_ground_nsrt(move_to_kettle_nsrt, state)
-    state = _run_ground_nsrt(push_kettle_on_burner4_nsrt, state)
-    assert OnTop([kettle, burner4]).holds(state)
-    assert TurnedOn([knob4]).holds(state)
+    # # Test moving to and pushing knob4, then moving to and pushing the kettle.
+    # obs = env.reset("test", 0)
+    # state = env.state_info_to_state(obs["state_info"])
+    # assert state.allclose(init_state)
+    # state = _run_ground_nsrt(move_to_knob4_nsrt, state)
+    # state = _run_ground_nsrt(push_knob4_nsrt, state)
+    # state = _run_ground_nsrt(move_to_kettle_nsrt, state)
+    # state = _run_ground_nsrt(push_kettle_on_burner4_nsrt, state)
+    # assert OnTop([kettle, burner4]).holds(state)
+    # assert TurnedOn([knob4]).holds(state)
 
     # Test reverse order: moving to and pushing the kettle, then moving to and
     # pushing knob4.

--- a/tests/envs/test_kitchen.py
+++ b/tests/envs/test_kitchen.py
@@ -125,8 +125,6 @@ def test_kitchen():
         [gripper, kettle, burner4])
 
     # Test moving to and turning on the light.
-    # TODO
-    import ipdb; ipdb.set_trace()
     obs = env.reset("test", 0)
     state = env.state_info_to_state(obs["state_info"])
     assert state.allclose(init_state)

--- a/tests/envs/test_kitchen.py
+++ b/tests/envs/test_kitchen.py
@@ -124,16 +124,16 @@ def test_kitchen():
     push_kettle_on_burner4_nsrt = PushObjOnObjForward.ground(
         [gripper, kettle, burner4])
 
-    # # Test moving to and pushing knob4, then moving to and pushing the kettle.
-    # obs = env.reset("test", 0)
-    # state = env.state_info_to_state(obs["state_info"])
-    # assert state.allclose(init_state)
-    # state = _run_ground_nsrt(move_to_knob4_nsrt, state)
-    # state = _run_ground_nsrt(push_knob4_nsrt, state)
-    # state = _run_ground_nsrt(move_to_kettle_nsrt, state)
-    # state = _run_ground_nsrt(push_kettle_on_burner4_nsrt, state)
-    # assert OnTop([kettle, burner4]).holds(state)
-    # assert TurnedOn([knob4]).holds(state)
+    # Test moving to and pushing knob4, then moving to and pushing the kettle.
+    obs = env.reset("test", 0)
+    state = env.state_info_to_state(obs["state_info"])
+    assert state.allclose(init_state)
+    state = _run_ground_nsrt(move_to_knob4_nsrt, state)
+    state = _run_ground_nsrt(push_knob4_nsrt, state)
+    state = _run_ground_nsrt(move_to_kettle_nsrt, state)
+    state = _run_ground_nsrt(push_kettle_on_burner4_nsrt, state)
+    assert OnTop([kettle, burner4]).holds(state)
+    assert TurnedOn([knob4]).holds(state)
 
     # Test reverse order: moving to and pushing the kettle, then moving to and
     # pushing knob4.

--- a/tests/envs/test_kitchen.py
+++ b/tests/envs/test_kitchen.py
@@ -108,7 +108,6 @@ def test_kitchen():
             obs = env.step(act)
             state = env.state_info_to_state(obs["state_info"])
             if option.terminal(state):
-                print(f"TERMINATING AFTER {_} steps")
                 break
         for atom in ground_nsrt.add_effects:
             assert atom.holds(state)

--- a/tests/envs/test_kitchen.py
+++ b/tests/envs/test_kitchen.py
@@ -93,7 +93,7 @@ def test_kitchen():
 
     obj_name_to_obj = {o.name: o for o in init_state}
     gripper = obj_name_to_obj["gripper"]
-    knob3 = obj_name_to_obj["knob3"]
+    knob4 = obj_name_to_obj["knob4"]
     kettle = obj_name_to_obj["kettle"]
     burner4 = obj_name_to_obj["burner4"]
     light = obj_name_to_obj["light"]
@@ -118,8 +118,8 @@ def test_kitchen():
     # Set up all the NSRTs for the following tests.
     move_to_light_nsrt = MoveTo.ground([gripper, light])
     push_light_nsrt = PushObjTurnOnLeftRight.ground([gripper, light])
-    move_to_knob3_nsrt = MoveTo.ground([gripper, knob3])
-    push_knob3_nsrt = PushObjTurnOnLeftRight.ground([gripper, knob3])
+    move_to_knob4_nsrt = MoveTo.ground([gripper, knob4])
+    push_knob4_nsrt = PushObjTurnOnLeftRight.ground([gripper, knob4])
     move_to_kettle_nsrt = MoveTo.ground([gripper, kettle])
     push_kettle_on_burner4_nsrt = PushObjOnObjForward.ground(
         [gripper, kettle, burner4])
@@ -132,28 +132,28 @@ def test_kitchen():
     state = _run_ground_nsrt(push_light_nsrt, state)
     assert TurnedOn([light]).holds(state)
 
-    # Test moving to and pushing knob3, then moving to and pushing the kettle.
+    # Test moving to and pushing knob4, then moving to and pushing the kettle.
     obs = env.reset("test", 0)
     state = env.state_info_to_state(obs["state_info"])
     assert state.allclose(init_state)
-    state = _run_ground_nsrt(move_to_knob3_nsrt, state)
-    state = _run_ground_nsrt(push_knob3_nsrt, state)
+    state = _run_ground_nsrt(move_to_knob4_nsrt, state)
+    state = _run_ground_nsrt(push_knob4_nsrt, state)
     state = _run_ground_nsrt(move_to_kettle_nsrt, state)
     state = _run_ground_nsrt(push_kettle_on_burner4_nsrt, state)
     assert OnTop([kettle, burner4]).holds(state)
-    assert TurnedOn([knob3]).holds(state)
+    assert TurnedOn([knob4]).holds(state)
 
     # Test reverse order: moving to and pushing the kettle, then moving to and
-    # pushing knob3.
+    # pushing knob4.
     obs = env.reset("test", 0)
     state = env.state_info_to_state(obs["state_info"])
     assert state.allclose(init_state)
     state = _run_ground_nsrt(move_to_kettle_nsrt, state)
     state = _run_ground_nsrt(push_kettle_on_burner4_nsrt, state)
-    state = _run_ground_nsrt(move_to_knob3_nsrt, state)
-    state = _run_ground_nsrt(push_knob3_nsrt, state)
+    state = _run_ground_nsrt(move_to_knob4_nsrt, state)
+    state = _run_ground_nsrt(push_knob4_nsrt, state)
     assert OnTop([kettle, burner4]).holds(state)
-    assert TurnedOn([knob3]).holds(state)
+    assert TurnedOn([knob4]).holds(state)
 
     # Test light, kettle, then knob.
     obs = env.reset("test", 0)
@@ -163,22 +163,22 @@ def test_kitchen():
     state = _run_ground_nsrt(push_light_nsrt, state)
     state = _run_ground_nsrt(move_to_kettle_nsrt, state)
     state = _run_ground_nsrt(push_kettle_on_burner4_nsrt, state)
-    state = _run_ground_nsrt(move_to_knob3_nsrt, state)
-    state = _run_ground_nsrt(push_knob3_nsrt, state)
+    state = _run_ground_nsrt(move_to_knob4_nsrt, state)
+    state = _run_ground_nsrt(push_knob4_nsrt, state)
     assert OnTop([kettle, burner4]).holds(state)
-    assert TurnedOn([knob3]).holds(state)
+    assert TurnedOn([knob4]).holds(state)
     assert TurnedOn([light]).holds(state)
 
     # Test knob, light, kettle.
     obs = env.reset("test", 0)
     state = env.state_info_to_state(obs["state_info"])
     assert state.allclose(init_state)
-    state = _run_ground_nsrt(move_to_knob3_nsrt, state)
-    state = _run_ground_nsrt(push_knob3_nsrt, state)
+    state = _run_ground_nsrt(move_to_knob4_nsrt, state)
+    state = _run_ground_nsrt(push_knob4_nsrt, state)
     state = _run_ground_nsrt(move_to_light_nsrt, state)
     state = _run_ground_nsrt(push_light_nsrt, state)
     state = _run_ground_nsrt(move_to_kettle_nsrt, state)
     state = _run_ground_nsrt(push_kettle_on_burner4_nsrt, state)
     assert OnTop([kettle, burner4]).holds(state)
-    assert TurnedOn([knob3]).holds(state)
+    assert TurnedOn([knob4]).holds(state)
     assert TurnedOn([light]).holds(state)

--- a/tests/envs/test_kitchen.py
+++ b/tests/envs/test_kitchen.py
@@ -124,6 +124,16 @@ def test_kitchen():
     push_kettle_on_burner4_nsrt = PushObjOnObjForward.ground(
         [gripper, kettle, burner4])
 
+    # Test moving to and turning on the light.
+    # TODO
+    import ipdb; ipdb.set_trace()
+    obs = env.reset("test", 0)
+    state = env.state_info_to_state(obs["state_info"])
+    assert state.allclose(init_state)
+    state = _run_ground_nsrt(move_to_light_nsrt, state)
+    state = _run_ground_nsrt(push_light_nsrt, state)
+    assert TurnedOn([light]).holds(state)
+
     # Test moving to and pushing knob4, then moving to and pushing the kettle.
     obs = env.reset("test", 0)
     state = env.state_info_to_state(obs["state_info"])
@@ -146,14 +156,6 @@ def test_kitchen():
     state = _run_ground_nsrt(push_knob4_nsrt, state)
     assert OnTop([kettle, burner4]).holds(state)
     assert TurnedOn([knob4]).holds(state)
-
-    # Test moving to and turning on the light.
-    obs = env.reset("test", 0)
-    state = env.state_info_to_state(obs["state_info"])
-    assert state.allclose(init_state)
-    state = _run_ground_nsrt(move_to_light_nsrt, state)
-    state = _run_ground_nsrt(push_light_nsrt, state)
-    assert TurnedOn([light]).holds(state)
 
     # Test light, kettle, then knob.
     obs = env.reset("test", 0)


### PR DESCRIPTION
this replaces the gym environment ("back end") for the kitchen environment to a more recent and stable version. the main advantage of the new version is that stable IK control of the end effector is possible, which massively reduces pain in designing options.

it's also possible that we could make the kitchen environment a regular dependency, but I'm punting on that because it requires a higher python version (3.9+) than our current minimum (3.8).

this PR recovers the performance of the "perfect" samplers. the next PRs will (1) recover performance of active learning; (2) recover supercloud-ability; (3) add more skills.