### PR TITLE
add optional impossible NSRT to regional bumpy cover environment

### DIFF
--- a/predicators/ground_truth_models/cover/nsrts.py
+++ b/predicators/ground_truth_models/cover/nsrts.py
@@ -5,6 +5,7 @@ from typing import Dict, Sequence, Set
 
 import numpy as np
 
+from predicators import utils
 from predicators.ground_truth_models import GroundTruthNSRTFactory
 from predicators.settings import CFG
 from predicators.structs import NSRT, Array, GroundAtom, LiftedAtom, Object, \
@@ -525,5 +526,35 @@ class RegionalBumpyCoverGroundTruthNSRTFactory(GroundTruthNSRTFactory):
                                    set(), option, option_vars,
                                    place_on_bumpy_sampler)
         nsrts.add(place_on_bumpy_nsrt)
+
+        # Optionally include an NSRT that appears to directly pick and place
+        # blocks onto targets, but actually fails completely in practice.
+        if CFG.regional_bumpy_cover_include_impossible_nsrt:
+
+            ImpossiblePickPlace = options["ImpossiblePickPlace"]
+
+            parameters = [block, target]
+            preconditions = {
+                LiftedAtom(HandEmpty, []),
+                LiftedAtom(Clear, [target]),
+            }
+            add_effects = {
+                LiftedAtom(HandEmpty, []),
+                LiftedAtom(InSmoothRegion, [block]),
+                LiftedAtom(Covers, [block, target]),
+            }
+            delete_effects = {
+                LiftedAtom(HandEmpty, []),
+                LiftedAtom(InBumpyRegion, [block])
+            }
+            option = ImpossiblePickPlace
+            option_vars = []
+
+            impossible_pick_place_nsrt = NSRT("ImpossiblePickPlace",
+                                              parameters, preconditions,
+                                              add_effects, delete_effects,
+                                              set(), option, option_vars,
+                                              utils.null_sampler)
+            nsrts.add(impossible_pick_place_nsrt)
 
         return nsrts

--- a/predicators/ground_truth_models/cover/nsrts.py
+++ b/predicators/ground_truth_models/cover/nsrts.py
@@ -548,7 +548,7 @@ class RegionalBumpyCoverGroundTruthNSRTFactory(GroundTruthNSRTFactory):
                 LiftedAtom(InBumpyRegion, [block])
             }
             option = ImpossiblePickPlace
-            option_vars = []
+            option_vars = parameters
 
             impossible_pick_place_nsrt = NSRT("ImpossiblePickPlace",
                                               parameters, preconditions,

--- a/predicators/ground_truth_models/cover/options.py
+++ b/predicators/ground_truth_models/cover/options.py
@@ -147,7 +147,9 @@ class RegionalBumpyCoverGroundTruthOptionFactory(GroundTruthOptionFactory):
                 raise utils.OptionExecutionFailure("Policy impossible.")
 
             ImpossiblePickPlace = utils.SingletonParameterizedOption(
-                "ImpossiblePickPlace", _impossible_policy)
+                "ImpossiblePickPlace",
+                _impossible_policy,
+                types=[block_type, target_type])
             options.add(ImpossiblePickPlace)
 
         return options

--- a/predicators/ground_truth_models/cover/options.py
+++ b/predicators/ground_truth_models/cover/options.py
@@ -101,40 +101,56 @@ class RegionalBumpyCoverGroundTruthOptionFactory(GroundTruthOptionFactory):
         block_type = types["block"]
         target_type = types["target"]
 
+        options: Set[ParameterizedOption] = set()
+
         PickFromSmooth = utils.SingletonParameterizedOption("PickFromSmooth",
                                                             _policy,
                                                             types=[block_type],
                                                             params_space=Box(
                                                                 0, 1, (1, )))
+        options.add(PickFromSmooth)
 
         PickFromBumpy = utils.SingletonParameterizedOption("PickFromBumpy",
                                                            _policy,
                                                            types=[block_type],
                                                            params_space=Box(
                                                                0, 1, (1, )))
+        options.add(PickFromBumpy)
 
         PickFromTarget = utils.SingletonParameterizedOption(
             "PickFromTarget",
             _policy,
             types=[block_type, target_type],
             params_space=Box(0, 1, (1, )))
+        options.add(PickFromTarget)
 
         PlaceOnTarget = utils.SingletonParameterizedOption(
             "PlaceOnTarget",
             _policy,
             types=[block_type, target_type],
             params_space=Box(0, 1, (1, )))
+        options.add(PlaceOnTarget)
 
         PlaceOnBumpy = utils.SingletonParameterizedOption("PlaceOnBumpy",
                                                           _policy,
                                                           types=[block_type],
                                                           params_space=Box(
                                                               0, 1, (1, )))
+        options.add(PlaceOnBumpy)
 
-        return {
-            PickFromSmooth, PickFromBumpy, PickFromTarget, PlaceOnTarget,
-            PlaceOnBumpy
-        }
+        if CFG.regional_bumpy_cover_include_impossible_nsrt:
+
+            def _impossible_policy(state: State, memory: Dict,
+                                   objects: Sequence[Object],
+                                   params: Array) -> Action:
+                del state, memory, objects, params  # unused
+                raise utils.OptionExecutionFailure("Policy impossible.")
+
+            ImpossiblePickPlace = utils.SingletonParameterizedOption(
+                "ImpossiblePickPlace", _impossible_policy)
+            options.add(ImpossiblePickPlace)
+
+        return options
 
 
 class CoverTypedOptionsGroundTruthOptionFactory(GroundTruthOptionFactory):

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -63,6 +63,9 @@ class GlobalSettings:
     bumpy_cover_bumpy_region_start = 0.8
     bumpy_cover_init_bumpy_prob = 0.25
 
+    # regional bumpy cover env parameters
+    regional_bumpy_cover_include_impossible_nsrt = False
+
     # blocks env parameters
     blocks_num_blocks_train = [3, 4]
     blocks_num_blocks_test = [5, 6]

--- a/tests/envs/test_cover.py
+++ b/tests/envs/test_cover.py
@@ -5,6 +5,8 @@ import pytest
 from gym.spaces import Box
 
 from predicators import utils
+from predicators.approaches import ApproachFailure
+from predicators.approaches.oracle_approach import OracleApproach
 from predicators.envs import create_new_env
 from predicators.envs.cover import CoverEnvRegrasp, CoverEnvTypedOptions, \
     CoverMultistepOptions
@@ -733,3 +735,30 @@ def test_regional_bumpy_cover_env():
     rng = np.random.default_rng(123)
     option = ground_nsrt.sample_option(held_state, set(), rng)
     assert option.params[0] > 0.5
+
+    # Test that when the impossible NSRT is included, the planner tries to use
+    # it, but then fails with an option execution error.
+    utils.reset_config({
+        "env": env_name,
+        "regional_bumpy_cover_include_impossible_nsrt": True,
+        "approach": "oracle",
+        "bilevel_plan_without_sim": True,
+        "num_train_tasks": 0,
+        "num_test_tasks": 5,
+    })
+    env = create_new_env(env_name)
+    options = get_gt_options(env.get_name())
+    assert len(options) == 6
+    nsrts = get_gt_nsrts(env.get_name(), env.predicates, options)
+    assert len(nsrts) == 6
+    test_tasks = [t.task for t in env.get_test_tasks()]
+    approach = OracleApproach(env.predicates,
+                              options,
+                              env.types,
+                              env.action_space,
+                              train_tasks=[])
+    for task in test_tasks:
+        policy = approach.solve(task, 500)
+        with pytest.raises(ApproachFailure) as e:
+            policy(task.init)
+        assert "Policy impossible" in str(e)


### PR DESCRIPTION
upcoming changes to the active learning approach should realize that the NSRT is impossible and opt not to use it

command that we can use to test future improvements:
```
python predicators/main.py --env regional_bumpy_cover --approach active_sampler_learning --experiment_id regional_bumpy_cover-main_explore --debug --strips_learner oracle --sampler_learner oracle --bilevel_plan_without_sim True --max_initial_demos 0 --sampler_mlp_classifier_max_itr 100000 --mlp_classifier_balance_data False --pytorch_train_print_every 10000 --active_sampler_learning_model myopic_classifier_mlp --active_sampler_learning_use_teacher False --online_nsrt_learning_requests_per_cycle 5 --num_online_learning_cycles 10 --active_sampler_learning_explore_length_base 10000 --explorer active_sampler --active_sampler_explore_scorer default --bumpy_cover_num_bumps 3 --bumpy_cover_spaces_per_bump 3 --bumpy_cover_init_bumpy_prob 1.0 --cover_num_blocks 10 --cover_block_widths [0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01] --cover_num_targets 10 --cover_target_widths [0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008] --seed 456 --regional_bumpy_cover_include_impossible_nsrt True
```