### PR TITLE
Adding a replay buffer to Maple Q Training

### DIFF
--- a/predicators/approaches/maple_q_approach.py
+++ b/predicators/approaches/maple_q_approach.py
@@ -145,7 +145,7 @@ class MapleQApproach(OnlineNSRTLearningApproach):
         # Update the data using the updated self._segmented_trajs.
         self._update_maple_data()
         # Re-learn Q function.
-        self._q_function.train(
+        self._q_function.train_q_function(
             CFG.active_sampler_learning_per_cycle_training_iters)
         # Save the things we need other than the NSRTs, which were already
         # saved in the above call to self._learn_nsrts()
@@ -177,7 +177,7 @@ class MapleQApproach(OnlineNSRTLearningApproach):
                 ns = segment.states[-1]
                 reward = 1.0 if goal.issubset(segment.final_atoms) else 0.0
                 terminal = reward > 0 or seg_i == len(segmented_traj) - 1
-                self._q_function.add_data_to_replay_buffer(
+                self._q_function.add_datum_to_replay_buffer(
                     (s, goal, o, ns, reward, terminal))
 
     def get_interaction_requests(self) -> List[InteractionRequest]:

--- a/predicators/approaches/maple_q_approach.py
+++ b/predicators/approaches/maple_q_approach.py
@@ -42,7 +42,8 @@ class MapleQApproach(OnlineNSRTLearningApproach):
         self._maple_data: MapleQData = []
         self._last_seen_segment_traj_idx = -1
 
-        # Store the Q function.
+        # Store the Q function. Note that this implicitly
+        # contains a replay buffer.
         self._q_function = MapleQFunction(
             seed=CFG.seed,
             hid_sizes=CFG.mlp_regressor_hid_sizes,

--- a/predicators/approaches/maple_q_approach.py
+++ b/predicators/approaches/maple_q_approach.py
@@ -50,7 +50,6 @@ class MapleQApproach(OnlineNSRTLearningApproach):
             clip_gradients=CFG.mlp_regressor_clip_gradients,
             clip_value=CFG.mlp_regressor_gradient_clip_value,
             learning_rate=CFG.learning_rate,
-            rng=self._rng,
             weight_decay=CFG.weight_decay,
             use_torch_gpu=CFG.use_torch_gpu,
             train_print_every=CFG.pytorch_train_print_every,

--- a/predicators/approaches/maple_q_approach.py
+++ b/predicators/approaches/maple_q_approach.py
@@ -50,6 +50,7 @@ class MapleQApproach(OnlineNSRTLearningApproach):
             clip_gradients=CFG.mlp_regressor_clip_gradients,
             clip_value=CFG.mlp_regressor_gradient_clip_value,
             learning_rate=CFG.learning_rate,
+            rng=self._rng,
             weight_decay=CFG.weight_decay,
             use_torch_gpu=CFG.use_torch_gpu,
             train_print_every=CFG.pytorch_train_print_every,

--- a/predicators/approaches/maple_q_approach.py
+++ b/predicators/approaches/maple_q_approach.py
@@ -146,7 +146,7 @@ class MapleQApproach(OnlineNSRTLearningApproach):
         self._update_maple_data()
         # Re-learn Q function.
         self._q_function.train_q_function(
-            CFG.active_sampler_learning_per_cycle_training_iters)
+            CFG.active_sampler_learning_per_cycle_num_batches_to_train)
         # Save the things we need other than the NSRTs, which were already
         # saved in the above call to self._learn_nsrts()
         save_path = utils.get_approach_save_path_str()

--- a/predicators/approaches/maple_q_approach.py
+++ b/predicators/approaches/maple_q_approach.py
@@ -145,8 +145,7 @@ class MapleQApproach(OnlineNSRTLearningApproach):
         # Update the data using the updated self._segmented_trajs.
         self._update_maple_data()
         # Re-learn Q function.
-        self._q_function.train_q_function(
-            CFG.active_sampler_learning_per_cycle_num_batches_to_train)
+        self._q_function.train_q_function()
         # Save the things we need other than the NSRTs, which were already
         # saved in the above call to self._learn_nsrts()
         save_path = utils.get_approach_save_path_str()

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -1251,8 +1251,7 @@ def _single_batch_generator(
 def _train_pytorch_model(model: nn.Module,
                          loss_fn: Callable[[Tensor, Tensor], Tensor],
                          optimizer: optim.Optimizer,
-                         batch_generator: Iterator[Tuple[Tensor,
-                                                               Tensor]],
+                         batch_generator: Iterator[Tuple[Tensor, Tensor]],
                          max_train_iters: MaxTrainIters,
                          dataset_size: int,
                          device: torch.device,
@@ -1532,8 +1531,9 @@ class MapleQFunction(MLPRegressor):
         # number of iterations. It will also normalize all the data.
         self.fit(X_arr, Y_arr)
 
-    def minibatch_generator(self, tensor_X: Tensor, tensor_Y: Tensor,
-                            batch_size: int) -> Tuple[Tensor, Tensor]:
+    def minibatch_generator(
+            self, tensor_X: Tensor, tensor_Y: Tensor,
+            batch_size: int) -> Iterator[Tuple[Tensor, Tensor]]:
         """Assuming both tensor_X and tensor_Y are 2D with the batch dimension
         first, sample a minibatch of size batch_size to train on."""
         train_dataset = TensorDataset(tensor_X, tensor_Y)

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -1314,7 +1314,7 @@ class ReplayBuffer(Generic[_D]):
     This data will be used for model training.
     """
 
-    def __init__(self, datum_size: int, rng: np.random.Generator) -> None:
+    def __init__(self, rng: np.random.Generator) -> None:
         self._rng = rng
 
     @abc.abstractmethod
@@ -1331,8 +1331,9 @@ class ReplayBuffer(Generic[_D]):
 class FixedSizeReplayBuffer(ReplayBuffer):
 
     def __init__(self, max_buffer_size: int,
-                 sample_with_replacement: bool) -> None:
-        super.__init__()
+                 sample_with_replacement: bool,
+                 rng: np.random.Generator) -> None:
+        super.__init__(rng)
         self._max_buffer_size = max_buffer_size
         self._buffer: List[_D] = []
         self._sample_with_replacement = sample_with_replacement
@@ -1389,6 +1390,7 @@ class MapleQFunction(MLPRegressor):
                  clip_gradients: bool,
                  clip_value: float,
                  learning_rate: float,
+                 rng: np.random.Generator,
                  weight_decay: float = 0,
                  use_torch_gpu: bool = False,
                  train_print_every: int = 1000,
@@ -1415,7 +1417,8 @@ class MapleQFunction(MLPRegressor):
         self._num_ground_nsrts = 0
         self._replay_buffer: ReplayBuffer[MapleQData] = FixedSizeReplayBuffer(
             max_buffer_size=self._replay_buffer_max_size,
-            sample_with_replacement=self._replay_buffer_sample_with_replacement
+            sample_with_replacement=self._replay_buffer_sample_with_replacement,
+            rng=rng
         )
 
     def set_grounding(self, objects: Set[Object],

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -10,13 +10,14 @@ import tempfile
 from dataclasses import dataclass
 from typing import Any, Callable, Collection, Dict, FrozenSet, Iterator, \
     List, Optional, Sequence, Set, Tuple
+from typing import TypeVar
 from typing import Type as TypingType
 
 import numpy as np
 import torch
 import torch.nn.functional as F
 from scipy.stats import beta as BetaRV
-from sklearn.base import BaseEstimator
+from sklearn.base import BaseEstimatorTypeVar
 from sklearn.neighbors import \
     KNeighborsClassifier as _SKLearnKNeighborsClassifier
 from sklearn.neighbors import \
@@ -1302,6 +1303,8 @@ def _train_pytorch_model(model: nn.Module,
     logging.info(f"Loaded best model with loss: {best_loss:.5f}")
     return best_loss
 
+
+# TODO: Implement a replay buffer that takes in an Array type
 
 # Low-level state, current high-level (predicate) state, option taken,
 # next low-level state, reward, done.

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -1333,7 +1333,7 @@ class FixedSizeReplayBuffer(ReplayBuffer):
     def __init__(self, max_buffer_size: int,
                  sample_with_replacement: bool,
                  rng: np.random.Generator) -> None:
-        super.__init__(rng)
+        super().__init__(rng)
         self._max_buffer_size = max_buffer_size
         self._buffer: List[_D] = []
         self._sample_with_replacement = sample_with_replacement

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -1538,10 +1538,11 @@ class MapleQFunction(MLPRegressor):
         """Assuming both tensor_X and tensor_Y are 2D with the batch dimension
         first, sample a minibatch of size batch_size to train on."""
         train_dataset = TensorDataset(tensor_X, tensor_Y)
-        train_dataloader = DataLoader(train_dataset,
-                                    #   batch_size=batch_size,
-                                      batch_size=tensor_X.shape[0],
-                                      shuffle=True)
+        train_dataloader = DataLoader(
+            train_dataset,
+            #   batch_size=batch_size,
+            batch_size=tensor_X.shape[0],
+            shuffle=True)
         iterable_loader = iter(train_dataloader)
         while True:
             try:

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -1368,6 +1368,9 @@ class FixedSizeReplayBuffer(ReplayBuffer):
             or batch_size > len(self._buffer)).tolist()
         return random_batch
 
+    def __len__(self):
+        return len(self._buffer)
+
 
 # Low-level state, current high-level (predicate) state, option taken,
 # next low-level state, reward, done.
@@ -1472,7 +1475,11 @@ class MapleQFunction(MLPRegressor):
             self._ordered_frozen_goals
         ) + self._num_ground_nsrts + self._max_num_params
         Y_size = 1
-        for t in range(iters):
+
+        if len(self._replay_buffer) == 0:
+            return
+
+        for _ in range(iters):
             # Sample a random batch of data from the replay buffer.
             curr_batch = self._replay_buffer.sample_random_batch(
                 CFG.active_sampler_learning_batch_size)

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -1327,7 +1327,6 @@ class MapleQFunction(MLPRegressor):
                  clip_gradients: bool,
                  clip_value: float,
                  learning_rate: float,
-                 rng: np.random.Generator,
                  weight_decay: float = 0,
                  use_torch_gpu: bool = False,
                  train_print_every: int = 1000,

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Collection, Dict, FrozenSet, Generic, \
     Iterator, List, Optional, Sequence, Set, Tuple
 from typing import Type as TypingType
-from typing import TypeVar, Union
+from typing import TypeVar
 
 import numpy as np
 import torch
@@ -1345,6 +1345,7 @@ class FixedSizeReplayBuffer(ReplayBuffer, Generic[_D]):
     def __init__(self, max_buffer_size: int, sample_with_replacement: bool,
                  rng: np.random.Generator) -> None:
         super().__init__(rng)
+        assert max_buffer_size > 0
         self._max_buffer_size = max_buffer_size
         self._buffer: List[_D] = []
         self._sample_with_replacement = sample_with_replacement
@@ -1544,6 +1545,7 @@ class MapleQFunction(MLPRegressor):
         while True:
             try:
                 X_batch, Y_batch = next(iterable_loader)
+            # pylint:disable=stop-iteration-return
             except StopIteration:
                 iterable_loader = iter(train_dataloader)
                 X_batch, Y_batch = next(iterable_loader)

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -1566,8 +1566,9 @@ class MapleQFunction(MLPRegressor):
             self._device)
         tensor_Y = torch.from_numpy(np.array(Y, dtype=np.float32)).to(
             self._device)
-        batch_generator = self.minibatch_generator(
-            tensor_X, tensor_Y, CFG.active_sampler_learning_batch_size)
+        # batch_generator = self.minibatch_generator(
+        #     tensor_X, tensor_Y, CFG.active_sampler_learning_batch_size)
+        batch_generator = _single_batch_generator(tensor_X, tensor_Y)
         # Run training.
         _train_pytorch_model(self,
                              loss_fn,

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -17,6 +17,7 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 from scipy.stats import beta as BetaRV
+from sklearn.base import BaseEstimator
 from sklearn.neighbors import \
     KNeighborsClassifier as _SKLearnKNeighborsClassifier
 from sklearn.neighbors import \

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -1539,7 +1539,8 @@ class MapleQFunction(MLPRegressor):
         first, sample a minibatch of size batch_size to train on."""
         train_dataset = TensorDataset(tensor_X, tensor_Y)
         train_dataloader = DataLoader(train_dataset,
-                                      batch_size=batch_size,
+                                    #   batch_size=batch_size,
+                                      batch_size=tensor_X.shape[0],
                                       shuffle=True)
         iterable_loader = iter(train_dataloader)
         while True:

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -1296,7 +1296,6 @@ def _train_pytorch_model(model: nn.Module,
         if itr == max_iters:
             break
         itr += 1
-
     # Load best model.
     model.load_state_dict(torch.load(model_name,
                                      map_location='cpu'))  # type: ignore

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -1323,7 +1323,7 @@ class ReplayBuffer(Generic[_D]):
         raise NotImplementedError("Subclasses should override!")
 
     @abc.abstractmethod
-    def random_batch(self, batch_size: int) -> Array:
+    def sample_random_batch(self, batch_size: int) -> Array:
         """Return a batch of a specified size."""
         raise NotImplementedError("Subclasses should override!")
 
@@ -1474,7 +1474,7 @@ class MapleQFunction(MLPRegressor):
         Y_size = 1
         for t in range(iters):
             # Sample a random batch of data from the replay buffer.
-            curr_batch = self._replay_buffer.random_batch(
+            curr_batch = self._replay_buffer.sample_random_batch(
                 CFG.active_sampler_learning_batch_size)
             X_arr = np.zeros((CFG.active_sampler_learning_batch_size, X_size))
             Y_arr = np.zeros((CFG.active_sampler_learning_batch_size, Y_size))

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -17,7 +17,6 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 from scipy.stats import beta as BetaRV
-from sklearn.base import BaseEstimatorTypeVar
 from sklearn.neighbors import \
     KNeighborsClassifier as _SKLearnKNeighborsClassifier
 from sklearn.neighbors import \

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -1538,10 +1538,9 @@ class MapleQFunction(MLPRegressor):
         """Assuming both tensor_X and tensor_Y are 2D with the batch dimension
         first, sample a minibatch of size batch_size to train on."""
         train_dataset = TensorDataset(tensor_X, tensor_Y)
-        train_dataloader = DataLoader(
-            train_dataset,
-              batch_size=batch_size,
-            shuffle=True)
+        train_dataloader = DataLoader(train_dataset,
+                                      batch_size=batch_size,
+                                      shuffle=True)
         iterable_loader = iter(train_dataloader)
         while True:
             try:

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -1540,8 +1540,7 @@ class MapleQFunction(MLPRegressor):
         train_dataset = TensorDataset(tensor_X, tensor_Y)
         train_dataloader = DataLoader(
             train_dataset,
-            #   batch_size=batch_size,
-            batch_size=tensor_X.shape[0],
+              batch_size=batch_size,
             shuffle=True)
         iterable_loader = iter(train_dataloader)
         while True:
@@ -1566,9 +1565,9 @@ class MapleQFunction(MLPRegressor):
             self._device)
         tensor_Y = torch.from_numpy(np.array(Y, dtype=np.float32)).to(
             self._device)
-        # batch_generator = self.minibatch_generator(
-        #     tensor_X, tensor_Y, CFG.active_sampler_learning_batch_size)
-        batch_generator = _single_batch_generator(tensor_X, tensor_Y)
+        batch_generator = self.minibatch_generator(
+            tensor_X, tensor_Y, CFG.active_sampler_learning_batch_size)
+        # batch_generator = _single_batch_generator(tensor_X, tensor_Y)
         # Run training.
         _train_pytorch_model(self,
                              loss_fn,

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -543,6 +543,7 @@ class GlobalSettings:
     active_sampler_learning_num_ensemble_members = 10
     active_sampler_learning_exploration_sample_strategy = "epsilon_greedy"
     active_sampler_learning_exploration_epsilon = 0.5
+    active_sampler_learning_replay_buffer_size = 1000000
 
     # skill competence model parameters
     skill_competence_model = "optimistic"

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -543,7 +543,9 @@ class GlobalSettings:
     active_sampler_learning_num_ensemble_members = 10
     active_sampler_learning_exploration_sample_strategy = "epsilon_greedy"
     active_sampler_learning_exploration_epsilon = 0.5
+    active_sampler_learning_per_cycle_training_iters = 1000
     active_sampler_learning_replay_buffer_size = 1000000
+    active_sampler_learning_batch_size = 64
 
     # skill competence model parameters
     skill_competence_model = "optimistic"

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -543,7 +543,6 @@ class GlobalSettings:
     active_sampler_learning_num_ensemble_members = 10
     active_sampler_learning_exploration_sample_strategy = "epsilon_greedy"
     active_sampler_learning_exploration_epsilon = 0.5
-    active_sampler_learning_per_cycle_num_batches_to_train = 30
     active_sampler_learning_replay_buffer_size = 1000000
     active_sampler_learning_batch_size = 64
 

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -543,7 +543,7 @@ class GlobalSettings:
     active_sampler_learning_num_ensemble_members = 10
     active_sampler_learning_exploration_sample_strategy = "epsilon_greedy"
     active_sampler_learning_exploration_epsilon = 0.5
-    active_sampler_learning_per_cycle_training_iters = 1000
+    active_sampler_learning_per_cycle_num_batches_to_train = 30
     active_sampler_learning_replay_buffer_size = 1000000
     active_sampler_learning_batch_size = 64
 

--- a/scripts/configs/active_sampler_learning.yaml
+++ b/scripts/configs/active_sampler_learning.yaml
@@ -30,6 +30,7 @@ APPROACHES:
     FLAGS:
       explorer: "maple_q"
       mlp_regressor_max_itr: 100000
+      active_sampler_learning_batch_size: 1024
 ENVS:
   tiny_grid_row:
     NAME: "grid_row"

--- a/scripts/configs/online_rl_cover.yaml
+++ b/scripts/configs/online_rl_cover.yaml
@@ -6,17 +6,17 @@ APPROACHES:
     FLAGS:
       explorer: "maple_q"
 ENVS:
-  discrete_regional_bumpy_cover:
-    NAME: "regional_bumpy_cover"
-    FLAGS:
-      regional_bumpy_cover_include_impossible_nsrt: "True"  # NOTE
-      bumpy_cover_init_bumpy_prob: 0.0  # NOTE
-      bumpy_cover_num_bumps: 3
-      bumpy_cover_spaces_per_bump: 3
-      cover_num_blocks: 1
-      cover_block_widths: '[0.01]'
-      cover_num_targets: 1
-      cover_target_widths: '[0.008]'
+  # discrete_regional_bumpy_cover:
+  #   NAME: "regional_bumpy_cover"
+  #   FLAGS:
+  #     regional_bumpy_cover_include_impossible_nsrt: "True"  # NOTE
+  #     bumpy_cover_init_bumpy_prob: 0.0  # NOTE
+  #     bumpy_cover_num_bumps: 3
+  #     bumpy_cover_spaces_per_bump: 3
+  #     cover_num_blocks: 1
+  #     cover_block_widths: '[0.01]'
+  #     cover_num_targets: 1
+  #     cover_target_widths: '[0.008]'
   continuous_regional_bumpy_cover:
     NAME: "regional_bumpy_cover"
     FLAGS:

--- a/scripts/configs/online_rl_cover.yaml
+++ b/scripts/configs/online_rl_cover.yaml
@@ -6,17 +6,17 @@ APPROACHES:
     FLAGS:
       explorer: "maple_q"
 ENVS:
-  # discrete_regional_bumpy_cover:
-  #   NAME: "regional_bumpy_cover"
-  #   FLAGS:
-  #     regional_bumpy_cover_include_impossible_nsrt: "True"  # NOTE
-  #     bumpy_cover_init_bumpy_prob: 0.0  # NOTE
-  #     bumpy_cover_num_bumps: 3
-  #     bumpy_cover_spaces_per_bump: 3
-  #     cover_num_blocks: 1
-  #     cover_block_widths: '[0.01]'
-  #     cover_num_targets: 1
-  #     cover_target_widths: '[0.008]'
+  discrete_regional_bumpy_cover:
+    NAME: "regional_bumpy_cover"
+    FLAGS:
+      regional_bumpy_cover_include_impossible_nsrt: "True"  # NOTE
+      bumpy_cover_init_bumpy_prob: 0.0  # NOTE
+      bumpy_cover_num_bumps: 3
+      bumpy_cover_spaces_per_bump: 3
+      cover_num_blocks: 1
+      cover_block_widths: '[0.01]'
+      cover_num_targets: 1
+      cover_target_widths: '[0.008]'
   continuous_regional_bumpy_cover:
     NAME: "regional_bumpy_cover"
     FLAGS:
@@ -28,17 +28,17 @@ ENVS:
       cover_block_widths: '[0.01]'
       cover_num_targets: 1
       cover_target_widths: '[0.008]'
-  hybrid_regional_bumpy_cover:
-    NAME: "regional_bumpy_cover"
-    FLAGS:
-      regional_bumpy_cover_include_impossible_nsrt: "True"  # NOTE
-      bumpy_cover_init_bumpy_prob: 1.0  # NOTE
-      bumpy_cover_num_bumps: 3
-      bumpy_cover_spaces_per_bump: 3
-      cover_num_blocks: 1
-      cover_block_widths: '[0.01]'
-      cover_num_targets: 1
-      cover_target_widths: '[0.008]'
+  # hybrid_regional_bumpy_cover:
+  #   NAME: "regional_bumpy_cover"
+  #   FLAGS:
+  #     regional_bumpy_cover_include_impossible_nsrt: "True"  # NOTE
+  #     bumpy_cover_init_bumpy_prob: 1.0  # NOTE
+  #     bumpy_cover_num_bumps: 3
+  #     bumpy_cover_spaces_per_bump: 3
+  #     cover_num_blocks: 1
+  #     cover_block_widths: '[0.01]'
+  #     cover_num_targets: 1
+  #     cover_target_widths: '[0.008]'
 ARGS:
   - "debug"
 FLAGS:

--- a/scripts/configs/online_rl_cover.yaml
+++ b/scripts/configs/online_rl_cover.yaml
@@ -53,4 +53,4 @@ FLAGS:
   max_num_steps_interaction_request: 5
   horizon: 2  # NOTE, otherwise too easy
 START_SEED: 456
-NUM_SEEDS: 1 #5
+NUM_SEEDS: 5

--- a/scripts/configs/online_rl_cover.yaml
+++ b/scripts/configs/online_rl_cover.yaml
@@ -5,7 +5,8 @@ APPROACHES:
     NAME: "maple_q"
     FLAGS:
       explorer: "maple_q"
-      # mlp_regressor_max_itr: 640000
+      mlp_regressor_max_itr: 640000
+      active_sampler_learning_batch_size: 512
 ENVS:
   # discrete_regional_bumpy_cover:
   #   NAME: "regional_bumpy_cover"

--- a/scripts/configs/online_rl_cover.yaml
+++ b/scripts/configs/online_rl_cover.yaml
@@ -6,39 +6,39 @@ APPROACHES:
     FLAGS:
       explorer: "maple_q"
 ENVS:
-  discrete_regional_bumpy_cover:
+  # discrete_regional_bumpy_cover:
+  #   NAME: "regional_bumpy_cover"
+  #   FLAGS:
+  #     regional_bumpy_cover_include_impossible_nsrt: "True"  # NOTE
+  #     bumpy_cover_init_bumpy_prob: 0.0  # NOTE
+  #     bumpy_cover_num_bumps: 3
+  #     bumpy_cover_spaces_per_bump: 3
+  #     cover_num_blocks: 1
+  #     cover_block_widths: '[0.01]'
+  #     cover_num_targets: 1
+  #     cover_target_widths: '[0.008]'
+  continuous_regional_bumpy_cover:
     NAME: "regional_bumpy_cover"
     FLAGS:
-      regional_bumpy_cover_include_impossible_nsrt: "True"  # NOTE
-      bumpy_cover_init_bumpy_prob: 0.0  # NOTE
+      regional_bumpy_cover_include_impossible_nsrt: "False"  # NOTE
+      bumpy_cover_init_bumpy_prob: 1.0  # NOTE
       bumpy_cover_num_bumps: 3
       bumpy_cover_spaces_per_bump: 3
       cover_num_blocks: 1
       cover_block_widths: '[0.01]'
       cover_num_targets: 1
       cover_target_widths: '[0.008]'
-  # continuous_regional_bumpy_cover:
-  #   NAME: "regional_bumpy_cover"
-  #   FLAGS:
-  #     regional_bumpy_cover_include_impossible_nsrt: "False"  # NOTE
-  #     bumpy_cover_init_bumpy_prob: 1.0  # NOTE
-  #     bumpy_cover_num_bumps: 3
-  #     bumpy_cover_spaces_per_bump: 3
-  #     cover_num_blocks: 1
-  #     cover_block_widths: '[0.01]'
-  #     cover_num_targets: 1
-  #     cover_target_widths: '[0.008]'
-  # hybrid_regional_bumpy_cover:
-  #   NAME: "regional_bumpy_cover"
-  #   FLAGS:
-  #     regional_bumpy_cover_include_impossible_nsrt: "True"  # NOTE
-  #     bumpy_cover_init_bumpy_prob: 1.0  # NOTE
-  #     bumpy_cover_num_bumps: 3
-  #     bumpy_cover_spaces_per_bump: 3
-  #     cover_num_blocks: 1
-  #     cover_block_widths: '[0.01]'
-  #     cover_num_targets: 1
-  #     cover_target_widths: '[0.008]'
+  hybrid_regional_bumpy_cover:
+    NAME: "regional_bumpy_cover"
+    FLAGS:
+      regional_bumpy_cover_include_impossible_nsrt: "True"  # NOTE
+      bumpy_cover_init_bumpy_prob: 1.0  # NOTE
+      bumpy_cover_num_bumps: 3
+      bumpy_cover_spaces_per_bump: 3
+      cover_num_blocks: 1
+      cover_block_widths: '[0.01]'
+      cover_num_targets: 1
+      cover_target_widths: '[0.008]'
 ARGS:
   - "debug"
 FLAGS:

--- a/scripts/configs/online_rl_cover.yaml
+++ b/scripts/configs/online_rl_cover.yaml
@@ -17,28 +17,28 @@ ENVS:
       cover_block_widths: '[0.01]'
       cover_num_targets: 1
       cover_target_widths: '[0.008]'
-  continuous_regional_bumpy_cover:
-    NAME: "regional_bumpy_cover"
-    FLAGS:
-      regional_bumpy_cover_include_impossible_nsrt: "False"  # NOTE
-      bumpy_cover_init_bumpy_prob: 1.0  # NOTE
-      bumpy_cover_num_bumps: 3
-      bumpy_cover_spaces_per_bump: 3
-      cover_num_blocks: 1
-      cover_block_widths: '[0.01]'
-      cover_num_targets: 1
-      cover_target_widths: '[0.008]'
-  hybrid_regional_bumpy_cover:
-    NAME: "regional_bumpy_cover"
-    FLAGS:
-      regional_bumpy_cover_include_impossible_nsrt: "True"  # NOTE
-      bumpy_cover_init_bumpy_prob: 1.0  # NOTE
-      bumpy_cover_num_bumps: 3
-      bumpy_cover_spaces_per_bump: 3
-      cover_num_blocks: 1
-      cover_block_widths: '[0.01]'
-      cover_num_targets: 1
-      cover_target_widths: '[0.008]'
+  # continuous_regional_bumpy_cover:
+  #   NAME: "regional_bumpy_cover"
+  #   FLAGS:
+  #     regional_bumpy_cover_include_impossible_nsrt: "False"  # NOTE
+  #     bumpy_cover_init_bumpy_prob: 1.0  # NOTE
+  #     bumpy_cover_num_bumps: 3
+  #     bumpy_cover_spaces_per_bump: 3
+  #     cover_num_blocks: 1
+  #     cover_block_widths: '[0.01]'
+  #     cover_num_targets: 1
+  #     cover_target_widths: '[0.008]'
+  # hybrid_regional_bumpy_cover:
+  #   NAME: "regional_bumpy_cover"
+  #   FLAGS:
+  #     regional_bumpy_cover_include_impossible_nsrt: "True"  # NOTE
+  #     bumpy_cover_init_bumpy_prob: 1.0  # NOTE
+  #     bumpy_cover_num_bumps: 3
+  #     bumpy_cover_spaces_per_bump: 3
+  #     cover_num_blocks: 1
+  #     cover_block_widths: '[0.01]'
+  #     cover_num_targets: 1
+  #     cover_target_widths: '[0.008]'
 ARGS:
   - "debug"
 FLAGS:
@@ -53,4 +53,4 @@ FLAGS:
   max_num_steps_interaction_request: 5
   horizon: 2  # NOTE, otherwise too easy
 START_SEED: 456
-NUM_SEEDS: 5
+NUM_SEEDS: 1 #5

--- a/scripts/configs/online_rl_cover.yaml
+++ b/scripts/configs/online_rl_cover.yaml
@@ -5,6 +5,7 @@ APPROACHES:
     NAME: "maple_q"
     FLAGS:
       explorer: "maple_q"
+      mlp_regressor_max_itr: 640000
 ENVS:
   # discrete_regional_bumpy_cover:
   #   NAME: "regional_bumpy_cover"

--- a/scripts/configs/online_rl_cover.yaml
+++ b/scripts/configs/online_rl_cover.yaml
@@ -8,17 +8,17 @@ APPROACHES:
       mlp_regressor_max_itr: 640000
       active_sampler_learning_batch_size: 512
 ENVS:
-  # discrete_regional_bumpy_cover:
-  #   NAME: "regional_bumpy_cover"
-  #   FLAGS:
-  #     regional_bumpy_cover_include_impossible_nsrt: "True"  # NOTE
-  #     bumpy_cover_init_bumpy_prob: 0.0  # NOTE
-  #     bumpy_cover_num_bumps: 3
-  #     bumpy_cover_spaces_per_bump: 3
-  #     cover_num_blocks: 1
-  #     cover_block_widths: '[0.01]'
-  #     cover_num_targets: 1
-  #     cover_target_widths: '[0.008]'
+  discrete_regional_bumpy_cover:
+    NAME: "regional_bumpy_cover"
+    FLAGS:
+      regional_bumpy_cover_include_impossible_nsrt: "True"  # NOTE
+      bumpy_cover_init_bumpy_prob: 0.0  # NOTE
+      bumpy_cover_num_bumps: 3
+      bumpy_cover_spaces_per_bump: 3
+      cover_num_blocks: 1
+      cover_block_widths: '[0.01]'
+      cover_num_targets: 1
+      cover_target_widths: '[0.008]'
   continuous_regional_bumpy_cover:
     NAME: "regional_bumpy_cover"
     FLAGS:
@@ -30,17 +30,17 @@ ENVS:
       cover_block_widths: '[0.01]'
       cover_num_targets: 1
       cover_target_widths: '[0.008]'
-  # hybrid_regional_bumpy_cover:
-  #   NAME: "regional_bumpy_cover"
-  #   FLAGS:
-  #     regional_bumpy_cover_include_impossible_nsrt: "True"  # NOTE
-  #     bumpy_cover_init_bumpy_prob: 1.0  # NOTE
-  #     bumpy_cover_num_bumps: 3
-  #     bumpy_cover_spaces_per_bump: 3
-  #     cover_num_blocks: 1
-  #     cover_block_widths: '[0.01]'
-  #     cover_num_targets: 1
-  #     cover_target_widths: '[0.008]'
+  hybrid_regional_bumpy_cover:
+    NAME: "regional_bumpy_cover"
+    FLAGS:
+      regional_bumpy_cover_include_impossible_nsrt: "True"  # NOTE
+      bumpy_cover_init_bumpy_prob: 1.0  # NOTE
+      bumpy_cover_num_bumps: 3
+      bumpy_cover_spaces_per_bump: 3
+      cover_num_blocks: 1
+      cover_block_widths: '[0.01]'
+      cover_num_targets: 1
+      cover_target_widths: '[0.008]'
 ARGS:
   - "debug"
 FLAGS:

--- a/scripts/configs/online_rl_cover.yaml
+++ b/scripts/configs/online_rl_cover.yaml
@@ -5,7 +5,7 @@ APPROACHES:
     NAME: "maple_q"
     FLAGS:
       explorer: "maple_q"
-      mlp_regressor_max_itr: 640000
+      # mlp_regressor_max_itr: 640000
 ENVS:
   # discrete_regional_bumpy_cover:
   #   NAME: "regional_bumpy_cover"

--- a/scripts/local/launch.py
+++ b/scripts/local/launch.py
@@ -40,6 +40,7 @@ def _main() -> None:
     num_cmds = len(cmds)
     for i, cmd in enumerate(cmds):
         print(f"********* RUNNING COMMAND {i+1} of {num_cmds} *********")
+        print(cmd)
         subprocess.run(cmd, shell=True, check=False)
 
 

--- a/scripts/local/launch.py
+++ b/scripts/local/launch.py
@@ -40,7 +40,6 @@ def _main() -> None:
     num_cmds = len(cmds)
     for i, cmd in enumerate(cmds):
         print(f"********* RUNNING COMMAND {i+1} of {num_cmds} *********")
-        print(cmd)
         subprocess.run(cmd, shell=True, check=False)
 
 

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -492,20 +492,3 @@ def test_maple_q_function():
     model.train_q_function()
     value = model.predict_q_value(task.init, task.goal, option)
     assert value != 0.0
-
-    # Test the replay buffer.
-    model = MapleQFunction(seed=123,
-                           hid_sizes=[32, 32],
-                           max_train_iters=100,
-                           n_iter_no_change=1000,
-                           clip_gradients=True,
-                           clip_value=5,
-                           learning_rate=1e-3,
-                           rng=rng,
-                           replay_buffer_max_size=1,
-                           replay_buffer_sample_with_replacement=False)
-    model.add_datum_to_replay_buffer(data)
-    model.add_datum_to_replay_buffer(data)
-    # pylint:disable=protected-access
-    batch = model._replay_buffer.sample_random_batch(8)
-    assert len(batch) == 8

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -502,7 +502,8 @@ def test_maple_q_function():
                            clip_value=5,
                            learning_rate=1e-3,
                            rng=rng,
-                           replay_buffer_max_size=1)
+                           replay_buffer_max_size=1,
+                           replay_buffer_sample_with_replacement=False)
     model.add_datum_to_replay_buffer(data)
     model.add_datum_to_replay_buffer(data)
     # pylint:disable=protected-access

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -469,7 +469,10 @@ def test_maple_q_function():
                            learning_rate=1e-3,
                            rng=rng)
     # Test before learning from any data.
-    model.train_from_q_data([])  # should have no effect
+    model.train_q_function()  # should have no effect
+    
+    # TODO: Test the replay buffer.
+    
     # Default value.
     option = ground_nsrts[0].sample_option(task.init, task.goal, rng)
     value = model.predict_q_value(task.init, task.goal, option)
@@ -483,12 +486,13 @@ def test_maple_q_function():
     sampled_option = model.get_option(task.init, task.goal, 1, epsilon=0.0)
     assert sampled_option.initiable(task.init)
     # Test learning.
-    data = [(task.init, task.goal, option, task.init, 1.0, False)]
-    model.train_from_q_data(data)
+    data = (task.init, task.goal, option, task.init, 1.0, False)
+    model.add_datum_to_replay_buffer(data)
+    model.train_q_function()
     # Should be different now.
     value = model.predict_q_value(task.init, task.goal, option)
     assert value != 0.0
     # Train a second iteration.
-    model.train_from_q_data(data)
+    model.train_q_function()
     value = model.predict_q_value(task.init, task.goal, option)
     assert value != 0.0

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -470,9 +470,9 @@ def test_maple_q_function():
                            rng=rng)
     # Test before learning from any data.
     model.train_q_function()  # should have no effect
-    
+
     # TODO: Test the replay buffer.
-    
+
     # Default value.
     option = ground_nsrts[0].sample_option(task.init, task.goal, rng)
     value = model.predict_q_value(task.init, task.goal, option)

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -459,7 +459,6 @@ def test_maple_q_function():
     ground_nsrts = [
         n for nsrt in nsrts for n in utils.all_ground_nsrts(nsrt, objects)
     ]
-
     model = MapleQFunction(seed=123,
                            hid_sizes=[32, 32],
                            max_train_iters=100,
@@ -470,9 +469,6 @@ def test_maple_q_function():
                            rng=rng)
     # Test before learning from any data.
     model.train_q_function()  # should have no effect
-
-    # TODO: Test the replay buffer.
-
     # Default value.
     option = ground_nsrts[0].sample_option(task.init, task.goal, rng)
     value = model.predict_q_value(task.init, task.goal, option)
@@ -496,3 +492,19 @@ def test_maple_q_function():
     model.train_q_function()
     value = model.predict_q_value(task.init, task.goal, option)
     assert value != 0.0
+
+    # Test the replay buffer.
+    model = MapleQFunction(seed=123,
+                           hid_sizes=[32, 32],
+                           max_train_iters=100,
+                           n_iter_no_change=1000,
+                           clip_gradients=True,
+                           clip_value=5,
+                           learning_rate=1e-3,
+                           rng=rng,
+                           replay_buffer_max_size=1)
+    model.add_datum_to_replay_buffer(data)
+    model.add_datum_to_replay_buffer(data)
+    # pylint:disable=protected-access
+    batch = model._replay_buffer.sample_random_batch(8)
+    assert len(batch) == 8

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -466,7 +466,8 @@ def test_maple_q_function():
                            n_iter_no_change=1000,
                            clip_gradients=True,
                            clip_value=5,
-                           learning_rate=1e-3)
+                           learning_rate=1e-3,
+                           rng=rng)
     # Test before learning from any data.
     model.train_from_q_data([])  # should have no effect
     # Default value.

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -465,8 +465,7 @@ def test_maple_q_function():
                            n_iter_no_change=1000,
                            clip_gradients=True,
                            clip_value=5,
-                           learning_rate=1e-3,
-                           rng=rng)
+                           learning_rate=1e-3)
     # Test before learning from any data.
     model.train_q_function()  # should have no effect
     # Default value.


### PR DESCRIPTION
Continuous Cover MAPLE Q Results with this change:
```
AGGREGATED DATA OVER SEEDS:
                                              NUM_TRAIN_TASKS    NUM_SOLVED AVG_NUM_PREDS AVG_TEST_TIME AVG_NODES_CREATED   LEARNING_TIME AVG_REF_COST  NUM_SEEDS
EXPERIMENT_ID                           CYCLE                                                                                                                    
continuous_regional_bumpy_cover-maple_q 0      1000.00 (0.00)   2.80 (3.66)   0.00 (0.00)   0.04 (0.00)       0.00 (0.00)   90.18 (27.60)  0.16 (0.04)          5
                                        1      1000.00 (0.00)   6.60 (4.27)   0.00 (0.00)   0.04 (0.00)       0.00 (0.00)  133.27 (36.76)  0.16 (0.10)          5
                                        10     1000.00 (0.00)   6.40 (4.13)   0.00 (0.00)   0.04 (0.00)       0.00 (0.00)  376.11 (53.54)  0.16 (0.10)          5
                                        11     1000.00 (0.00)   7.80 (3.92)   0.00 (0.00)   0.04 (0.00)       0.00 (0.00)  409.52 (53.81)  0.10 (0.00)          5
                                        12     1000.00 (0.00)  10.00 (0.00)   0.00 (0.00)   0.04 (0.00)       0.00 (0.00)  439.47 (53.58)  0.10 (0.00)          5
                                        13     1000.00 (0.00)   6.00 (4.90)   0.00 (0.00)   0.04 (0.00)       0.00 (0.00)  472.76 (49.26)  0.10 (0.00)          5
                                        14     1000.00 (0.00)   8.00 (4.00)   0.00 (0.00)   0.04 (0.00)       0.00 (0.00)  516.09 (46.08)  0.10 (0.00)          5
                                        15     1000.00 (0.00)   8.00 (4.00)   0.00 (0.00)   0.04 (0.00)       0.00 (0.00)  550.29 (46.71)  0.10 (0.00)          5
                                        16     1000.00 (0.00)  10.00 (0.00)   0.00 (0.00)   0.04 (0.00)       0.00 (0.00)  588.18 (48.13)  0.10 (0.00)          5
                                        17     1000.00 (0.00)   6.00 (4.90)   0.00 (0.00)   0.04 (0.00)       0.00 (0.00)  625.03 (49.61)  0.10 (0.00)          5
                                        18     1000.00 (0.00)   6.00 (4.90)   0.00 (0.00)   0.04 (0.00)       0.00 (0.00)  665.24 (55.02)  0.10 (0.00)          5
                                        19     1000.00 (0.00)   8.00 (4.00)   0.00 (0.00)   0.04 (0.00)       0.00 (0.00)  703.02 (54.13)  0.10 (0.00)          5
                                        2      1000.00 (0.00)  10.00 (0.00)   0.00 (0.00)   0.04 (0.00)       0.00 (0.00)  155.46 (31.28)  0.10 (0.00)          5
                                        3      1000.00 (0.00)   9.80 (0.40)   0.00 (0.00)   0.04 (0.00)       0.00 (0.00)  187.63 (37.22)  0.10 (0.00)          5
                                        4      1000.00 (0.00)   8.00 (4.00)   0.00 (0.00)   0.04 (0.00)       0.00 (0.00)  213.68 (41.95)  0.10 (0.00)          5
                                        5      1000.00 (0.00)  10.00 (0.00)   0.00 (0.00)   0.04 (0.00)       0.00 (0.00)  238.04 (40.15)  0.10 (0.00)          5
                                        6      1000.00 (0.00)  10.00 (0.00)   0.00 (0.00)   0.04 (0.00)       0.00 (0.00)  264.42 (41.50)  0.10 (0.00)          5
                                        7      1000.00 (0.00)   9.60 (0.80)   0.00 (0.00)   0.04 (0.00)       0.00 (0.00)  298.16 (46.78)  0.10 (0.01)          5
                                        8      1000.00 (0.00)   7.00 (3.69)   0.00 (0.00)   0.04 (0.01)       0.00 (0.00)  322.65 (49.95)  0.12 (0.02)          5
                                        9      1000.00 (0.00)   8.00 (4.00)   0.00 (0.00)   0.04 (0.00)       0.00 (0.00)  351.03 (52.20)  0.10 (0.00)          5
                                        None   1000.00 (0.00)   0.00 (0.00)   0.00 (0.00)     nan (nan)       0.00 (0.00)     0.28 (0.00)    nan (nan)          5
```