### PR TITLE
Fixes competence estimation for when we do epsilon-greedy exploration sampling

### DIFF
--- a/predicators/approaches/active_sampler_learning_approach.py
+++ b/predicators/approaches/active_sampler_learning_approach.py
@@ -315,6 +315,9 @@ class ActiveSamplerLearningApproach(OnlineNSRTLearningApproach):
         for old_nsrt in self._nsrts:
             if old_nsrt.option not in new_nsrt_options:
                 new_test_nsrts.add(old_nsrt)
+                # Since we don't have a learned score function, just make
+                # a lambda function that returns the same score (1.0)
+                # for every input that gets passed in.
                 self._nsrt_to_explorer_sampler[
                     old_nsrt] = _wrap_sampler_exploration(
                         old_nsrt._sampler,  # pylint: disable=protected-access

--- a/predicators/approaches/active_sampler_learning_approach.py
+++ b/predicators/approaches/active_sampler_learning_approach.py
@@ -317,8 +317,8 @@ class ActiveSamplerLearningApproach(OnlineNSRTLearningApproach):
                 new_test_nsrts.add(old_nsrt)
                 self._nsrt_to_explorer_sampler[
                     old_nsrt] = _wrap_sampler_exploration(
-                        old_nsrt._sampler,
-                        lambda o, _, params: [1.0] * len(params), "greedy")  # pylint: disable=protected-access
+                        old_nsrt._sampler, # pylint: disable=protected-access
+                        lambda o, _, params: [1.0] * len(params), "greedy")
         self._nsrts = new_test_nsrts
         # Re-save the NSRTs now that we've updated them.
         save_path = utils.get_approach_save_path_str()

--- a/predicators/approaches/active_sampler_learning_approach.py
+++ b/predicators/approaches/active_sampler_learning_approach.py
@@ -317,8 +317,9 @@ class ActiveSamplerLearningApproach(OnlineNSRTLearningApproach):
                 new_test_nsrts.add(old_nsrt)
                 self._nsrt_to_explorer_sampler[
                     old_nsrt] = _wrap_sampler_exploration(
-                        old_nsrt._sampler, # pylint: disable=protected-access
-                        lambda o, _, params: [1.0] * len(params), "greedy")
+                        old_nsrt._sampler,  # pylint: disable=protected-access
+                        lambda o, _, params: [1.0] * len(params),
+                        "greedy")
         self._nsrts = new_test_nsrts
         # Re-save the NSRTs now that we've updated them.
         save_path = utils.get_approach_save_path_str()

--- a/predicators/explorers/__init__.py
+++ b/predicators/explorers/__init__.py
@@ -12,8 +12,9 @@ from predicators.explorers.bilevel_planning_explorer import \
 from predicators.ml_models import MapleQFunction
 from predicators.option_model import _OptionModelBase
 from predicators.settings import CFG
-from predicators.structs import NSRT, GroundAtom, NSRTSampler, \
-    ParameterizedOption, Predicate, State, Task, Type, _GroundSTRIPSOperator
+from predicators.structs import NSRT, GroundAtom, \
+    NSRTSamplerWithEpsilonIndicator, ParameterizedOption, Predicate, State, \
+    Task, Type, _GroundSTRIPSOperator
 
 __all__ = ["BaseExplorer"]
 
@@ -37,7 +38,8 @@ def create_explorer(
     ground_op_hist: Optional[Dict[_GroundSTRIPSOperator, List[bool]]] = None,
     competence_models: Optional[Dict[_GroundSTRIPSOperator,
                                      SkillCompetenceModel]] = None,
-    nsrt_to_explorer_sampler: Optional[Dict[NSRT, NSRTSampler]] = None,
+    nsrt_to_explorer_sampler: Optional[Dict[
+        NSRT, NSRTSamplerWithEpsilonIndicator]] = None,
     seen_train_task_idxs: Optional[Set[int]] = None,
     pursue_task_goal_first: Optional[bool] = None,
     maple_q_function: Optional[MapleQFunction] = None,

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -1798,6 +1798,12 @@ EntToEntSub = Dict[_TypedEntity, _TypedEntity]
 Datastore = List[Tuple[Segment, VarToObjSub]]
 NSRTSampler = Callable[
     [State, Set[GroundAtom], np.random.Generator, Sequence[Object]], Array]
+# NSRT Sampler that also returns a boolean indicating whether the sample was
+# generated randomly (for exploration) or from the current learned
+# distribution.
+NSRTSamplerWithEpsilonIndicator = Callable[
+    [State, Set[GroundAtom], np.random.Generator, Sequence[Object]],
+    Tuple[Array, bool]]
 Metrics = DefaultDict[str, float]
 LiftedOrGroundAtom = TypeVar("LiftedOrGroundAtom", LiftedAtom, GroundAtom,
                              _Atom)

--- a/scripts/configs/active_sampler_learning.yaml
+++ b/scripts/configs/active_sampler_learning.yaml
@@ -32,34 +32,34 @@ APPROACHES:
     NAME: "active_sampler_learning"
     FLAGS:
       explorer: "random_nsrts"
-  maple_q:
-    NAME: "maple_q"
-    FLAGS:
-      explorer: "maple_q"
-      mlp_regressor_max_itr: 100000
-      active_sampler_learning_batch_size: 1024
+  # maple_q:
+  #   NAME: "maple_q"
+  #   FLAGS:
+  #     explorer: "maple_q"
+  #     mlp_regressor_max_itr: 100000
+  #     active_sampler_learning_batch_size: 1024
 ENVS:
-  tiny_grid_row:
-    NAME: "grid_row"
-    FLAGS:
-      grid_row_num_cells: 3
-      max_num_steps_interaction_request: 500
-      active_sampler_learning_explore_length_base: 100000  # effectively disable
-      active_sampler_learning_feature_selection: all
-      active_sampler_learning_explore_pursue_goal_interval: 1
-  regional_bumpy_cover:
-    NAME: "regional_bumpy_cover"
-    FLAGS:
-      regional_bumpy_cover_include_impossible_nsrt: "True"
-      bumpy_cover_num_bumps: 3
-      bumpy_cover_spaces_per_bump: 5
-      bumpy_cover_init_bumpy_prob: 0.25
-      cover_num_blocks: 10
-      cover_block_widths: '[0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01]'
-      cover_num_targets: 10
-      cover_target_widths: '[0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008]'
-      active_sampler_learning_feature_selection: all
-      active_sampler_learning_explore_pursue_goal_interval: 1
+  # tiny_grid_row:
+  #   NAME: "grid_row"
+  #   FLAGS:
+  #     grid_row_num_cells: 3
+  #     max_num_steps_interaction_request: 500
+  #     active_sampler_learning_explore_length_base: 100000  # effectively disable
+  #     active_sampler_learning_feature_selection: all
+  #     active_sampler_learning_explore_pursue_goal_interval: 1
+  # regional_bumpy_cover:
+  #   NAME: "regional_bumpy_cover"
+  #   FLAGS:
+  #     regional_bumpy_cover_include_impossible_nsrt: "True"
+  #     bumpy_cover_num_bumps: 3
+  #     bumpy_cover_spaces_per_bump: 5
+  #     bumpy_cover_init_bumpy_prob: 0.25
+  #     cover_num_blocks: 10
+  #     cover_block_widths: '[0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01]'
+  #     cover_num_targets: 10
+  #     cover_target_widths: '[0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008]'
+  #     active_sampler_learning_feature_selection: all
+  #     active_sampler_learning_explore_pursue_goal_interval: 1
   grid_row:
     NAME: "grid_row"
     FLAGS:
@@ -67,23 +67,23 @@ ENVS:
       active_sampler_learning_explore_length_base: 100000  # effectively disable
       active_sampler_learning_feature_selection: all
       active_sampler_learning_explore_pursue_goal_interval: 1
-  ball_and_cup_sticky_table:
-    NAME: "ball_and_cup_sticky_table"
-    FLAGS:
-      sticky_table_place_smooth_fall_prob: 1.00
-      sticky_table_place_sticky_fall_prob: 0.00
-      sticky_table_pick_success_prob: 1.0
-      sticky_table_num_sticky_tables: 1
-      sticky_table_num_tables: 5
-      sticky_table_place_ball_fall_prob: 1.00
-      active_sampler_learning_explore_length_base: 25
-      active_sampler_learning_exploration_epsilon: 0.5
-      skill_competence_model_optimistic_recency_size: 2
-      skill_competence_model_optimistic_window_size: 2
-      horizon: 8
-      active_sampler_learning_explore_length_base: 100000  # effectively disable
-      active_sampler_learning_feature_selection: oracle
-      active_sampler_learning_explore_pursue_goal_interval: 1
+  # ball_and_cup_sticky_table:
+  #   NAME: "ball_and_cup_sticky_table"
+  #   FLAGS:
+  #     sticky_table_place_smooth_fall_prob: 1.00
+  #     sticky_table_place_sticky_fall_prob: 0.00
+  #     sticky_table_pick_success_prob: 1.0
+  #     sticky_table_num_sticky_tables: 1
+  #     sticky_table_num_tables: 5
+  #     sticky_table_place_ball_fall_prob: 1.00
+  #     active_sampler_learning_explore_length_base: 25
+  #     active_sampler_learning_exploration_epsilon: 0.5
+  #     skill_competence_model_optimistic_recency_size: 2
+  #     skill_competence_model_optimistic_window_size: 2
+  #     horizon: 8
+  #     active_sampler_learning_explore_length_base: 100000  # effectively disable
+  #     active_sampler_learning_feature_selection: oracle
+  #     active_sampler_learning_explore_pursue_goal_interval: 1
 ARGS:
   - "debug"
 FLAGS:

--- a/scripts/configs/active_sampler_learning.yaml
+++ b/scripts/configs/active_sampler_learning.yaml
@@ -60,30 +60,30 @@ ENVS:
   #     cover_target_widths: '[0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008,0.008]'
   #     active_sampler_learning_feature_selection: all
   #     active_sampler_learning_explore_pursue_goal_interval: 1
-  grid_row:
-    NAME: "grid_row"
-    FLAGS:
-      max_num_steps_interaction_request: 150
-      active_sampler_learning_explore_length_base: 100000  # effectively disable
-      active_sampler_learning_feature_selection: all
-      active_sampler_learning_explore_pursue_goal_interval: 1
-  # ball_and_cup_sticky_table:
-  #   NAME: "ball_and_cup_sticky_table"
+  # grid_row:
+  #   NAME: "grid_row"
   #   FLAGS:
-  #     sticky_table_place_smooth_fall_prob: 1.00
-  #     sticky_table_place_sticky_fall_prob: 0.00
-  #     sticky_table_pick_success_prob: 1.0
-  #     sticky_table_num_sticky_tables: 1
-  #     sticky_table_num_tables: 5
-  #     sticky_table_place_ball_fall_prob: 1.00
-  #     active_sampler_learning_explore_length_base: 25
-  #     active_sampler_learning_exploration_epsilon: 0.5
-  #     skill_competence_model_optimistic_recency_size: 2
-  #     skill_competence_model_optimistic_window_size: 2
-  #     horizon: 8
+  #     max_num_steps_interaction_request: 150
   #     active_sampler_learning_explore_length_base: 100000  # effectively disable
-  #     active_sampler_learning_feature_selection: oracle
+  #     active_sampler_learning_feature_selection: all
   #     active_sampler_learning_explore_pursue_goal_interval: 1
+  ball_and_cup_sticky_table:
+    NAME: "ball_and_cup_sticky_table"
+    FLAGS:
+      sticky_table_place_smooth_fall_prob: 1.00
+      sticky_table_place_sticky_fall_prob: 0.00
+      sticky_table_pick_success_prob: 1.0
+      sticky_table_num_sticky_tables: 1
+      sticky_table_num_tables: 5
+      sticky_table_place_ball_fall_prob: 1.00
+      active_sampler_learning_explore_length_base: 25
+      active_sampler_learning_exploration_epsilon: 0.5
+      skill_competence_model_optimistic_recency_size: 2
+      skill_competence_model_optimistic_window_size: 2
+      horizon: 8
+      active_sampler_learning_explore_length_base: 100000  # effectively disable
+      active_sampler_learning_feature_selection: oracle
+      active_sampler_learning_explore_pursue_goal_interval: 1
 ARGS:
   - "debug"
 FLAGS:

--- a/tests/explorers/test_active_sampler_explorer.py
+++ b/tests/explorers/test_active_sampler_explorer.py
@@ -182,7 +182,9 @@ def test_active_sampler_explorer():
     nsrt_to_explorer_sampler: Dict[NSRT, NSRTSamplerWithEpsilonIndicator] = {}
     for nsrt in nsrts:
         nsrt_to_explorer_sampler[nsrt] = _wrap_sampler_exploration(
-            nsrt.sampler, lambda s, o, x: [0.0] * len(x), strategy="epsilon_greedy")
+            nsrt.sampler,
+            lambda s, o, x: [0.0] * len(x),
+            strategy="epsilon_greedy")
     explorer = create_explorer(
         "active_sampler",
         env.predicates,
@@ -377,7 +379,9 @@ def test_active_sampler_explorer():
     new_nsrt_to_greedy_explorer_sampler = {}
     for nsrt, sampler in nsrt_to_explorer_sampler.items():
         new_nsrt_to_greedy_explorer_sampler[nsrt] = _wrap_sampler_exploration(
-            nsrt.sampler, lambda s, o, x: [0.0] * len(x), strategy="epsilon_greedy")
+            nsrt.sampler,
+            lambda s, o, x: [0.0] * len(x),
+            strategy="epsilon_greedy")
     explorer = create_explorer(
         "active_sampler",
         env.predicates,

--- a/tests/explorers/test_active_sampler_explorer.py
+++ b/tests/explorers/test_active_sampler_explorer.py
@@ -10,7 +10,7 @@ from predicators.envs.cover import RegionalBumpyCoverEnv
 from predicators.explorers import create_explorer
 from predicators.ground_truth_models import get_gt_nsrts, get_gt_options
 from predicators.option_model import _OracleOptionModel
-from predicators.structs import NSRT, NSRTSampler
+from predicators.structs import NSRT, NSRTSamplerWithEpsilonIndicator
 
 
 def test_active_sampler_explorer():
@@ -31,9 +31,10 @@ def test_active_sampler_explorer():
     train_tasks = [t.task for t in env.get_train_tasks()]
     ground_op_hist = {}
     competence_models = {}
-    nsrt_to_explorer_sampler: Dict[NSRT, NSRTSampler] = {}
+    nsrt_to_explorer_sampler: Dict[NSRT, NSRTSamplerWithEpsilonIndicator] = {}
     for nsrt in nsrts:
-        nsrt_to_explorer_sampler[nsrt] = nsrt.sampler
+        nsrt_to_explorer_sampler[nsrt] = _wrap_sampler_exploration(
+            nsrt.sampler, lambda s, o, x: [0.0] * len(x), strategy="greedy")
     seen_train_task_idxs = set(range(len(train_tasks)))
     explorer = create_explorer(
         "active_sampler",
@@ -178,9 +179,10 @@ def test_active_sampler_explorer():
     train_tasks = [t.task for t in env.get_train_tasks()]
     ground_op_hist = {}
     competence_models = {}
-    nsrt_to_explorer_sampler: Dict[NSRT, NSRTSampler] = {}
+    nsrt_to_explorer_sampler: Dict[NSRT, NSRTSamplerWithEpsilonIndicator] = {}
     for nsrt in nsrts:
-        nsrt_to_explorer_sampler[nsrt] = nsrt.sampler
+        nsrt_to_explorer_sampler[nsrt] = _wrap_sampler_exploration(
+            nsrt.sampler, lambda s, o, x: [0.0] * len(x), strategy="epsilon_greedy")
     explorer = create_explorer(
         "active_sampler",
         env.predicates,
@@ -375,7 +377,7 @@ def test_active_sampler_explorer():
     new_nsrt_to_greedy_explorer_sampler = {}
     for nsrt, sampler in nsrt_to_explorer_sampler.items():
         new_nsrt_to_greedy_explorer_sampler[nsrt] = _wrap_sampler_exploration(
-            sampler, lambda s, o, x: [0.0] * len(x), strategy="epsilon_greedy")
+            nsrt.sampler, lambda s, o, x: [0.0] * len(x), strategy="epsilon_greedy")
     explorer = create_explorer(
         "active_sampler",
         env.predicates,

--- a/tests/explorers/test_active_sampler_explorer.py
+++ b/tests/explorers/test_active_sampler_explorer.py
@@ -5,7 +5,7 @@ import pytest
 
 from predicators import utils
 from predicators.approaches.active_sampler_learning_approach import \
-    _wrap_sampler
+    _wrap_sampler_exploration
 from predicators.envs.cover import RegionalBumpyCoverEnv
 from predicators.explorers import create_explorer
 from predicators.ground_truth_models import get_gt_nsrts, get_gt_options
@@ -374,7 +374,7 @@ def test_active_sampler_explorer():
     })
     new_nsrt_to_greedy_explorer_sampler = {}
     for nsrt, sampler in nsrt_to_explorer_sampler.items():
-        new_nsrt_to_greedy_explorer_sampler[nsrt] = _wrap_sampler(
+        new_nsrt_to_greedy_explorer_sampler[nsrt] = _wrap_sampler_exploration(
             sampler, lambda s, o, x: [0.0] * len(x), strategy="epsilon_greedy")
     explorer = create_explorer(
         "active_sampler",
@@ -417,7 +417,7 @@ def test_active_sampler_explorer():
     })
     new_nsrt_to_greedy_explorer_sampler = {}
     for nsrt, sampler in nsrt_to_explorer_sampler.items():
-        new_nsrt_to_greedy_explorer_sampler[nsrt] = _wrap_sampler(
+        new_nsrt_to_greedy_explorer_sampler[nsrt] = _wrap_sampler_exploration(
             sampler,
             lambda s, o, x: [0.0] * len(x),
             strategy="not a real explorer")


### PR DESCRIPTION
Previously, we always updated the competence estimator with new data. Now, we only do so if we actually sampled from the learned policy; we don't let exploration samples influence our competence estimate.