### PR TITLE
Enable saving an image sequence of each demonstration

### DIFF
--- a/predicators/args.py
+++ b/predicators/args.py
@@ -28,6 +28,7 @@ def create_arg_parser(env_required: bool = True,
     parser.add_argument("--make_failure_videos", action="store_true")
     parser.add_argument("--make_interaction_videos", action="store_true")
     parser.add_argument("--make_demo_videos", action="store_true")
+    parser.add_argument("--make_demo_images", action="store_true")
     parser.add_argument("--make_cogman_videos", action="store_true")
     parser.add_argument("--load_approach", action="store_true")
     # In the case of online learning approaches, load_approach by itself

--- a/predicators/datasets/demo_only.py
+++ b/predicators/datasets/demo_only.py
@@ -195,7 +195,7 @@ def _generate_demonstrations(env: BaseEnv, train_tasks: List[Task],
                                            caption, event_to_action)
                 termination_function = task.goal_holds
 
-            if CFG.make_demo_videos:
+            if CFG.make_demo_videos or CFG.make_demo_images:
                 monitor = utils.VideoMonitor(env.render)
             else:
                 monitor = None
@@ -249,6 +249,13 @@ def _generate_demonstrations(env: BaseEnv, train_tasks: List[Task],
             video = monitor.get_video()
             outfile = f"{CFG.env}__{CFG.seed}__demo__task{idx}.mp4"
             utils.save_video(outfile, video)
+        if CFG.make_demo_images:
+            assert monitor is not None
+            video = monitor.get_video()
+            width = len(str(len(train_tasks)))
+            task_number = str(idx).zfill(width)
+            outfile_prefix = f"{CFG.env}__{CFG.seed}__demo__task{task_number}"
+            utils.save_images(outfile_prefix, video)
     if annotate_with_gt_ops:
         dataset = Dataset(trajectories, annotations)
     else:

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -432,6 +432,7 @@ class GlobalSettings:
     approach_dir = "saved_approaches"
     data_dir = "saved_datasets"
     video_dir = "videos"
+    images_dir = "images"
     video_fps = 2
     failure_video_mode = "longest_only"
 

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -432,7 +432,7 @@ class GlobalSettings:
     approach_dir = "saved_approaches"
     data_dir = "saved_datasets"
     video_dir = "videos"
-    images_dir = "images"
+    image_dir = "images"
     video_fps = 2
     failure_video_mode = "longest_only"
 

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -3167,6 +3167,7 @@ def save_video(outfile: str, video: Video) -> None:
 
 
 def save_images(outfile_prefix: str, video: Video) -> None:
+    """Save the video as individual images to image_dir."""
     outdir = CFG.images_dir
     os.makedirs(outdir, exist_ok=True)
     width = len(str(len(video)))

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -3168,7 +3168,7 @@ def save_video(outfile: str, video: Video) -> None:
 
 def save_images(outfile_prefix: str, video: Video) -> None:
     """Save the video as individual images to image_dir."""
-    outdir = CFG.images_dir
+    outdir = CFG.image_dir
     os.makedirs(outdir, exist_ok=True)
     width = len(str(len(video)))
     for i, image in enumerate(video):

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -3166,6 +3166,18 @@ def save_video(outfile: str, video: Video) -> None:
     logging.info(f"Wrote out to {outpath}")
 
 
+def save_images(outfile_prefix: str, video: Video) -> None:
+    outdir = CFG.images_dir
+    os.makedirs(outdir, exist_ok=True)
+    width = len(str(len(video)))
+    for i, image in enumerate(video):
+        image_number = str(i).zfill(width)
+        outfile = outfile_prefix + f"_image_{image_number}.png"
+        outpath = os.path.join(outdir, outfile)
+        imageio.imwrite(outpath, image)
+        logging.info(f"Wrote out to {outpath}")
+
+
 def get_env_asset_path(asset_name: str, assert_exists: bool = True) -> str:
     """Return the absolute path to env asset."""
     dir_path = os.path.dirname(os.path.realpath(__file__))

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -179,28 +179,34 @@ def test_demo_dataset():
     })
     with pytest.raises(ValueError):
         create_dataset(env, train_tasks, get_gt_options(env.get_name()))
-    # Test demo video generation.
+    # Test demo video and image generation.
     video_dir = os.path.join(os.path.dirname(__file__), "_fake_videos")
+    image_dir = os.path.join(os.path.dirname(__file__), "_fake_images")
     utils.reset_config({
         "env": "cover",
         "offline_data_method": "demo",
         "num_train_tasks": 1,
         "make_demo_videos": True,
+        "make_demo_images": True,
         "cover_num_blocks": 1,
         "cover_num_targets": 1,
         "cover_block_widths": [0.1],
         "cover_target_widths": [0.05],
         "cover_initial_holding_prob": 1.0,
         "video_dir": video_dir,
+        "image_dir": image_dir
     })
     video_file = os.path.join(video_dir, "cover__123__demo__task0.mp4")
+    image_file = os.path.join(image_dir, "cover__123__demo__task0_image_0.png")
     env = CoverEnv()
     train_tasks = [t.task for t in env.get_train_tasks()]
     assert len(train_tasks) == 1
     dataset = create_dataset(env, train_tasks, get_gt_options(env.get_name()))
     assert len(dataset.trajectories) == 1
     assert os.path.exists(video_file)
+    assert os.path.exists(image_file)
     shutil.rmtree(video_dir)
+    shutil.rmtree(image_dir)
     # Test demo collection with bilevel_plan_without_sim.
     utils.reset_config({
         "env": "cover",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2358,7 +2358,7 @@ def test_create_pddl():
                                           "spanner")
     assert domain_str == """(define (domain spanner)
   (:requirements :typing)
-  (:types
+  (:types 
     man nut spanner - locatable
     monkey
     locatable location - object)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2503,7 +2503,7 @@ def test_save_images():
     """Tests for save_images()."""
     dirname = "_fake_tmp_images_dir"
     prefix = "image_prefix"
-    utils.reset_config({"images_dir": dirname})
+    utils.reset_config({"image_dir": dirname})
     rng = np.random.default_rng(123)
     video = [rng.integers(255, size=(3, 3), dtype=np.uint8) for _ in range(3)]
     utils.save_images(prefix, video)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2358,7 +2358,7 @@ def test_create_pddl():
                                           "spanner")
     assert domain_str == """(define (domain spanner)
   (:requirements :typing)
-  (:types 
+  (:types
     man nut spanner - locatable
     monkey
     locatable location - object)
@@ -2496,6 +2496,20 @@ def test_save_video():
     video = [rng.integers(255, size=(3, 3), dtype=np.uint8) for _ in range(3)]
     utils.save_video(filename, video)
     os.remove(os.path.join(dirname, filename))
+    os.rmdir(dirname)
+
+
+def test_save_images():
+    """Tests for save_images()."""
+    dirname = "_fake_tmp_images_dir"
+    prefix = "image_prefix"
+    utils.reset_config({"images_dir": dirname})
+    rng = np.random.default_rng(123)
+    video = [rng.integers(255, size=(3, 3), dtype=np.uint8) for _ in range(3)]
+    utils.save_images(prefix, video)
+    os.remove(os.path.join(dirname, prefix + "_image_0.png"))
+    os.remove(os.path.join(dirname, prefix + "_image_1.png"))
+    os.remove(os.path.join(dirname, prefix + "_image_2.png"))
     os.rmdir(dirname)
 
 


### PR DESCRIPTION
For predicate invention with a video-language model, we need to pass in images of the demonstrations to the VLM. This PR adds the flag `--make_demo_images`, which puts image sequences of each demonstration inside `CFG.image_dir` for debugging purposes, analagous to how `--make_demo_videos` puts videos in `CFG.video_dir`. 