### PR TITLE
don't abstract intermediate states if not needed; only save ground atom trajectories when asked

### DIFF
--- a/predicators/approaches/bridge_policy_approach.py
+++ b/predicators/approaches/bridge_policy_approach.py
@@ -272,7 +272,7 @@ class BridgePolicyApproach(OracleApproach):
             traj = response.teacher_traj
             assert traj is not None
             atom_traj = [utils.abstract(s, preds) for s in traj.states]
-            segmented_traj = segment_trajectory((traj, atom_traj))
+            segmented_traj = segment_trajectory(traj, preds, atom_traj)
             if not segmented_traj:
                 assert len(atom_traj) == 1
                 states = [traj.states[0]]

--- a/predicators/approaches/gnn_option_policy_approach.py
+++ b/predicators/approaches/gnn_option_policy_approach.py
@@ -43,15 +43,14 @@ class GNNOptionPolicyApproach(GNNApproach):
         self, dataset: Dataset
     ) -> List[Tuple[State, Set[GroundAtom], Set[GroundAtom], _Option]]:
         data = []
-        ground_atom_dataset = utils.create_ground_atom_dataset(
-            dataset.trajectories, self._initial_predicates)
         # In this approach, we never learned any NSRTs, so we just call
         # segment_trajectory() to segment the given dataset.
         segmented_trajs = [
-            segment_trajectory(traj) for traj in ground_atom_dataset
+            segment_trajectory(traj, self._initial_predicates)
+            for traj in dataset.trajectories
         ]
-        for segment_traj, (ll_traj, _) in zip(segmented_trajs,
-                                              ground_atom_dataset):
+        for segment_traj, ll_traj in zip(segmented_trajs,
+                                         dataset.trajectories):
             if not ll_traj.is_demo:
                 continue
             goal = self._train_tasks[ll_traj.train_task_idx].goal

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -21,8 +21,8 @@ from predicators.nsrt_learning.strips_learning import learn_strips_operators
 from predicators.predicate_search_score_functions import \
     _PredicateSearchScoreFunction, create_score_function
 from predicators.settings import CFG
-from predicators.structs import Dataset, GroundAtomTrajectory, \
-    Object, ParameterizedOption, Predicate, Segment, State, Task, Type
+from predicators.structs import Dataset, GroundAtomTrajectory, Object, \
+    ParameterizedOption, Predicate, Segment, State, Task, Type
 
 ################################################################################
 #                          Programmatic classifiers                            #

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -21,7 +21,7 @@ from predicators.nsrt_learning.strips_learning import learn_strips_operators
 from predicators.predicate_search_score_functions import \
     _PredicateSearchScoreFunction, create_score_function
 from predicators.settings import CFG
-from predicators.structs import Dataset, GroundAtom, GroundAtomTrajectory, \
+from predicators.structs import Dataset, GroundAtomTrajectory, \
     Object, ParameterizedOption, Predicate, Segment, State, Task, Type
 
 ################################################################################

--- a/predicators/args.py
+++ b/predicators/args.py
@@ -37,6 +37,7 @@ def create_arg_parser(env_required: bool = True,
     parser.add_argument("--restart_learning", action="store_true")
     parser.add_argument("--load_data", action="store_true")
     parser.add_argument("--load_atoms", action="store_true")
+    parser.add_argument("--save_atoms", action="store_true")
     parser.add_argument("--skip_until_cycle", default=-1, type=int)
     parser.add_argument("--experiment_id", default="", type=str)
     parser.add_argument("--load_experiment_id", default="", type=str)

--- a/predicators/nsrt_learning/nsrt_learning_main.py
+++ b/predicators/nsrt_learning/nsrt_learning_main.py
@@ -52,9 +52,10 @@ def learn_nsrts_from_data(
                 [int(i) for i in range(len(trajectories))],
                 key=lambda _: rng.random())
             trajectories = [trajectories[i] for i in random_data_indices]
-            ground_atom_dataset = [
-                ground_atom_dataset[i] for i in random_data_indices
-            ]
+            if ground_atom_dataset is not None:
+                ground_atom_dataset = [
+                    ground_atom_dataset[i] for i in random_data_indices
+                ]
         # STEP 1: Segment each trajectory in the dataset based on changes in
         #         either predicates or options. If we are doing option learning,
         #         then the data will not contain options, so this segmenting

--- a/predicators/nsrt_learning/nsrt_learning_main.py
+++ b/predicators/nsrt_learning/nsrt_learning_main.py
@@ -21,7 +21,8 @@ from predicators.structs import NSRT, PNAD, GroundAtomTrajectory, \
 def learn_nsrts_from_data(
     trajectories: List[LowLevelTrajectory], train_tasks: List[Task],
     predicates: Set[Predicate], known_options: Set[ParameterizedOption],
-    action_space: Box, ground_atom_dataset: List[GroundAtomTrajectory],
+    action_space: Box,
+    ground_atom_dataset: Optional[List[GroundAtomTrajectory]],
     sampler_learner: str, annotations: Optional[List[Any]]
 ) -> Tuple[Set[NSRT], List[List[Segment]], Dict[Segment, NSRT]]:
     """Learn NSRTs from the given dataset of low-level transitions, using the
@@ -58,9 +59,15 @@ def learn_nsrts_from_data(
         #         either predicates or options. If we are doing option learning,
         #         then the data will not contain options, so this segmenting
         #         procedure only uses the predicates.
-        segmented_trajs = [
-            segment_trajectory(traj) for traj in ground_atom_dataset
-        ]
+        if ground_atom_dataset is None:
+            segmented_trajs = [
+                segment_trajectory(traj, predicates) for traj in trajectories
+            ]
+        else:
+            segmented_trajs = [
+                segment_trajectory(traj, predicates, atom_seq=atom_seq)
+                for traj, atom_seq in ground_atom_dataset
+            ]
         # If performing goal-conditioned sampler learning, we need to attach the
         # goals to the segments.
         if CFG.sampler_learning_use_goals:

--- a/predicators/nsrt_learning/segmentation.py
+++ b/predicators/nsrt_learning/segmentation.py
@@ -1,44 +1,54 @@
 """Methods for segmenting low-level trajectories into segments."""
 
-from typing import Callable, List
+from typing import Callable, List, Optional, Set
 
 from predicators import utils
 from predicators.envs import get_or_create_env
 from predicators.ground_truth_models import get_gt_nsrts, get_gt_options
 from predicators.settings import CFG
-from predicators.structs import Action, GroundAtomTrajectory, \
-    LowLevelTrajectory, Segment, State
+from predicators.structs import Action, GroundAtom, GroundAtomTrajectory, \
+    LowLevelTrajectory, Predicate, Segment, State
 
 
-def segment_trajectory(trajectory: GroundAtomTrajectory) -> List[Segment]:
+def segment_trajectory(
+        ll_traj: LowLevelTrajectory,
+        predicates: Set[Predicate],
+        atom_seq: Optional[List[Set[GroundAtom]]] = None) -> List[Segment]:
     """Segment a ground atom trajectory."""
-    if CFG.segmenter == "atom_changes":
-        return _segment_with_atom_changes(trajectory)
+    # Start with the segmenters that don't need atom_seq. Still pass it in
+    # because if it was provided, it can be used to avoid calling abstract.
     if CFG.segmenter == "option_changes":
-        return _segment_with_option_changes(trajectory)
-    if CFG.segmenter == "oracle":
-        return _segment_with_oracle(trajectory)
-    if CFG.segmenter == "contacts":
-        return _segment_with_contact_changes(trajectory)
+        return _segment_with_option_changes(ll_traj, predicates, atom_seq)
     if CFG.segmenter == "every_step":
-        return _segment_with_switch_function(trajectory, lambda _: True)
+        return _segment_with_switch_function(ll_traj, predicates, atom_seq,
+                                             lambda _: True)
+    # All segmenters below need atom_seq. Create it if it wasn't passed in.
+    if atom_seq is None:
+        atom_seq = [utils.abstract(s) for s in ll_traj.states]
+    if CFG.segmenter == "atom_changes":
+        return _segment_with_atom_changes(ll_traj, predicates, atom_seq)
+    if CFG.segmenter == "oracle":
+        return _segment_with_oracle(ll_traj, predicates, atom_seq)
+    if CFG.segmenter == "contacts":
+        return _segment_with_contact_changes(ll_traj, predicates, atom_seq)
     raise NotImplementedError(f"Unrecognized segmenter: {CFG.segmenter}.")
 
 
 def _segment_with_atom_changes(
-        trajectory: GroundAtomTrajectory) -> List[Segment]:
+        ll_traj: LowLevelTrajectory, predicates: Set[Predicate],
+        atom_seq: List[Set[GroundAtomTrajectory]]) -> List[Segment]:
     """Segment a trajectory whenever the abstract state changes."""
 
-    _, all_atoms = trajectory
-
     def _switch_fn(t: int) -> bool:
-        return all_atoms[t] != all_atoms[t + 1]
+        return atom_seq[t] != atom_seq[t + 1]
 
-    return _segment_with_switch_function(trajectory, _switch_fn)
+    return _segment_with_switch_function(ll_traj, predicates, atom_seq,
+                                         _switch_fn)
 
 
 def _segment_with_contact_changes(
-        trajectory: GroundAtomTrajectory) -> List[Segment]:
+        ll_traj: LowLevelTrajectory, predicates: Set[Predicate],
+        atom_seq: List[Set[GroundAtomTrajectory]]) -> List[Segment]:
     """Segment a trajectory based on contact changes.
 
     Since environments do not expose contacts, this is implemented in an
@@ -64,7 +74,6 @@ def _segment_with_contact_changes(
         raise NotImplementedError("Contact-based segmentation not implemented "
                                   f"for environment {CFG.env}.")
 
-    traj, _ = trajectory
     # If some predicates are excluded, we need to load predicates from the
     # environment in case contact-based ones are excluded. Note that this is
     # not really leaking information because the same effect could be achieved
@@ -74,44 +83,48 @@ def _segment_with_contact_changes(
     keep_preds = {p for p in env.predicates if p.name in keep_pred_names}
     assert len(keep_preds) == len(keep_pred_names)
     all_keep_atoms = []
-    for state in traj.states:
+    for state in ll_traj.states:
         all_keep_atoms.append(utils.abstract(state, keep_preds))
 
     def _switch_fn(t: int) -> bool:
         return all_keep_atoms[t] != all_keep_atoms[t + 1]
 
-    return _segment_with_switch_function(trajectory, _switch_fn)
+    return _segment_with_switch_function(ll_traj, predicates, atom_seq,
+                                         _switch_fn)
 
 
 def _segment_with_option_changes(
-        trajectory: GroundAtomTrajectory) -> List[Segment]:
+        ll_traj: LowLevelTrajectory, predicates: Set[Predicate],
+        atom_seq: Optional[List[Set[GroundAtomTrajectory]]]) -> List[Segment]:
     """Segment a trajectory whenever the (assumed known) option changes."""
-
-    traj, _ = trajectory
 
     def _switch_fn(t: int) -> bool:
         # Segment by checking whether the option changes on the next step.
-        option_t = traj.actions[t].get_option()
+        option_t = ll_traj.actions[t].get_option()
         # As a special case, if this is the last timestep, then use the
         # option's terminal function to check if it completed, or see if the
         # termination was due to max_num_steps_option_rollout.
-        if t == len(traj.actions) - 1:
+        if t == len(ll_traj.actions) - 1:
             # Calculate the number of steps since the option changed.
             backward_t = t
             while backward_t > 0:
-                if traj.actions[backward_t - 1].get_option() is not option_t:
+                if ll_traj.actions[backward_t -
+                                   1].get_option() is not option_t:
                     break
                 backward_t -= 1
             option_duration = t - backward_t + 1
             if option_duration >= CFG.max_num_steps_option_rollout:
                 return True
-            return option_t.terminal(traj.states[t + 1])
-        return option_t is not traj.actions[t + 1].get_option()
+            return option_t.terminal(ll_traj.states[t + 1])
+        return option_t is not ll_traj.actions[t + 1].get_option()
 
-    return _segment_with_switch_function(trajectory, _switch_fn)
+    return _segment_with_switch_function(ll_traj, predicates, atom_seq,
+                                         _switch_fn)
 
 
-def _segment_with_oracle(trajectory: GroundAtomTrajectory) -> List[Segment]:
+def _segment_with_oracle(
+        ll_traj: LowLevelTrajectory, predicates: Set[Predicate],
+        atom_seq: List[Set[GroundAtomTrajectory]]) -> List[Segment]:
     """Segment a trajectory using oracle NSRTs.
 
     If options are known, just uses _segment_with_option_changes().
@@ -120,20 +133,19 @@ def _segment_with_oracle(trajectory: GroundAtomTrajectory) -> List[Segment]:
     which oracle ground NSRTs are applicable. When any of them have their
     effects achieved, that marks the switch point between segments.
     """
-    traj, all_atoms = trajectory
-    if traj.actions and traj.actions[0].has_option():
+    if ll_traj.actions and ll_traj.actions[0].has_option():
         assert CFG.option_learner == "no_learning"
-        return _segment_with_option_changes(trajectory)
+        return _segment_with_option_changes(ll_traj, predicates, atom_seq)
     env = get_or_create_env(CFG.env)
     env_options = get_gt_options(env.get_name())
     gt_nsrts = get_gt_nsrts(env.get_name(), env.predicates, env_options)
-    objects = list(traj.states[0])
+    objects = list(ll_traj.states[0])
     ground_nsrts = {
         ground_nsrt
         for nsrt in gt_nsrts
         for ground_nsrt in utils.all_ground_nsrts(nsrt, objects)
     }
-    atoms = all_atoms[0]
+    atoms = atom_seq[0]
     all_expected_next_atoms = [
         utils.apply_operator(n, atoms)
         for n in utils.get_applicable_operators(ground_nsrts, atoms)
@@ -141,7 +153,7 @@ def _segment_with_oracle(trajectory: GroundAtomTrajectory) -> List[Segment]:
 
     def _switch_fn(t: int) -> bool:
         nonlocal all_expected_next_atoms  # update at each switch point
-        next_atoms = all_atoms[t + 1]
+        next_atoms = atom_seq[t + 1]
         # Check if any of the current NSRT effects hold.
         for expected_next_atoms in all_expected_next_atoms:
             # Check if we have reached the expected next atoms.
@@ -157,11 +169,13 @@ def _segment_with_oracle(trajectory: GroundAtomTrajectory) -> List[Segment]:
         # Not yet time to segment.
         return False
 
-    return _segment_with_switch_function(trajectory, _switch_fn)
+    return _segment_with_switch_function(ll_traj, predicates, atom_seq,
+                                         _switch_fn)
 
 
 def _segment_with_switch_function(
-        trajectory: GroundAtomTrajectory,
+        ll_traj: LowLevelTrajectory, predicates: Set[Predicate],
+        atom_seq: Optional[List[Set[GroundAtomTrajectory]]],
         switch_fn: Callable[[int], bool]) -> List[Segment]:
     """Helper for other segmentation methods.
 
@@ -169,26 +183,33 @@ def _segment_with_switch_function(
     should be segmented at the end of that timestep.
     """
     segments = []
-    traj, all_atoms = trajectory
-    assert len(traj.states) == len(all_atoms)
-    assert len(traj.states) > 0
+    assert len(ll_traj.states) == len(atom_seq)
+    assert len(ll_traj.states) > 0
     current_segment_states: List[State] = []
     current_segment_actions: List[Action] = []
-    current_segment_init_atoms = all_atoms[0]
-    for t in range(len(traj.actions)):
-        current_segment_states.append(traj.states[t])
-        current_segment_actions.append(traj.actions[t])
+    if atom_seq is not None:
+        current_segment_init_atoms = atom_seq[0]
+    else:
+        s0 = ll_traj.states[0]
+        current_segment_init_atoms = utils.abstract(s0, predicates)
+    for t in range(len(ll_traj.actions)):
+        current_segment_states.append(ll_traj.states[t])
+        current_segment_actions.append(ll_traj.actions[t])
         if switch_fn(t):
             # Include the final state as the end of this segment.
-            current_segment_states.append(traj.states[t + 1])
+            current_segment_states.append(ll_traj.states[t + 1])
             current_segment_traj = LowLevelTrajectory(current_segment_states,
                                                       current_segment_actions)
-            current_segment_final_atoms = all_atoms[t + 1]
-            if traj.actions[t].has_option():
+            if atom_seq is not None:
+                current_segment_final_atoms = atom_seq[t + 1]
+            else:
+                st1 = ll_traj.states[t + 1]
+                current_segment_final_atoms = utils.abstract(st1, predicates)
+            if ll_traj.actions[t].has_option():
                 segment = Segment(current_segment_traj,
                                   current_segment_init_atoms,
                                   current_segment_final_atoms,
-                                  traj.actions[t].get_option())
+                                  ll_traj.actions[t].get_option())
             else:
                 # If we're in option learning mode, include the default option
                 # here; replaced later during option learning.

--- a/predicators/predicate_search_score_functions.py
+++ b/predicators/predicate_search_score_functions.py
@@ -133,7 +133,8 @@ class _OperatorLearningBasedScoreFunction(_PredicateSearchScoreFunction):
             self._atom_dataset,
             candidate_predicates | self._initial_predicates)
         segmented_trajs = [
-            segment_trajectory(traj) for traj in pruned_atom_data
+            segment_trajectory(ll_traj, set(candidate_predicates), atom_seq)
+            for (ll_traj, atom_seq) in pruned_atom_data
         ]
         # Each entry in pruned_atom_data is a tuple of (low-level trajectory,
         # low-level ground atoms sequence). We remove the latter, because

--- a/scripts/skeleton_score_analysis.py
+++ b/scripts/skeleton_score_analysis.py
@@ -147,9 +147,10 @@ def _skeleton_based_score_function(
     train_tasks, dataset, demo_skeleton_lengths = _setup_data_for_env(
         env_name, seed)
     # Learn operators.
-    atom_dataset = utils.create_ground_atom_dataset(dataset.trajectories,
-                                                    current_predicate_set)
-    segmented_trajs = [segment_trajectory(traj) for traj in atom_dataset]
+    segmented_trajs = [
+        segment_trajectory(traj, current_predicate_set)
+        for traj in dataset.trajectories
+    ]
     pnads = learn_strips_operators(dataset.trajectories,
                                    train_tasks,
                                    current_predicate_set,

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -27,6 +27,7 @@ def _test_approach(env_name,
                    num_train_tasks=1,
                    offline_data_method="demo+replay",
                    solve_exceptions=None,
+                   save_atoms=False,
                    load_atoms=False,
                    additional_settings=None):
     """Integration test for the given approach."""
@@ -51,6 +52,7 @@ def _test_approach(env_name,
         "sampler_learner": sampler_learner,
         "segmenter": segmenter,
         "cover_initial_holding_prob": 0.0,
+        "save_atoms": save_atoms,
         "load_atoms": load_atoms,
         **additional_settings,
     })
@@ -178,6 +180,7 @@ def test_saving_and_loading_atoms():
     approach = _test_approach(env_name="blocks",
                               approach_name="nsrt_learning",
                               try_solving=False,
+                              save_atoms=True,
                               load_atoms=False)
     # Next, try to manually load these saved atoms.
     dataset_fname, _ = utils.create_dataset_filename_str(

--- a/tests/nsrt_learning/strips_learning/test_backchaining_based_learners.py
+++ b/tests/nsrt_learning/strips_learning/test_backchaining_based_learners.py
@@ -560,8 +560,7 @@ def test_backchaining_strips_learner_order_dependence(approach_name,
     traj2 = LowLevelTrajectory(
         [state1, state10, state11, state12, state13],
         [moveto_book1, pick_book1, movetoshelf1, place_book1], True, 1)
-    ground_atom_trajs = utils.create_ground_atom_dataset([traj1, traj2], preds)
-    segmented_trajs = [segment_trajectory(traj) for traj in ground_atom_trajs]
+    segmented_trajs = [segment_trajectory(t, preds) for t in [traj1, traj2]]
     # Now, run the learner on the demo.
     learner = approach_cls([traj1, traj2], [task1, task2],
                            preds,
@@ -595,8 +594,7 @@ def test_backchaining_strips_learner_order_dependence(approach_name,
     traj2 = LowLevelTrajectory(
         [state1, state10, state11, state12, state13],
         [moveto_book1, pick_book1, movetoshelf1, place_book1], True, 0)
-    ground_atom_trajs = utils.create_ground_atom_dataset([traj2, traj1], preds)
-    segmented_trajs = [segment_trajectory(traj) for traj in ground_atom_trajs]
+    segmented_trajs = [segment_trajectory(t, preds) for t in [traj2, traj1]]
     # Now, create and run the learner with the 3 demos in the reverse order.
     learner = approach_cls([traj2, traj1], [task2, task1],
                            preds,
@@ -826,9 +824,9 @@ def test_keep_effect_data_partitioning(approach_cls):
     task1 = Task(all_off_not_configed, goal)
     task2 = Task(m3_on, goal)
 
-    ground_atom_trajs = utils.create_ground_atom_dataset([traj1, traj2],
-                                                         predicates)
-    segmented_trajs = [segment_trajectory(traj) for traj in ground_atom_trajs]
+    segmented_trajs = [
+        segment_trajectory(t, predicates) for t in [traj1, traj2]
+    ]
 
     # Now, run the learner on the two demos.
     learner = approach_cls([traj1, traj2], [task1, task2],
@@ -1039,9 +1037,10 @@ def test_combinatorial_keep_effect_data_partitioning(approach_name,
     task3 = Task(all_off_not_configed, goal)
     task4 = Task(m3_fix_m3_on, goal)
 
-    ground_atom_trajs = utils.create_ground_atom_dataset(
-        [traj1, traj2, traj3, traj4], predicates)
-    segmented_trajs = [segment_trajectory(traj) for traj in ground_atom_trajs]
+    segmented_trajs = [
+        segment_trajectory(t, predicates)
+        for t in [traj1, traj2, traj3, traj4]
+    ]
 
     # Now, run the learner on the four demos.
     learner = approach_cls([traj1, traj2, traj3, traj4],
@@ -1210,8 +1209,7 @@ def test_keep_effect_adding_new_variables(approach_cls):
     goal = {ButtonPressed([button]), PotatoHeld([potato3])}
     task = Task(s0, goal)
 
-    ground_atom_traj = utils.create_ground_atom_dataset([traj], predicates)[0]
-    segmented_traj = segment_trajectory(ground_atom_traj)
+    segmented_traj = segment_trajectory(traj, predicates)
 
     # Now, run the learner on the demo.
     learner = approach_cls([traj], [task],
@@ -1314,9 +1312,9 @@ def test_multi_pass_backchaining(approach_cls, val):
     goal3 = {GroundAtom(C, []), GroundAtom(D, [])}
     task3 = Task(s30, goal3)
 
-    ground_atom_trajs = utils.create_ground_atom_dataset([traj1, traj2, traj3],
-                                                         predicates)
-    segmented_trajs = [segment_trajectory(traj) for traj in ground_atom_trajs]
+    segmented_trajs = [
+        segment_trajectory(t, predicates) for t in [traj1, traj2, traj3]
+    ]
 
     # Now, run the learner on the three demos.
     learner = approach_cls([traj1, traj2, traj3], [task1, task2, task3],
@@ -1436,8 +1434,7 @@ def test_segment_not_in_datastore(approach_cls):
     task3 = Task(s30, goal3)
     # Ground and segment these trajectories.
     trajs = [traj0, traj1, traj2, traj3]
-    ground_atom_trajs = utils.create_ground_atom_dataset(trajs, predicates)
-    segmented_trajs = [segment_trajectory(traj) for traj in ground_atom_trajs]
+    segmented_trajs = [segment_trajectory(t, predicates) for t in trajs]
     # Now, run the learner on the demos.
     learner = approach_cls(trajs, [task0, task1, task2, task3],
                            predicates,
@@ -1625,8 +1622,7 @@ def test_backchaining_randomly_generated(approach_cls, use_single_option,
     trajs = [traj1, traj2, traj3, traj4][:num_demos]
     tasks = [task1, task2, task3, task4][:num_demos]
 
-    ground_atom_trajs = utils.create_ground_atom_dataset(trajs, predicates)
-    segmented_trajs = [segment_trajectory(traj) for traj in ground_atom_trajs]
+    segmented_trajs = [segment_trajectory(t, predicates) for t in trajs]
 
     # Now, run the learner on the demos.
     learner = approach_cls(trajs,

--- a/tests/nsrt_learning/strips_learning/test_oracle_learner.py
+++ b/tests/nsrt_learning/strips_learning/test_oracle_learner.py
@@ -26,10 +26,8 @@ def test_oracle_strips_learner():
     env = create_new_env("blocks")
     train_tasks = [t.task for t in env.get_train_tasks()]
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))
-    ground_atom_dataset = utils.create_ground_atom_dataset(
-        dataset.trajectories, env.predicates)
     segmented_trajs = [
-        segment_trajectory(traj) for traj in ground_atom_dataset
+        segment_trajectory(t, env.predicates) for t in dataset.trajectories
     ]
     pnads = learn_strips_operators(dataset.trajectories,
                                    train_tasks,
@@ -74,10 +72,8 @@ def test_oracle_strips_learner():
     env = create_new_env("blocks")
     train_tasks = [t.task for t in env.get_train_tasks()]
     dataset = create_dataset(env, train_tasks, set())
-    ground_atom_dataset = utils.create_ground_atom_dataset(
-        dataset.trajectories, env.predicates)
     segmented_trajs = [
-        segment_trajectory(traj) for traj in ground_atom_dataset
+        segment_trajectory(t, env.predicates) for t in dataset.trajectories
     ]
     pnads = learn_strips_operators(dataset.trajectories,
                                    train_tasks,
@@ -126,10 +122,8 @@ def test_oracle_strips_learner():
     assert not action.get_option().terminal(next_state)
     truncated_traj = LowLevelTrajectory([state, next_state], [action])
     dataset = Dataset([truncated_traj])
-    ground_atom_dataset = utils.create_ground_atom_dataset(
-        dataset.trajectories, env.predicates)
     segmented_trajs = [
-        segment_trajectory(traj) for traj in ground_atom_dataset
+        segment_trajectory(t, env.predicates) for t in dataset.trajectories
     ]
     assert len(segmented_trajs[0]) == 0
     pnads = learn_strips_operators(dataset.trajectories,
@@ -149,6 +143,6 @@ def test_oracle_strips_learner():
         "max_num_steps_option_rollout": 1,
     })
     segmented_trajs = [
-        segment_trajectory(traj) for traj in ground_atom_dataset
+        segment_trajectory(t, env.predicates) for t in dataset.trajectories
     ]
     assert len(segmented_trajs[0]) == 1  # was 0 before

--- a/tests/nsrt_learning/test_option_learning.py
+++ b/tests/nsrt_learning/test_option_learning.py
@@ -42,13 +42,11 @@ def test_known_options_option_learner():
     train_tasks = [t.task for t in env.get_train_tasks()]
     dataset = create_demo_replay_data(env, train_tasks,
                                       get_gt_options(env.get_name()))
-    ground_atom_dataset = utils.create_ground_atom_dataset(
-        dataset.trajectories, env.predicates)
-    for traj, _ in ground_atom_dataset:
+    for traj in dataset.trajectories:
         for act in traj.actions:
             assert act.has_option()
     segmented_trajs = [
-        segment_trajectory(traj) for traj in ground_atom_dataset
+        segment_trajectory(t, env.predicates) for t in dataset.trajectories
     ]
     pnads = learn_strips_operators(dataset.trajectories,
                                    train_tasks,
@@ -87,13 +85,11 @@ def test_oracle_option_learner_cover():
     env = create_new_env("cover")
     train_tasks = [t.task for t in env.get_train_tasks()]
     dataset = create_demo_replay_data(env, train_tasks, known_options=set())
-    ground_atom_dataset = utils.create_ground_atom_dataset(
-        dataset.trajectories, env.predicates)
-    for traj, _ in ground_atom_dataset:
+    for traj in dataset.trajectories:
         for act in traj.actions:
             assert not act.has_option()
     segmented_trajs = [
-        segment_trajectory(traj) for traj in ground_atom_dataset
+        segment_trajectory(t, env.predicates) for t in dataset.trajectories
     ]
     pnads = learn_strips_operators(dataset.trajectories,
                                    train_tasks,
@@ -137,13 +133,11 @@ def test_oracle_option_learner_blocks():
     env = create_new_env("blocks")
     train_tasks = [t.task for t in env.get_train_tasks()]
     dataset = create_demo_replay_data(env, train_tasks, known_options=set())
-    ground_atom_dataset = utils.create_ground_atom_dataset(
-        dataset.trajectories, env.predicates)
-    for traj, _ in ground_atom_dataset:
+    for traj in dataset.trajectories:
         for act in traj.actions:
             assert not act.has_option()
     segmented_trajs = [
-        segment_trajectory(traj) for traj in ground_atom_dataset
+        segment_trajectory(t, env.predicates) for t in dataset.trajectories
     ]
     pnads = learn_strips_operators(dataset.trajectories,
                                    train_tasks,

--- a/tests/test_predicate_search_score_functions.py
+++ b/tests/test_predicate_search_score_functions.py
@@ -245,11 +245,12 @@ def test_relaxation_energy_score_function():
 
         def evaluate(self,
                      candidate_predicates: FrozenSet[Predicate]) -> float:
+            preds = candidate_predicates | self._initial_predicates
             pruned_atom_data = utils.prune_ground_atom_dataset(
-                self._atom_dataset,
-                candidate_predicates | self._initial_predicates)
+                self._atom_dataset, preds)
             segmented_trajs = [
-                segment_trajectory(traj) for traj in pruned_atom_data
+                segment_trajectory(ll_traj, set(preds), atom_seq)
+                for ll_traj, atom_seq in pruned_atom_data
             ]
             low_level_trajs = [ll_traj for ll_traj, _ in pruned_atom_data]
             # This is the part that we are overriding, to force no successors.
@@ -277,11 +278,12 @@ def test_relaxation_energy_score_function():
 
         def evaluate(self,
                      candidate_predicates: FrozenSet[Predicate]) -> float:
+            preds = candidate_predicates | self._initial_predicates
             pruned_atom_data = utils.prune_ground_atom_dataset(
-                self._atom_dataset,
-                candidate_predicates | self._initial_predicates)
+                self._atom_dataset, preds)
             segmented_trajs = [
-                segment_trajectory(traj) for traj in pruned_atom_data
+                segment_trajectory(ll_traj, set(preds), atom_seq)
+                for ll_traj, atom_seq in pruned_atom_data
             ]
             low_level_trajs = [ll_traj for ll_traj, _ in pruned_atom_data]
             # This is the part that we are overriding, to force no successors.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,6 +33,7 @@ def test_count_positives_for_ops(max_groundings, exp_num_true, exp_num_false):
     plate_type = Type("plate_type", ["feat1"])
     on = Predicate("On", [cup_type, plate_type], lambda s, o: True)
     not_on = Predicate("NotOn", [cup_type, plate_type], lambda s, o: True)
+    preds = {on, not_on}
     cup_var = cup_type("?cup")
     plate_var = plate_type("?plate")
     parameters = [cup_var, plate_var]
@@ -69,7 +70,8 @@ def test_count_positives_for_ops(max_groundings, exp_num_true, exp_num_false):
                                                set()]),
     ]
     segments = [
-        seg for traj in pruned_atom_data for seg in segment_trajectory(traj)
+        seg for ll_traj, atom_seq in pruned_atom_data
+        for seg in segment_trajectory(ll_traj, preds, atom_seq)
     ]
 
     num_true, num_false, _, _ = utils.count_positives_for_ops(


### PR DESCRIPTION
users who want to `--load_atoms` later will now need to `--save_atoms`. default is to not save atoms because the ground atom trajectories get quite large for environments that have long-horizon options (e.g. kitchen), leading to both memory and time issues.