### PR TITLE
Changes to fix execution monitoring in the online exploration case

### DIFF
--- a/predicators/approaches/online_nsrt_learning_approach.py
+++ b/predicators/approaches/online_nsrt_learning_approach.py
@@ -52,6 +52,14 @@ class OnlineNSRTLearningApproach(NSRTLearningApproach):
         # is randomly selected.
         explorer = self._create_explorer()
 
+        # NOTE: this is definitely awkward, but we have to reset this
+        # info so that if we ever use the execution monitor while doing
+        # exploration and collecting more data, it doesn't mistakenly
+        # try to monitor stuff using a previously-saved plan.
+        self._last_nsrt_plan = []
+        self._last_atoms_seq = []
+        self._last_plan = []
+
         # Create the interaction requests.
         requests = []
         for _ in range(CFG.online_nsrt_learning_requests_per_cycle):

--- a/predicators/cogman.py
+++ b/predicators/cogman.py
@@ -67,7 +67,11 @@ class CogMan:
             self._exec_monitor.reset(task)
             self._exec_monitor.update_approach_info(
                 self._approach.get_execution_monitoring_info())
-            assert not self._exec_monitor.step(state)
+            # We only reset the approach if the override policy is
+            # None, so this below assertion only works in this
+            # case.
+            if self._override_policy is None:
+                assert not self._exec_monitor.step(state)
         assert self._current_policy is not None
         act = self._current_policy(state)
         self._exec_monitor.update_approach_info(

--- a/predicators/execution_monitoring/base_execution_monitor.py
+++ b/predicators/execution_monitoring/base_execution_monitor.py
@@ -22,6 +22,7 @@ class BaseExecutionMonitor(abc.ABC):
         """Reset after replanning."""
         del task  # unused
         self._curr_plan_timestep = 0
+        self._approach_info = []
 
     @abc.abstractmethod
     def step(self, state: State) -> bool:


### PR DESCRIPTION
Online exploration in the forthcoming complex sticky table environment causes some issues with execution monitoring. Specifically, when we use the `expected_atoms` monitor, at the start of new online learning cycles, we end up accidentally remembering the monitoring info for old plans and trying to monitor w.r.t them. This PR makes a few minor changes to fix this issue.