### PR TITLE
Fix some conceptual issues with StickButtonMovementEnv

### DIFF
--- a/predicators/envs/stick_button.py
+++ b/predicators/envs/stick_button.py
@@ -147,9 +147,9 @@ class StickButtonEnv(BaseEnv):
                 # Check for a collision with the stick holder. The reason that
                 # we only check for a collision here, as opposed to every
                 # timestep, is that we imagine the robot moving down in the z
-                # direction to pick up the stick, at which button it may
-                # collide with the stick holder. On other timesteps, the robot
-                # would be high enough above the holder to avoid collisions.
+                # direction to pick up the stick after it has reached it on the
+                # x-y plane. On other timesteps, the robot would be high enough
+                # above the holder to avoid collisions.
                 if robot_circ.intersects(holder_rect):
                     # No-op in case of collision.
                     return state.copy()
@@ -711,9 +711,9 @@ class StickButtonMovementEnv(StickButtonEnv):
                 # Check for a collision with the stick holder. The reason that
                 # we only check for a collision here, as opposed to every
                 # timestep, is that we imagine the robot moving down in the z
-                # direction to pick up the stick, at which button it may
-                # collide with the stick holder. On other timesteps, the robot
-                # would be high enough above the holder to avoid collisions.
+                # direction to pick up the stick after it has reached it on the
+                # x-y plane. On other timesteps, the robot would be high enough
+                # above the holder to avoid collisions.
                 if robot_circ.intersects(holder_rect):
                     # No-op in case of collision.
                     return state.copy()

--- a/predicators/envs/stick_button.py
+++ b/predicators/envs/stick_button.py
@@ -486,6 +486,8 @@ class StickButtonMovementEnv(StickButtonEnv):
     # is CCW angle in radians, consistent with utils.Rectangle. The tip
     # x and y correspond to the end of the stick.
     _stick_type = Type("stick", ["x", "y", "tip_x", "tip_y", "theta", "held"])
+    # We add an attribute for the open/closed status of the robot's gripper.
+    _robot_type = _robot_type = Type("robot", ["x", "y", "theta", "fingers"])
 
     def _get_tasks(self, num: int, num_button_lst: List[int],
                    rng: np.random.Generator) -> List[EnvironmentTask]:
@@ -610,6 +612,16 @@ class StickButtonMovementEnv(StickButtonEnv):
             task = EnvironmentTask(init_state, goal)
             tasks.append(task)
         return tasks
+
+    @staticmethod
+    def _Grasped_holds(state: State, objects: Sequence[Object]) -> bool:
+        robot, stick = objects
+        return state.get(stick, "held") > 0.5 and state.get(robot, "fingers") <= 0.5
+
+    @staticmethod
+    def _HandEmpty_holds(state: State, objects: Sequence[Object]) -> bool:
+        robot, = objects
+        return state.get(robot, "fingers") > 0.5
 
     def simulate(self, state: State, action: Action) -> State:
         """Run simulation and update tip_x and tip_y."""

--- a/predicators/envs/stick_button.py
+++ b/predicators/envs/stick_button.py
@@ -727,16 +727,6 @@ class StickButtonMovementEnv(StickButtonEnv):
 
         return next_state
 
-    # def simulate(self, state: State, action: Action) -> State:
-    #     """Run simulation and update tip_x and tip_y."""
-    #     next_state = super().simulate(state, action)
-    #     stick_rect = self.object_to_geom(self._stick, next_state)
-    #     assert isinstance(stick_rect, utils.Rectangle)
-    #     tip_rect = self.stick_rect_to_tip_rect(stick_rect)
-    #     next_state.set(self._stick, "tip_x", tip_rect.x)
-    #     next_state.set(self._stick, "tip_y", tip_rect.y)
-    #     return next_state
-
     @classmethod
     def get_name(cls) -> str:
         return "stick_button_move"

--- a/predicators/ground_truth_models/stick_button/nsrts.py
+++ b/predicators/ground_truth_models/stick_button/nsrts.py
@@ -370,9 +370,8 @@ class StickButtonMoveGroundTruthNSRTFactory(StickButtonGroundTruthNSRTFactory):
         # RobotPressButton
         robot = Variable("?robot", robot_type)
         button = Variable("?button", button_type)
-        stick = Variable("?stick", stick_type)
-        parameters = [robot, button, stick]
-        option_vars = [robot, button, stick]
+        parameters = [robot, button]
+        option_vars = [robot, button]
         option = RobotPressButton
         preconditions = {
             LiftedAtom(HandEmpty, [robot]),

--- a/predicators/ground_truth_models/stick_button/nsrts.py
+++ b/predicators/ground_truth_models/stick_button/nsrts.py
@@ -262,6 +262,7 @@ class StickButtonMoveGroundTruthNSRTFactory(StickButtonGroundTruthNSRTFactory):
         robot_type = types["robot"]
         button_type = types["button"]
         stick_type = types["stick"]
+        holder_type = types["holder"]
 
         # Predicates
         Pressed = predicates["Pressed"]
@@ -464,8 +465,9 @@ class StickButtonMoveGroundTruthNSRTFactory(StickButtonGroundTruthNSRTFactory):
         # PlaceStickFromNothing
         robot = Variable("?robot", robot_type)
         stick = Variable("?stick", stick_type)
-        parameters = [robot, stick]
-        option_vars = [robot, stick]
+        holder = Variable("?holder", holder_type)
+        parameters = [robot, stick, holder]
+        option_vars = [robot, stick, holder]
         option = PlaceStick
         preconditions = {
             LiftedAtom(Grasped, [robot, stick]),
@@ -494,9 +496,10 @@ class StickButtonMoveGroundTruthNSRTFactory(StickButtonGroundTruthNSRTFactory):
         # PlaceStickFromButton
         robot = Variable("?robot", robot_type)
         stick = Variable("?stick", stick_type)
+        holder = Variable("?holder", holder_type)
         from_button = Variable("?from_button", button_type)
-        parameters = [robot, stick, from_button]
-        option_vars = [robot, stick]
+        parameters = [robot, stick, holder, from_button]
+        option_vars = [robot, stick, holder]
         option = PlaceStick
         preconditions = {
             LiftedAtom(StickAboveButton, [stick, from_button]),

--- a/predicators/ground_truth_models/stick_button/options.py
+++ b/predicators/ground_truth_models/stick_button/options.py
@@ -271,6 +271,7 @@ class StickButtonMovementGroundTruthOptionFactory(
         RobotAboveButton = predicates["RobotAboveButton"]
         StickAboveButton = predicates["StickAboveButton"]
         Pressed = predicates["Pressed"]
+        Grasped = predicates["Grasped"]
 
         # RobotMoveToButton
         def _RobotMoveToButton_terminal(state: State, memory: Dict,
@@ -342,7 +343,8 @@ class StickButtonMovementGroundTruthOptionFactory(
 
         unchanged_options = {
             opt
-            for opt in init_options if opt.name not in ["RobotPressButton", "PlaceStick"]
+            for opt in init_options
+            if opt.name not in ["RobotPressButton", "PlaceStick"]
         }
         changed_options = {RobotPressButton, PlaceStick}
         new_options = {RobotMoveToButton, StickMoveToButton}
@@ -370,7 +372,8 @@ class StickButtonMovementGroundTruthOptionFactory(
             dx = dx / max_speed
             dy = dy / max_speed
             # No need to rotate, and we don't want to press until we're there.
-            return Action(np.array([dx, dy, 0.0, -1.0, -1.0], dtype=np.float32))
+            return Action(np.array([dx, dy, 0.0, -1.0, -1.0],
+                                   dtype=np.float32))
 
         return policy
 
@@ -400,7 +403,8 @@ class StickButtonMovementGroundTruthOptionFactory(
                 dx = dx / max_speed
                 dy = dy / max_speed
                 # No need to rotate or press.
-                return Action(np.array([dx, dy, 0.0, -1.0, -1.0], dtype=np.float32))
+                return Action(
+                    np.array([dx, dy, 0.0, -1.0, -1.0], dtype=np.float32))
             assert not CFG.stick_button_disable_angles
             # Otherwise, rotate the stick.
             dtheta = np.clip(desired_theta - stheta,
@@ -408,7 +412,8 @@ class StickButtonMovementGroundTruthOptionFactory(
                              StickButtonEnv.max_angular_speed)
             # Normalize.
             dtheta = dtheta / StickButtonEnv.max_angular_speed
-            return Action(np.array([0.0, 0.0, dtheta, -1.0, -1.0], dtype=np.float32))
+            return Action(
+                np.array([0.0, 0.0, dtheta, -1.0, -1.0], dtype=np.float32))
 
         return policy
 
@@ -419,7 +424,8 @@ class StickButtonMovementGroundTruthOptionFactory(
                    params: Array) -> Action:
             del memory, params  # unused
             robot, button = objects
-            action = Action(np.array([0.0, 0.0, 0.0, -1.0, -1.0], dtype=np.float32))
+            action = Action(
+                np.array([0.0, 0.0, 0.0, -1.0, -1.0], dtype=np.float32))
             # If the robot is above the button, press.
             if StickButtonEnv.Above_holds(state, [robot, button]):
                 action = Action(
@@ -442,9 +448,11 @@ class StickButtonMovementGroundTruthOptionFactory(
             tip_rect = StickButtonEnv.stick_rect_to_tip_rect(stick_rect)
             # If the stick tip is above the button, press.
             if tip_rect.intersects(button_circ):
-                return Action(np.array([0.0, 0.0, 0.0, 1.0, -1.0], dtype=np.float32))
+                return Action(
+                    np.array([0.0, 0.0, 0.0, 1.0, -1.0], dtype=np.float32))
             # Else, do nothing.
-            return Action(np.array([0.0, 0.0, 0.0, -1.0, -1.0], dtype=np.float32))
+            return Action(
+                np.array([0.0, 0.0, 0.0, -1.0, -1.0], dtype=np.float32))
 
         return policy
 
@@ -462,7 +470,8 @@ class StickButtonMovementGroundTruthOptionFactory(
             tx, ty = cls._get_stick_grasp_loc(state, stick, params)
             # If we're close enough to the grasp location, pickplace.
             if (tx - rx)**2 + (ty - ry)**2 < StickButtonEnv.pick_grasp_tol:
-                return Action(np.array([0.0, 0.0, 0.0, -1.0, 1.0], dtype=np.float32))
+                return Action(
+                    np.array([0.0, 0.0, 0.0, -1.0, 1.0], dtype=np.float32))
             # Move toward the target.
             dx = np.clip(tx - rx, -max_speed, max_speed)
             dy = np.clip(ty - ry, -max_speed, max_speed)
@@ -470,7 +479,8 @@ class StickButtonMovementGroundTruthOptionFactory(
             dx = dx / max_speed
             dy = dy / max_speed
             # No need to rotate or press.
-            return Action(np.array([dx, dy, 0.0, -1.0, -1.0], dtype=np.float32))
+            return Action(np.array([dx, dy, 0.0, -1.0, -1.0],
+                                   dtype=np.float32))
 
         return policy
 
@@ -491,7 +501,8 @@ class StickButtonMovementGroundTruthOptionFactory(
             ty = state.get(holder, "y") + offset_y
             # If we're close enough, put the stick down.
             if (tx - rx)**2 + (ty - ry)**2 < StickButtonEnv.pick_grasp_tol:
-                return Action(np.array([0.0, 0.0, 0.0, -1.0, 1.0], dtype=np.float32))
+                return Action(
+                    np.array([0.0, 0.0, 0.0, -1.0, 1.0], dtype=np.float32))
             # Move toward the target.
             dx = np.clip(tx - rx, -max_speed, max_speed)
             dy = np.clip(ty - ry, -max_speed, max_speed)
@@ -499,6 +510,7 @@ class StickButtonMovementGroundTruthOptionFactory(
             dx = dx / max_speed
             dy = dy / max_speed
             # No need to rotate or press.
-            return Action(np.array([dx, dy, 0.0, -1.0, -1.0], dtype=np.float32))
+            return Action(np.array([dx, dy, 0.0, -1.0, -1.0],
+                                   dtype=np.float32))
 
         return policy

--- a/predicators/ground_truth_models/stick_button/options.py
+++ b/predicators/ground_truth_models/stick_button/options.py
@@ -348,7 +348,6 @@ class StickButtonMovementGroundTruthOptionFactory(
         }
         changed_options = {RobotPressButton, PlaceStick}
         new_options = {RobotMoveToButton, StickMoveToButton}
-        # {RobotPressButton, PickStick, StickPressButton, PlaceStick}
 
         return unchanged_options | changed_options | new_options
 

--- a/tests/envs/test_stick_button.py
+++ b/tests/envs/test_stick_button.py
@@ -335,7 +335,7 @@ def test_stick_button_move():
     assert holder_type.name == "holder"
     assert robot_type.name == "robot"
     assert stick_type.name == "stick"
-    assert env.action_space.shape == (4, )
+    assert env.action_space.shape == (5, )
     # Create a custom initial state, with the robot in the middle, one button
     # reachable on the left, one button out of the reachable zone in the middle,
     # and the stick on the right at a 45 degree angle.
@@ -362,6 +362,7 @@ def test_stick_button_move():
     state.set(stick, "x", stick_x)
     state.set(stick, "y", (env.rz_y_ub + env.rz_y_lb) / 4)
     state.set(stick, "theta", np.pi / 4)
+    state.set(stick, "held", 0.0)
     task = EnvironmentTask(state, task.goal)
     env.render_state(state, task)
     assert GroundAtom(AboveNoButton, []).holds(state)
@@ -389,7 +390,9 @@ def test_stick_button_move():
         max_num_steps=1000,
         exceptions_to_break_on={utils.OptionExecutionFailure})
     assert traj.states[-2].get(stick, "held") < 0.5
+    assert traj.states[-2].get(robot, "fingers") > 0.5
     assert traj.states[-1].get(stick, "held") > 0.5
+    assert traj.states[-1].get(robot, "fingers") <= 0.5
 
     # Test StickPressButton without moving first to show it doesn't work.
     option = StickPressButton.ground([robot, stick, unreachable_button], [])

--- a/tests/envs/test_stick_button.py
+++ b/tests/envs/test_stick_button.py
@@ -348,6 +348,7 @@ def test_stick_button_move():
     state.set(robot, "x", robot_x)
     state.set(robot, "y", (env.rz_y_ub + env.rz_y_lb) / 2)
     state.set(robot, "theta", np.pi / 2)
+    state.set(robot, "fingers", 1.0)
     reachable_button, unreachable_button = buttons
     reachable_x = (env.rz_x_ub + env.rz_x_lb) / 4
     state.set(reachable_button, "x", reachable_x)

--- a/tests/envs/test_stick_button.py
+++ b/tests/envs/test_stick_button.py
@@ -479,7 +479,7 @@ def test_stick_button_move():
         "stick_button_disable_angles": True,
         "stick_button_holder_scale": 0.1,
     })
-    env = StickButtonEnv()
+    env = StickButtonMovementEnv()
     # Create a custom initial state, with the robot right on top of the stick
     # and stick holder.
     state = env.get_train_tasks()[0].init.copy()

--- a/tests/envs/test_stick_button.py
+++ b/tests/envs/test_stick_button.py
@@ -495,6 +495,6 @@ def test_stick_button_move():
     state.set(holder, "x", x - (env.holder_height - env.stick_height) / 2)
     state.set(holder, "y", y)
     # Press to pick up the stick.
-    action = Action(np.array([0., 0., 0., 1.], dtype=np.float32))
+    action = Action(np.array([0.0, 0.0, 0.0, -1.0, 1.0], dtype=np.float32))
     next_state = env.simulate(state, action)
     assert state.allclose(next_state)  # should noop

--- a/tests/envs/test_stick_button.py
+++ b/tests/envs/test_stick_button.py
@@ -342,6 +342,7 @@ def test_stick_button_move():
     state = env.get_train_tasks()[0].init.copy()
     robot, = state.get_objects(robot_type)
     stick, = state.get_objects(stick_type)
+    holder, = state.get_objects(holder_type)
     buttons = state.get_objects(button_type)
     assert len(buttons) == 2
     robot_x = (env.rz_x_ub + env.rz_x_lb) / 2
@@ -376,7 +377,6 @@ def test_stick_button_move():
     assert StickPressButton.name == "StickPressButton"
     assert RobotMoveToButton.name == "RobotMoveToButton"
     assert StickMoveToButton.name == "StickMoveToButton"
-
     # Test PickStick.
     option = PickStick.ground([robot, stick], [0.1])
     option_plan = [option]
@@ -432,7 +432,7 @@ def test_stick_button_move():
     # Special test for PlaceStick NSRT because it's not used by oracle.
     nsrts = get_gt_nsrts(env.get_name(), env.predicates, options)
     nsrt = next(iter(n for n in nsrts if n.name == "PlaceStickFromNothing"))
-    ground_nsrt = nsrt.ground([robot, stick])
+    ground_nsrt = nsrt.ground([robot, stick, holder])
     rng = np.random.default_rng(123)
     option = ground_nsrt.sample_option(state, set(), rng)
     assert -1 <= option.params[0] <= 1

--- a/tests/envs/test_stick_button.py
+++ b/tests/envs/test_stick_button.py
@@ -498,3 +498,4 @@ def test_stick_button_move():
     action = Action(np.array([0., 0., 0., 1.], dtype=np.float32))
     next_state = env.simulate(state, action)
     assert state.allclose(next_state)  # should noop
+    

--- a/tests/envs/test_stick_button.py
+++ b/tests/envs/test_stick_button.py
@@ -498,4 +498,3 @@ def test_stick_button_move():
     action = Action(np.array([0., 0., 0., 1.], dtype=np.float32))
     next_state = env.simulate(state, action)
     assert state.allclose(next_state)  # should noop
-    


### PR DESCRIPTION
There were a few conceptual issues in the environment and definitions of nsrts/options for stick button that I wanted to resolve to minimize confusing results when iterating on predicate invention. This PR closes #1626. 

**Summary of changes:**

- Operator RobotPressButton (and its option) had stick as an argument -- but the stick is never used or referenced by the operator or option, so I removed this. 
- Operators RobotMoveToButtonFromNothing and RobotMoveToButtonFromButton don't have stick as an argument, but access its state inside the evaluation of the predicate HandEmpty (which in turn calls the Grasped predicate's classifier). I added a new attribute for the robot (fingers) like we see in PaintingEnv and ToolsEnv and made HandEmpty's classifier look at that attribute. 
- Sometimes when running the option StickPressButton, the holder happens to be nearby and you also place the stick down. To prevent this unwanted behavior, I made the action space have a separate dimension for "press" and "pickplace". 
- The PlaceStick option accesses the holder's state but didn't have it as an option argument, so I added it as an argument to the option and the corresponding operator. 

**Notes about code:**
There is some amount of code duplication in `StickButtonMovementEnv.simulate()` but I thought it's fine because `StickButtonMovementEnv._get_tasks()` already has a lot of duplicated code. 

I only made the changes to StickButtonMovementEnv and not StickButtonEnv because results from previous or other ongoing work may rely on the way stick button currently works, and we're only making use of StickButtonMovementEnv for our predicate invention work -- but if reviewers would like, I can make these changes to StickButtonEnv. 

**Tests:**
`python predicators/main.py --env stick_button_move --approach oracle --seed [n]` gets 28/50, 30/50, 32/50, and 34/50 solved for seeds 0 through 3, for an average of 31/50 solved. The same command before the changes gets 35/50, 29/50, 33/50, and 32/50 solved for seeds 0 through 3, for an average of 32.25/50 solved. I'm not exactly sure why it does a bit worse after these changes (probably just randomness), but I think the difference is small enough to give us confidence that we don't have any significant errors in the code. 
