### PR TITLE
Clustering via reverse engineering

### DIFF
--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -974,14 +974,11 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
                     types_in_effects = [
                         set(a.predicate.types) for a in seg.add_effects
                     ]
-                    if len(types_in_effects) == 0 or len(
-                            set.union(*types_in_effects)) == 0:
-                        # If there are no add effects or if the object
-                        # arguments for all add effects are empty (which would
-                        # happen if the add effects only involved Forall
-                        # predicates that have no object arguments, e.g. in
-                        # repeated_nextto), then don't cluster further.
-                        continue
+                    # To cluster on type, there must be types. That is, there
+                    # must be add effects in the segment and the object
+                    # arguments for at least one add effect must be nonempty.
+                    assert len(types_in_effects) > 0 and len(
+                        set.union(*types_in_effects)) > 0
                     types = tuple(sorted(list(set.union(*types_in_effects))))
                     types_to_segments.setdefault(types, []).append(seg)
                 logging.info(

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -13,6 +13,9 @@ from typing import Callable, Dict, FrozenSet, Iterator, List, Sequence, Set, \
     Tuple
 
 from gym.spaces import Box
+import numpy as np
+from sklearn.mixture import GaussianMixture as GMM
+from scipy.stats import kstest
 
 from predicators import utils
 from predicators.approaches.nsrt_learning_approach import NSRTLearningApproach
@@ -887,12 +890,215 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
 
         return set(kept_predicates)
 
+    @staticmethod
+    def _get_consistent_predicates(predicates: Set[Predicate], clusters: List[List[Segment]]) -> Tuple[Set[Predicate], Set[Predicate]]:
+        """Returns all predicates that are consistent with respect to a set of
+        segment clusters. A consistent predicate is is either an add effect, a
+        delete effect, or doesn't change, within each cluster, for all clusters.
+        """
+
+        consistent: Set[Predicate] = set()
+        inconsistent: Set[Predicate] = set()
+        for pred in predicates:
+            keep_pred = True
+            for seg_list in clusters:
+                segment_0 = seg_list[0]
+                pred_in_add_effs_0 = pred in [
+                    atom.predicate for atom in segment_0.add_effects
+                ]
+                pred_in_del_effs_0 = pred in [
+                    atom.predicate for atom in segment_0.delete_effects
+                ]
+                for seg in seg_list[1:]:
+                    pred_in_curr_add_effs = pred in [
+                        atom.predicate for atom in seg.add_effects
+                    ]
+                    pred_in_curr_del_effs = pred in [
+                        atom.predicate for atom in seg.delete_effects
+                    ]
+                    not_consistently_add = pred_in_add_effs_0 != pred_in_curr_add_effs
+                    not_consistently_delete = pred_in_del_effs_0 != pred_in_curr_del_effs
+                    if not_consistently_add or not_consistently_delete:
+                        keep_pred = False
+                        inconsistent.add(pred)
+                        logging.info(f"Inconsistent predicate: {pred.name}")
+                        break
+                if not keep_pred:
+                    break
+            else:
+                consistent.add(pred)
+        return consistent, inconsistent
+
     def _select_predicates_by_clustering(
             self, candidates: Dict[Predicate, float],
             initial_predicates: Set[Predicate], dataset: Dataset,
             atom_dataset: List[GroundAtomTrajectory]) -> Set[Predicate]:
         """Cluster segments from the atom_dataset into clusters corresponding
         to operators and use this to select predicates."""
+
+        if CFG.grammar_search_pred_clusterer == "option-type-number-sample":
+            # Algorithm:
+            # TODO
+
+            assert CFG.segmenter == "option_changes"
+            segments = [
+                seg for ll_traj, atom_seq in atom_dataset for seg in segment_trajectory(ll_traj, initial_predicates, atom_seq)
+            ]
+
+            # Step 1:
+            # Cluster segments by the option that generated them.
+            option_to_segments = {}
+            for seg in segments:
+                name = seg.get_option().name
+                option_to_segments.setdefault(name, []).append(seg)
+            logging.info(f"STEP 1: generated {len(option_to_segments.keys())} option-based clusters.")
+            clusters = option_to_segments.copy() # Tree-like structure.
+
+            # Step 2:
+            # Further cluster by the types that appear in a segment's add
+            # effects.
+            for i, pair in enumerate(option_to_segments.items()):
+                option, segments = pair
+                types_to_segments = {}
+                for seg in segments:
+                    types_in_effects = [set(a.predicate.types) for a in seg.add_effects]
+                    if len(types_in_effects) == 0 or len(set.union(*types_in_effects)) == 0:
+                        # If there are no add effects or if the object
+                        # arguments for all add effects are empty (which would
+                        # happen if the add effects only involved Forall
+                        # predicates that have no object arguments, e.g. in
+                        # repeated_nextto), then don't cluster further.
+                        continue
+                    types = tuple(sorted(list(set.union(*types_in_effects))))
+                    types_to_segments.setdefault(types, []).append(seg)
+                logging.info(f"STEP 2: generated {len(types_to_segments.keys())} type-based clusters for cluster {i+1} from STEP 1 involving option {option}.")
+                clusters[option] = types_to_segments
+
+            # Step 3:
+            # Further cluster by the maximum number of objects that appear in a
+            # segment's add effects.
+            for i, (option, types_to_segments) in enumerate(clusters.items()):
+                for j, (types, segments) in enumerate(types_to_segments.items()):
+                    num_to_segments = {}
+                    for seg in segments:
+                        max_num_objs = max(len(a.objects) for a in seg.add_effects)
+                        num_to_segments.setdefault(max_num_objs, []).append(seg)
+                    logging.info(f"STEP 3: generated {len(num_to_segments.keys())} num-object-based clusters for cluster {i+j+1} from STEP 2 involving option {option} and type {types}.")
+                    clusters[option][types] = num_to_segments
+
+            # Step 4:
+            # Further cluster by sample, if a sample is present.
+            for i, (option, types_to_num) in enumerate(clusters.items()):
+                for j, (types, num_to_segments) in enumerate(types_to_num.items()):
+                    for k, (max_num_objs, segments) in enumerate(num_to_segments.items()):
+                        # If the segments in this cluster have no sample, then
+                        # don't cluster further.
+                        if len(segments[0].get_option().params) == 0:
+                            clusters[option][types][max_num_objs] = [segments]
+                            logging.info(f"STEP 4: generated no further sample-based clusters (no parameter) for the {i+j+k+1}th cluster from STEP 3 involving option {option}, type {types}, and max num objects {max_num_objs}.")
+                            continue
+                        else:
+                            # pylint: disable=line-too-long
+                            # If the parameters are described by a uniform
+                            # distribution, then don't cluster further. A proper
+                            # implementation would do a multi-dimensional test
+                            # (https://ieeexplore.ieee.org/document/4767477,
+                            # https://ui.adsabs.harvard.edu/abs/1987MNRAS.225..155F/abstract,
+                            # https://stats.stackexchange.com/questions/30982/how-to-test-uniformity-in-several-dimensions)
+                            # but for now we will only check each dimension
+                            # individually to keep the implementation simple.
+                            # pylint: enable=line-too-long
+                            samples = np.array([seg.get_option().params for seg in segments])
+                            each_dim_uniform = True
+                            for d in range(samples.shape[1]):
+                                col = samples[:,d]
+                                minimum = col.min()
+                                maximum = col.max()
+                                null_hypothesis = np.random.uniform(minimum, maximum, len(col))
+                                p_value = kstest(col, null_hypothesis).pvalue
+
+                                # We use a significance value of 0.05.
+                                if p_value < 0.05:
+                                    each_dim_uniform = False
+                                    break
+                            if each_dim_uniform:
+                                clusters[option][types][max_num_objs] = [segments]
+                                logging.info(f"STEP 4: generated no further sample-based clusters (uniformly distributed parameter) for the {i+j+k+1}th cluster from STEP 3 involving option {option}, type {types}, and max num objects {max_num_objs}.")
+                                continue
+                            else:
+                                # Determine clusters by assignment from a
+                                # Gaussian Mixture Model.
+                                max_components = min(len(samples), len(np.unique(samples)), CFG.grammar_search_clustering_gmm_num_components)
+                                n_components = np.arange(1, max_components+1)
+                                models = [GMM(n, covariance_type="full", random_state=0).fit(samples) for n in n_components]
+                                bic = [m.bic(samples) for m in models]
+                                best = models[np.argmin(bic)]
+                                assignments = best.predict(samples)
+                                label_to_segments = {}
+                                for l, assignment in enumerate(assignments):
+                                    label_to_segments.setdefault(assignment, []).append(segments[l])
+                                clusters[option][types][max_num_objs] = list(label_to_segments.values())
+                                logging.info(f"STEP 4: generated {len(label_to_segments.keys())} sample-based clusters for the {i+j+k+1}th cluster from STEP 3 involving option {option}, type {types}, and max num objects {max_num_objs}.")
+
+            # We could avoid these loops by creating the final set of clusters
+            # as part of STEP 4, but this is not slow and serves to clarify
+            # the nested dictionary structure, which we may make use of in
+            # follow-up work.
+            final_clusters = []
+            for option in clusters.keys():
+                for types in clusters[option].keys():
+                    for max_num_objs in clusters[option][types].keys():
+                        for cluster in clusters[option][types][max_num_objs]:
+                            final_clusters.append(cluster)
+            logging.info(f"Total {len(final_clusters)} final clusters.")
+
+            # Step 5:
+            # Extract predicates from the pure intersection of the add effects
+            # in each cluster.
+            extracted_preds = set()
+            shared_add_effects_per_cluster = []
+            for b, c in enumerate(final_clusters):
+                grounded_add_effects_per_segment = [seg.add_effects for seg in c]
+                ungrounded_add_effects_per_segment = []
+                for effs in grounded_add_effects_per_segment:
+                    ungrounded_add_effects_per_segment.append(set(a.predicate for a in effs))
+                shared_add_effects_in_cluster = set.intersection(*ungrounded_add_effects_per_segment)
+                shared_add_effects_per_cluster.append(shared_add_effects_in_cluster)
+                extracted_preds |= shared_add_effects_in_cluster
+
+            # Step 6:
+            # Remove inconsistent predicates except if removing them prevents us
+            # from disambiguating two or more clusters (i.e. their add effect
+            # sets are the same after removing the inconsistent predicates).
+            # A consistent predicate is is either an add effect, a delete
+            # effect, or doesn't change, within each cluster, for all clusters.
+            # Note that it is possible that when 2 inconsistent predicates are
+            # removed, then two clusters cannot be disambiguated, but if you
+            # keep either of the two, then you can disambiguate the clusters.
+            # For now, we just add both back, which is not ideal.
+            consistent, inconsistent = self._get_consistent_predicates(extracted_preds, list(final_clusters))
+            predicates_to_keep: Set[Predicate] = set()
+            consistent_shared_add_effects_per_cluster = [add_effs - inconsistent for add_effs in shared_add_effects_per_cluster]
+            num_clusters = len(final_clusters)
+            for i in range(num_clusters):
+                for j in range(num_clusters):
+                    if i == j:
+                        continue
+                    else:
+                        if consistent_shared_add_effects_per_cluster[i] == consistent_shared_add_effects_per_cluster[j]:
+                            print(f"Final clusters {i} and {j} cannot be disambiguated after removing some inconsistent predicates.")
+                            predicates_to_keep |= shared_add_effects_per_cluster[i]
+                            predicates_to_keep |= shared_add_effects_per_cluster[j]
+
+            # Remove the initial predicates.
+            predicates_to_keep -= initial_predicates
+
+            logging.info(
+                f"\nSelected {len(predicates_to_keep)} predicates out of "
+                f"{len(candidates)} candidates:")
+            for pred in sorted(predicates_to_keep):
+                logging.info(f"{pred}")
+            return predicates_to_keep
 
         if CFG.grammar_search_pred_clusterer == "oracle":
             assert CFG.offline_data_method == "demo+gt_operators"
@@ -932,35 +1138,7 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
             # Finally, select predicates that are consistent (either, it is
             # an add effect, or a delete effect, or doesn't change)
             # within all demos.
-            predicates_to_keep: Set[Predicate] = set()
-            # for pred in consistent_add_effs_preds:
-            for pred in non_static_predicates:
-                keep_pred = True
-                for seg_list in gt_op_to_segments.values():
-                    segment_0 = seg_list[0]
-                    pred_in_add_effs_0 = pred in [
-                        atom.predicate for atom in segment_0.add_effects
-                    ]
-                    pred_in_del_effs_0 = pred in [
-                        atom.predicate for atom in segment_0.delete_effects
-                    ]
-                    for seg in seg_list[1:]:
-                        pred_in_curr_add_effs = pred in [
-                            atom.predicate for atom in seg.add_effects
-                        ]
-                        pred_in_curr_del_effs = pred in [
-                            atom.predicate for atom in seg.delete_effects
-                        ]
-                        if not ((pred_in_add_effs_0 == pred_in_curr_add_effs)
-                                and
-                                (pred_in_del_effs_0 == pred_in_curr_del_effs)):
-                            keep_pred = False
-                            break
-                    if not keep_pred:
-                        break
-
-                else:
-                    predicates_to_keep.add(pred)
+            predicates_to_keep = self._get_consistent_predicates(non_static_predicates, list(gt_op_to_segments.values()))
 
             # Before returning, remove all the initial predicates.
             predicates_to_keep -= initial_predicates

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -1135,7 +1135,7 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
             # within the PlaceOnTable cluster in painting, but we don't want to
             # remove them, since we had generated them specifically to
             # disambiguate segments in the cluster with the Pick option.
-            # A consistent predicate is is either an add effect, a delete
+            # A consistent predicate is either an add effect, a delete
             # effect, or doesn't change, within each cluster, for all clusters.
             # Note that it is possible that when 2 inconsistent predicates are
             # removed, then two clusters cannot be disambiguated, but if you

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -1132,7 +1132,6 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
                 shared_add_effects_per_cluster.append(
                     shared_add_effects_in_cluster)
                 extracted_preds |= shared_add_effects_in_cluster
-            print("SIZE OF EXTRACTED: ", len(extracted_preds))
 
             # Step 6:
             # Remove inconsistent predicates except if removing them prevents us
@@ -1163,7 +1162,7 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
                     if consistent_shared_add_effects_per_cluster[
                             i] == consistent_shared_add_effects_per_cluster[
                                 j]:
-                        print(
+                        logging.info(
                             f"Final clusters {i} and {j} cannot be "
                             f"disambiguated after removing the inconsistent"
                             f" predicates.")

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -1057,9 +1057,7 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
                                 each_dim_uniform = False
                                 break
                         if each_dim_uniform:
-                            clusters[option][types][max_num_objs] = [
-                                segments
-                            ]
+                            clusters[option][types][max_num_objs] = [segments]
                             logging.info(
                                 f"STEP 4: generated no further sample-based"
                                 f" clusters (uniformly distributed "
@@ -1074,33 +1072,29 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
                         # complexity of the model (chosen by BIC here)
                         # are hyperparameters.
                         max_components = min(
-                            len(samples), len(np.unique(samples)), CFG.
-                            grammar_search_clustering_gmm_num_components
-                        )
+                            len(samples), len(np.unique(samples)),
+                            CFG.grammar_search_clustering_gmm_num_components)
                         n_components = np.arange(1, max_components + 1)
                         models = [
-                            GMM(n,
-                                covariance_type="full",
+                            GMM(n, covariance_type="full",
                                 random_state=0).fit(samples)
                             for n in n_components
                         ]
                         bic = [m.bic(samples) for m in models]
                         best = models[np.argmin(bic)]
                         assignments = best.predict(samples)
-                        label_to_segments: Dict[int,
-                                                List[Segment]] = {}
+                        label_to_segments: Dict[int, List[Segment]] = {}
                         for l, assignment in enumerate(assignments):
                             label_to_segments.setdefault(
                                 assignment, []).append(segments[l])
                         clusters[option][types][max_num_objs] = list(
                             label_to_segments.values())
-                        logging.info(
-                            f"STEP 4: generated "
-                            f"{len(label_to_segments.keys())}"
-                            f"sample-based clusters for cluster "
-                            f"{i+j+k+1} from STEP 3 involving option "
-                            f"{option}, type {types}, and max num "
-                            f"objects {max_num_objs}.")
+                        logging.info(f"STEP 4: generated "
+                                     f"{len(label_to_segments.keys())}"
+                                     f"sample-based clusters for cluster "
+                                     f"{i+j+k+1} from STEP 3 involving option "
+                                     f"{option}, type {types}, and max num "
+                                     f"objects {max_num_objs}.")
 
             # We could avoid these loops by creating the final set of clusters
             # as part of STEP 4, but this is not prohibitively slow and serves
@@ -1160,8 +1154,7 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
                     if i == j:
                         continue
                     if consistent_shared_add_effects_per_cluster[
-                            i] == consistent_shared_add_effects_per_cluster[
-                                j]:
+                            i] == consistent_shared_add_effects_per_cluster[j]:
                         logging.info(
                             f"Final clusters {i} and {j} cannot be "
                             f"disambiguated after removing the inconsistent"

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -626,6 +626,9 @@ class GlobalSettings:
     grammar_search_expected_nodes_allow_noops = True
     grammar_search_classifier_pretty_str_names = ["?x", "?y", "?z"]
 
+    # grammar search clustering algorithm parameters
+    grammar_search_clustering_gmm_num_components = 10
+
     @classmethod
     def get_arg_specific_settings(cls, args: Dict[str, Any]) -> Dict[str, Any]:
         """A workaround for global settings that are derived from the

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -433,3 +433,32 @@ def test_predicate_invention_with_oracle_clustering():
                    offline_data_method="demo+gt_operators",
                    solve_exceptions=ApproachFailure,
                    additional_settings=additional_settings)
+
+def test_predicate_invention_with_custom_clustering():
+    """Test for predicate invention with a custom clustering algorithm."""
+    additional_settings = {
+        "grammar_search_pred_selection_approach": "clustering",
+        "grammar_search_pred_clusterer": "option-type-number-sample",
+        "segmenter": "option_changes",
+    }
+    _test_approach(env_name="blocks",
+                   num_train_tasks=10,
+                   approach_name="grammar_search_invention",
+                   strips_learner="cluster_and_intersect",
+                   offline_data_method="demo",
+                   solve_exceptions=ApproachFailure,
+                   additional_settings=additional_settings)
+    _test_approach(env_name="painting",
+                   num_train_tasks=10,
+                   approach_name="grammar_search_invention",
+                   strips_learner="cluster_and_intersect",
+                   offline_data_method="demo",
+                   solve_exceptions=ApproachFailure,
+                   additional_settings=additional_settings)
+    # _test_approach(env_name="repeated_nextto",
+    #                num_train_tasks=10,
+    #                approach_name="grammar_search_invention",
+    #                strips_learner="cluster_and_intersect",
+    #                offline_data_method="demo",
+    #                solve_exceptions=ApproachFailure,
+    #                additional_settings=additional_settings)

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -434,6 +434,7 @@ def test_predicate_invention_with_oracle_clustering():
                    solve_exceptions=ApproachFailure,
                    additional_settings=additional_settings)
 
+
 def test_predicate_invention_with_custom_clustering():
     """Test for predicate invention with a custom clustering algorithm."""
     additional_settings = {
@@ -455,10 +456,10 @@ def test_predicate_invention_with_custom_clustering():
                    offline_data_method="demo",
                    solve_exceptions=ApproachFailure,
                    additional_settings=additional_settings)
-    # _test_approach(env_name="repeated_nextto",
-    #                num_train_tasks=10,
-    #                approach_name="grammar_search_invention",
-    #                strips_learner="cluster_and_intersect",
-    #                offline_data_method="demo",
-    #                solve_exceptions=ApproachFailure,
-    #                additional_settings=additional_settings)
+    _test_approach(env_name="repeated_nextto",
+                   num_train_tasks=10,
+                   approach_name="grammar_search_invention",
+                   strips_learner="pnad_search",
+                   offline_data_method="demo",
+                   solve_exceptions=ApproachFailure,
+                   additional_settings=additional_settings)


### PR DESCRIPTION
This PR implements a predicate invention approach that employs clustering to try to reverse engineer the clusters of segments that correspond to the oracle operators and select predicates that are add effects in those clusters, letting pnad_search downstream handle chainability and removing some extraneous predicates through backchaining that might cause overfitting issues.

The performance on the four tasks from the AAAI paper is illustrated below: 
The non-oracle clustering method:
```
                      NUM_TRAIN_TASKS    NUM_SOLVED AVG_NUM_PREDS AVG_TEST_TIME  AVG_NODES_CREATED   LEARNING_TIME  NUM_SEEDS
EXPERIMENT_ID
blocks_main_200demo     200.00 (0.00)  48.70 (1.27)  14.20 (0.60)   0.66 (0.19)  3074.73 (1223.38)  149.81 (38.48)         10
cover_main_200demo      200.00 (0.00)  49.20 (0.75)   9.80 (3.25)   0.05 (0.02)        5.92 (0.30)    39.82 (2.82)         10
painting_main_200demo   200.00 (0.00)  49.70 (0.64)  41.90 (1.64)   1.06 (0.20)  4354.69 (1189.59)   253.45 (3.07)         10
tools_main_200demo      200.00 (0.00)  43.30 (1.68)  44.10 (0.30)   0.74 (0.16)   1357.64 (409.98)   227.94 (5.82)         10
```
v.s.
The AAAI method: 
```
                                              NUM_TRAIN_TASKS    NUM_SOLVED AVG_NUM_PREDS AVG_TEST_TIME  AVG_NODES_CREATED        LEARNING_TIME  NUM_SEEDS
EXPERIMENT_ID                                                                                                                                             
pybullet_blocks_main_200demo                    200.00 (0.00)  49.00 (0.77)   7.60 (1.28)   0.54 (0.17)  3997.55 (2237.44)   13717.18 (2739.89)         10
cover_main_200demo                              200.00 (0.00)  49.30 (0.64)   5.90 (0.54)   0.01 (0.00)        4.94 (0.23)       549.25 (69.44)         10
painting_main_200demo                           200.00 (0.00)  49.90 (0.30)  20.80 (1.78)   0.18 (0.04)    402.88 (116.42)  89404.23 (13707.67)         10
tools_main_200demo                              200.00 (0.00)  45.90 (5.79)  28.00 (5.14)   0.44 (0.30)  1926.29 (1585.43)   19286.83 (3002.72)         10
```

The main takeaways from these results is that (1) it's much faster, (2) but it still learns a lot of extra predicates. Overall, this shows that the clustering idea, in how it leverages more structure in the demonstrations to be more efficient at predicate invention, has promise. 

The high-level outline of the algorithm is as follows:
1. cluster segments by option
2. further cluster by types of objects affected 
3. further cluster by # of objects affected 
4. If a parameter exists for the option involved in this cluster's segments...
If the parameters are described by a uniform distribution (via a KS test for now), don't cluster further. 
Else, further cluster by assignment from a GMM fit to the parameters. 
5. Get predicates from pure intersection of add effects within each cluster.
6. Remove inconsistent predicates except if removing them prevents us from disambiguating two or more clusters (i.e. their add effect sets are the same after removing inconsistent predicates). If it does, add those predicates back. 
7. Learn operators via pnad search

Some intuition and thoughts about the above:
- Overall, the procedure can be seen as figuring out clusters of segments for which we want a dedicated operator, and subselecting predicates from the initial candidate predicates based on those clusters. And then we let pnad search handle the chainability. 
- The idea behind step 6 is that HoldingTop and HoldingSide are inconsistent within the PlaceOnTable cluster in painting, but we don't want to remove them, since we had generated them specifically to disambiguate segments involving the Pick option into two clusters. 
- Step 4 (not clustering further if the parameters are described by a uniform) helps prevent overfitting. If the parameter data is uniform, a GMM might, e.g. still create 3 clusters. And then we might get some very specific predicates out of that, that end up being inconsistent. And then when we apply step 5, these clusters were quite similar (they should be one cluster!) so we won't disambiguate them, and we'll add the inconsistent predicates back (which we don't want, since they're the ones we get from overfitting). 
- This algorithm is a somewhat hacky, but also isn't that hacky (as evidenced by it working in RNT, etc). The next steps for this direction might be to create environments to break it, to understand how we can make it more general. But mainly it's been a great way through which to get a good understanding of what's going on with the clustering idea in general. 