### PR TITLE
fix hierarchical typing edge case

### DIFF
--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -2806,7 +2806,14 @@ def create_pddl_domain(operators: Collection[NSRTOrSTRIPSOperator],
         for parent_type in sorted(parent_to_children_types):
             child_types = parent_to_children_types[parent_type]
             if not child_types:
-                types_str += f"\n    {parent_type.name}"
+                # Special case: type has no children and also does not appear as a
+                # child of another type.
+                is_child_type = any(
+                    parent_type in children
+                    for children in parent_to_children_types.values())
+                if not is_child_type:
+                    types_str += f"\n    {parent_type.name}"
+                # Otherwise, the type will appear as a child elsewhere.
             else:
                 child_type_str = " ".join(t.name for t in child_types)
                 types_str += f"\n    {child_type_str} - {parent_type.name}"

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -2806,9 +2806,10 @@ def create_pddl_domain(operators: Collection[NSRTOrSTRIPSOperator],
         for parent_type in sorted(parent_to_children_types):
             child_types = parent_to_children_types[parent_type]
             if not child_types:
-                continue
-            child_type_str = " ".join(t.name for t in child_types)
-            types_str += f"\n    {child_type_str} - {parent_type.name}"
+                types_str += f"\n    {parent_type.name}"
+            else:
+                child_type_str = " ".join(t.name for t in child_types)
+                types_str += f"\n    {child_type_str} - {parent_type.name}"
     ops_lst = sorted(operators)
     preds_str = "\n    ".join(pred.pddl_str() for pred in preds_lst)
     ops_strs = "\n\n  ".join(op.pddl_str() for op in ops_lst)

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -2806,8 +2806,8 @@ def create_pddl_domain(operators: Collection[NSRTOrSTRIPSOperator],
         for parent_type in sorted(parent_to_children_types):
             child_types = parent_to_children_types[parent_type]
             if not child_types:
-                # Special case: type has no children and also does not appear as a
-                # child of another type.
+                # Special case: type has no children and also does not appear
+                # as a child of another type.
                 is_child_type = any(
                     parent_type in children
                     for children in parent_to_children_types.values())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2318,12 +2318,16 @@ def test_create_pddl():
     env = ProceduralTasksSpannerPDDLEnv()
     nsrts = get_gt_nsrts(env.get_name(), env.predicates,
                          get_gt_options(env.get_name()))
-    domain_str = utils.create_pddl_domain(nsrts, env.predicates, env.types,
+    # Test case where there is a special type with no parents or children.
+    monkey_type = Type("monkey", [])
+    types = env.types | {monkey_type}
+    domain_str = utils.create_pddl_domain(nsrts, env.predicates, types,
                                           "spanner")
     assert domain_str == """(define (domain spanner)
   (:requirements :typing)
   (:types 
     man nut spanner - locatable
+    monkey
     locatable location - object)
 
   (:predicates


### PR DESCRIPTION
the case this fixes is where there is hierarchical typing, but some type that doesn't have any ancestors, and there are some objects of the latter type in problem files. for example:

```
  (:types 
    immovable movable - base-object
    container - movable
    robot
  )
```

with `robot`