### PR TITLE
Enable saving and loading of predicate grammar atom datasets

### DIFF
--- a/predicators/approaches/nsrt_learning_approach.py
+++ b/predicators/approaches/nsrt_learning_approach.py
@@ -5,7 +5,6 @@ or options.
 """
 
 import logging
-import os
 import time
 from typing import Any, Dict, List, Optional, Set
 
@@ -68,42 +67,13 @@ class NSRTLearningApproach(BilevelPlanningApproach):
         # options take many steps, this makes a big time/space difference.
         ground_atom_dataset: Optional[List[GroundAtomTrajectory]] = None
         if CFG.load_atoms:
-            os.makedirs(CFG.data_dir, exist_ok=True)
-            # Check that the dataset file was previously saved.
-            if os.path.exists(dataset_fname):
-                # Load the ground atoms dataset.
-                with open(dataset_fname, "rb") as f:
-                    ground_atom_dataset_atoms = pkl.load(f)
-                assert len(trajectories) == len(ground_atom_dataset_atoms)
-                logging.info("\n\nLOADED GROUND ATOM DATASET")
-
-                # The saved ground atom dataset consists only of sequences
-                # of sets of GroundAtoms, we need to recombine this with
-                # the LowLevelTrajectories to create a GroundAtomTrajectory.
-                ground_atom_dataset = []
-                for i, traj in enumerate(trajectories):
-                    ground_atom_seq = ground_atom_dataset_atoms[i]
-                    ground_atom_dataset.append(
-                        (traj, [set(atoms) for atoms in ground_atom_seq]))
-            else:
-                raise ValueError(f"Cannot load ground atoms: {dataset_fname}")
+            ground_atom_dataset = utils.load_ground_atom_dataset(
+                dataset_fname, trajectories)
         elif CFG.save_atoms:
             # Apply predicates to data, producing a dataset of abstract states.
             ground_atom_dataset = utils.create_ground_atom_dataset(
                 trajectories, self._get_current_predicates())
-            # Save ground atoms dataset to file. Note that a
-            # GroundAtomTrajectory contains a normal LowLevelTrajectory and a
-            # list of sets of GroundAtoms, so we only save the list of
-            # GroundAtoms (the LowLevelTrajectories are saved separately).
-            ground_atom_dataset_to_pkl = []
-            for gt_traj in ground_atom_dataset:
-                trajectory = []
-                for ground_atom_set in gt_traj[1]:
-                    trajectory.append(ground_atom_set)
-                ground_atom_dataset_to_pkl.append(trajectory)
-            with open(dataset_fname, "wb") as f:
-                pkl.dump(ground_atom_dataset_to_pkl, f)
-
+            utils.save_ground_atom_dataset(ground_atom_dataset, dataset_fname)
         self._nsrts, self._segmented_trajs, self._seg_to_nsrt = \
             learn_nsrts_from_data(trajectories,
                                   self._train_tasks,

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any, Callable, ClassVar, Collection, Dict, \
 from typing import Type as TypingType
 from typing import TypeVar, Union, cast
 
+import dill as pkl
 import imageio
 import matplotlib
 import matplotlib.pyplot as plt
@@ -2569,6 +2570,51 @@ def prune_ground_atom_dataset(
                       for sa in atoms]
         new_ground_atom_dataset.append((traj, kept_atoms))
     return new_ground_atom_dataset
+
+
+def load_ground_atom_dataset(
+        dataset_fname: str,
+        trajectories: List[LowLevelTrajectory]) -> List[GroundAtomTrajectory]:
+    """Load a previously-saved ground atom dataset."""
+    os.makedirs(CFG.data_dir, exist_ok=True)
+    # Check that the dataset file was previously saved.
+    ground_atom_dataset_atoms: Optional[List[List[Set[GroundAtom]]]] = []
+    if os.path.exists(dataset_fname):
+        # Load the ground atoms dataset.
+        with open(dataset_fname, "rb") as f:
+            ground_atom_dataset_atoms = pkl.load(f)
+        assert ground_atom_dataset_atoms is not None
+        assert len(trajectories) == len(ground_atom_dataset_atoms)
+        logging.info("\n\nLOADED GROUND ATOM DATASET")
+
+        # The saved ground atom dataset consists only of sequences
+        # of sets of GroundAtoms, we need to recombine this with
+        # the LowLevelTrajectories to create a GroundAtomTrajectory.
+        ground_atom_dataset = []
+        for i, traj in enumerate(trajectories):
+            ground_atom_seq = ground_atom_dataset_atoms[i]
+            ground_atom_dataset.append(
+                (traj, [set(atoms) for atoms in ground_atom_seq]))
+    else:
+        raise ValueError(f"Cannot load ground atoms: {dataset_fname}")
+    return ground_atom_dataset
+
+
+def save_ground_atom_dataset(ground_atom_dataset: List[GroundAtomTrajectory],
+                             dataset_fname: str) -> None:
+    """Saves a given ground atom dataset so it can be loaded in the future."""
+    # Save ground atoms dataset to file. Note that a
+    # GroundAtomTrajectory contains a normal LowLevelTrajectory and a
+    # list of sets of GroundAtoms, so we only save the list of
+    # GroundAtoms (the LowLevelTrajectories are saved separately).
+    ground_atom_dataset_to_pkl = []
+    for gt_traj in ground_atom_dataset:
+        trajectory = []
+        for ground_atom_set in gt_traj[1]:
+            trajectory.append(ground_atom_set)
+        ground_atom_dataset_to_pkl.append(trajectory)
+    with open(dataset_fname, "wb") as f:
+        pkl.dump(ground_atom_dataset_to_pkl, f)
 
 
 def extract_preds_and_types(

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -2575,7 +2575,15 @@ def prune_ground_atom_dataset(
 def load_ground_atom_dataset(
         dataset_fname: str,
         trajectories: List[LowLevelTrajectory]) -> List[GroundAtomTrajectory]:
-    """Load a previously-saved ground atom dataset."""
+    """Load a previously-saved ground atom dataset.
+
+    Note importantly that we only save atoms themselves, we don't save
+    the low-level trajectory information that's necessary to make
+    GroundAtomTrajectories given series of ground atoms (that info can
+    be saved separately, in case one wants to just load trajectories and
+    not also load ground atoms). Thus, this function needs to take these
+    trajectories as input.
+    """
     os.makedirs(CFG.data_dir, exist_ok=True)
     # Check that the dataset file was previously saved.
     ground_atom_dataset_atoms: Optional[List[List[Set[GroundAtom]]]] = []

--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -80,7 +80,7 @@ def test_predicate_grammar(segmenter):
     utils.reset_config({
         "grammar_search_grammar_use_diff_features": True,
         "segmenter": segmenter,
-        "env": "cover"
+        "env": "cover",
     })
     forall_grammar = _create_grammar(dataset, env.predicates)
     assert len(forall_grammar.generate(max_num=100)) == 55

--- a/tests/approaches/test_nsrt_learning_approach.py
+++ b/tests/approaches/test_nsrt_learning_approach.py
@@ -359,7 +359,17 @@ def test_grammar_search_invention_approach():
         "grammar_search_search_algorithm": "hill_climbing",
         "pretty_print_when_loading": True,
         "grammar_search_gbfs_num_evals": 1,
+        "save_atoms": True
     }
+    _test_approach(env_name="cover",
+                   approach_name="grammar_search_invention",
+                   excluded_predicates="Holding",
+                   try_solving=False,
+                   sampler_learner="random",
+                   num_train_tasks=3,
+                   additional_settings=additional_settings)
+    # Now test loading.
+    additional_settings.update({"load_atoms": True})
     _test_approach(env_name="cover",
                    approach_name="grammar_search_invention",
                    excluded_predicates="Holding",
@@ -370,6 +380,7 @@ def test_grammar_search_invention_approach():
     # Test approach with unrecognized search algorithm.
     additional_settings["grammar_search_search_algorithm"] = \
         "not a real search algorithm"
+    additional_settings["load_atoms"] = False
     with pytest.raises(Exception) as e:
         _test_approach(env_name="cover",
                        approach_name="grammar_search_invention",


### PR DESCRIPTION
As @ashayathalye and I are starting to do predicate invention with increasingly larger grammars, the time taken to just apply the grammar predicates to a dataset is getting significant and slowing down iteration time. This PR makes the `--load_atoms` and `--save_atoms` flags apply to the predicate grammar as well!