### PR TITLE
Implement infinite-horizon for exploration

### DIFF
--- a/predicators/approaches/bilevel_planning_approach.py
+++ b/predicators/approaches/bilevel_planning_approach.py
@@ -131,6 +131,7 @@ class BilevelPlanningApproach(BaseApproach):
                 timeout,
                 seed,
                 task_planning_heuristic=self._task_planning_heuristic,
+                max_horizon=float(CFG.horizon),
                 **kwargs)
         except PlanningFailure as e:
             raise ApproachFailure(e.args[0], e.info)

--- a/predicators/explorers/active_sampler_explorer.py
+++ b/predicators/explorers/active_sampler_explorer.py
@@ -304,6 +304,8 @@ class ActiveSamplerExplorer(BaseExplorer):
             o: -np.log(m.get_current_competence())
             for o, m in self._competence_models.items()
         }
+        # Set large horizon for planning here because we don't want to error
+        # out due to plan exceeding horizon here.
         plan, atoms_seq, _ = run_task_plan_once(
             task,
             self._nsrts,
@@ -313,7 +315,8 @@ class ActiveSamplerExplorer(BaseExplorer):
             self._seed,
             task_planning_heuristic=task_planning_heuristic,
             ground_op_costs=ground_op_costs,
-            default_cost=self._default_cost)
+            default_cost=self._default_cost,
+            max_horizon=np.inf)
         return utils.nsrt_plan_to_greedy_option_policy(
             plan, task.goal, self._rng, necessary_atoms_seq=atoms_seq)
 
@@ -415,7 +418,8 @@ class ActiveSamplerExplorer(BaseExplorer):
                 self._seed,
                 task_planning_heuristic=task_planning_heuristic,
                 ground_op_costs=ground_op_costs,
-                default_cost=self._default_cost)
+                default_cost=self._default_cost,
+                max_horizon=np.inf)
             self._task_plan_cache[task_id] = [n.op for n in plan]
 
         self._task_plan_calls_since_replan[task_id] += 1

--- a/predicators/planning.py
+++ b/predicators/planning.py
@@ -1174,6 +1174,7 @@ def run_task_plan_once(
         ground_op_costs: Optional[Dict[_GroundSTRIPSOperator, float]] = None,
         default_cost: float = 1.0,
         cost_precision: int = 3,
+        max_horizon: float = np.inf,
         **kwargs: Any
 ) -> Tuple[List[_GroundNSRT], List[Set[GroundAtom]], Metrics]:
     """Get a single abstract plan for a task."""
@@ -1204,6 +1205,9 @@ def run_task_plan_once(
                       max_skeletons_optimized=1,
                       use_visited_state_set=True,
                       **kwargs))
+        if len(plan) > max_horizon:
+            raise PlanningFailure(
+                "Skeleton produced by A-star exceeds horizon!")
     elif "fd" in CFG.sesame_task_planner:  # pragma: no cover
         fd_exec_path = os.environ["FD_EXEC_PATH"]
         exec_str = os.path.join(fd_exec_path, "fast-downward.py")
@@ -1243,7 +1247,7 @@ def run_task_plan_once(
 
         plan, atoms_seq, metrics = fd_plan_from_sas_file(
             sas_file, timeout_cmd, timeout, exec_str, alias_flag, start_time,
-            list(objects), init_atoms, nsrts, CFG.horizon)
+            list(objects), init_atoms, nsrts, max_horizon)
     else:
         raise ValueError("Unrecognized sesame_task_planner: "
                          f"{CFG.sesame_task_planner}")

--- a/predicators/planning.py
+++ b/predicators/planning.py
@@ -1046,7 +1046,7 @@ def _update_sas_file_with_costs(
 def fd_plan_from_sas_file(
     sas_file: str, timeout_cmd: str, timeout: float, exec_str: str,
     alias_flag: str, start_time: float, objects: List[Object],
-    init_atoms: Set[GroundAtom], nsrts: Set[NSRT], max_horizon: int
+    init_atoms: Set[GroundAtom], nsrts: Set[NSRT], max_horizon: float
 ) -> Tuple[List[_GroundNSRT], List[Set[GroundAtom]],
            Metrics]:  # pragma: no cover
     """Given a SAS file, runs search on it to generate a plan."""
@@ -1137,7 +1137,7 @@ def _sesame_plan_with_fast_downward(
     while True:
         skeleton, atoms_sequence, metrics = fd_plan_from_sas_file(
             sas_file, timeout_cmd, timeout, exec_str, alias_flag, start_time,
-            objects, init_atoms, nsrts, max_horizon)
+            objects, init_atoms, nsrts, float(max_horizon))
         # Run low-level search on this skeleton.
         low_level_timeout = timeout - (time.perf_counter() - start_time)
         try:
@@ -1247,7 +1247,7 @@ def run_task_plan_once(
 
         plan, atoms_seq, metrics = fd_plan_from_sas_file(
             sas_file, timeout_cmd, timeout, exec_str, alias_flag, start_time,
-            list(objects), init_atoms, nsrts, max_horizon)
+            list(objects), init_atoms, nsrts, float(max_horizon))
     else:
         raise ValueError("Unrecognized sesame_task_planner: "
                          f"{CFG.sesame_task_planner}")

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -694,26 +694,27 @@ def test_sesame_plan_fast_downward():
         except ValueError as e:
             assert "Unrecognized sesame_task_planner" in str(e)
 
-    def test_task_planning_only():
-        """Tests for the run_task_plan_once function."""
-        utils.reset_config({
-            "env": "cluttered_table",
-            "num_test_tasks": 50,
-            "sesame_task_planner": sesame_task_planner,
-        })
-        env = ClutteredTableEnv()
-        nsrts = get_gt_nsrts(env.get_name(), env.predicates,
-                             get_gt_options(env.get_name()))
-        env_task = env.get_test_tasks()[0]
-        task = env_task.task
-        preds = env.predicates
-        types = env.types
-        with pytest.raises(PlanningFailure) as e:
-            run_task_plan_once(task,
-                               nsrts,
-                               preds,
-                               types,
-                               100000.0,
-                               0,
-                               max_horizon=0.0)
-        assert "exceeds horizon" in str(e)
+
+def test_task_planning_only():
+    """Tests for the run_task_plan_once function."""
+    utils.reset_config({
+        "env": "cluttered_table",
+        "num_test_tasks": 50,
+    })
+    env = ClutteredTableEnv()
+    nsrts = get_gt_nsrts(env.get_name(), env.predicates,
+                         get_gt_options(env.get_name()))
+    env_task = env.get_test_tasks()[0]
+    task = env_task.task
+    preds = env.predicates
+    types = env.types
+    with pytest.raises(PlanningFailure) as e:
+        run_task_plan_once(task,
+                           nsrts,
+                           preds,
+                           types,
+                           100000.0,
+                           0,
+                           task_planning_heuristic="lmcut",
+                           max_horizon=0.0)
+    assert "exceeds horizon" in str(e)

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -17,7 +17,7 @@ from predicators.ground_truth_models import get_gt_nsrts, get_gt_options
 from predicators.option_model import _OptionModelBase, _OracleOptionModel, \
     create_option_model
 from predicators.planning import PlanningFailure, PlanningTimeout, \
-    sesame_plan, task_plan, task_plan_grounding
+    run_task_plan_once, sesame_plan, task_plan, task_plan_grounding
 from predicators.settings import CFG
 from predicators.structs import NSRT, Action, ParameterizedOption, Predicate, \
     State, STRIPSOperator, Task, Type, _GroundNSRT, _Option
@@ -693,3 +693,27 @@ def test_sesame_plan_fast_downward():
             assert "Please follow the instructions" in str(e)
         except ValueError as e:
             assert "Unrecognized sesame_task_planner" in str(e)
+
+    def test_task_planning_only():
+        """Tests for the run_task_plan_once function."""
+        utils.reset_config({
+            "env": "cluttered_table",
+            "num_test_tasks": 50,
+            "sesame_task_planner": sesame_task_planner,
+        })
+        env = ClutteredTableEnv()
+        nsrts = get_gt_nsrts(env.get_name(), env.predicates,
+                             get_gt_options(env.get_name()))
+        env_task = env.get_test_tasks()[0]
+        task = env_task.task
+        preds = env.predicates
+        types = env.types
+        with pytest.raises(PlanningFailure) as e:
+            run_task_plan_once(task,
+                               nsrts,
+                               preds,
+                               types,
+                               100000.0,
+                               0,
+                               max_horizon=0.0)
+        assert "exceeds horizon" in str(e)


### PR DESCRIPTION
During active sampler learning, instead of measuring success rate under a particular timeout, we might want to measure success rate under a particular horizon. We can do this by setting the `--horizon` argument to whatever particular number we want when running our experiments. However, this causes an issue with approaches that call the planner during exploration: in particular, these will sometimes come up with plans they want to practice that might be longer than the given horizon. If this happens, an error gets thrown that causes a crash...

This PR sets the horizon to `np.inf` during exploration, thereby disabling the horizon check during exploration, but keeping it around for use at evaluation time.