### PR TITLE
Fix + raise awareness of subtle bugs with active sampler exploration

### DIFF
--- a/predicators/explorers/active_sampler_explorer.py
+++ b/predicators/explorers/active_sampler_explorer.py
@@ -231,8 +231,7 @@ class ActiveSamplerExplorer(BaseExplorer):
                             "assumption of our active sampler learning "
                             "framework; ensure you DO NOT see this message "
                             "if you're running experiments comparing"
-                            "different active sampler learning approaches."
-                        )
+                            "different active sampler learning approaches.")
                         continue
                     logging.info("[Explorer] Plan found.")
                     break


### PR DESCRIPTION
This PR fixes a bug with the `task_repeat` exploration baseline for active sampler learning. Previously, the agent would keep trying to get to the goal. Once it hits it, it makes one single plan to get to the initial state. If/when this plan ever fails, it goes back to trying to achieve the goal. Now, the agent stubbornly tries to achieve both the initial state and goal until it succeeds.

Also, we raise a warning when the planning graph is incomplete, which can lead to all kind of strange bugs if someone unknowingly runs experiments given this is the case.