### PR TITLE
new kitchen supercloud updates

### DIFF
--- a/scripts/configs/kitchen_active_learning.yaml
+++ b/scripts/configs/kitchen_active_learning.yaml
@@ -36,4 +36,3 @@ FLAGS:  # general flags
   active_sampler_learning_explore_length_base: 10000  # effectively disable
 START_SEED: 456
 NUM_SEEDS: 10
-USE_MUJOCO: True

--- a/scripts/configs/kitchen_oracle.yaml
+++ b/scripts/configs/kitchen_oracle.yaml
@@ -18,4 +18,3 @@ FLAGS:  # general flags
   num_test_tasks: 5
 START_SEED: 456
 NUM_SEEDS: 2
-USE_MUJOCO: True


### PR DESCRIPTION
nice and simple! no longer need mujoco hack. just needed to install the new dependency on my supercloud (and upgrade to 3.9).