### PR TITLE
fix segmentation error with predicate invention from txt files or img demos

### DIFF
--- a/predicators/approaches/nsrt_learning_approach.py
+++ b/predicators/approaches/nsrt_learning_approach.py
@@ -74,6 +74,27 @@ class NSRTLearningApproach(BilevelPlanningApproach):
             ground_atom_dataset = utils.create_ground_atom_dataset(
                 trajectories, self._get_current_predicates())
             utils.save_ground_atom_dataset(ground_atom_dataset, dataset_fname)
+        elif CFG.offline_data_method in ["demo+labelled_atoms", "img_demos"]:
+            # In this case, the annotations aren't basically ground atoms!
+            # We can use these to make GroundAtomTrajectories.
+            assert annotations is not None
+            assert len(annotations) == len(trajectories)
+            ground_atom_dataset = []
+            annotations_with_only_known_preds = []
+            known_preds = self._get_current_predicates()
+            for atoms_traj in annotations:
+                curr_known_preds_atoms_traj = []
+                for atoms_set in atoms_traj:
+                    curr_known_preds_atoms_set = set(
+                        atom for atom in atoms_set
+                        if atom.predicate in known_preds)
+                    curr_known_preds_atoms_traj.append(
+                        curr_known_preds_atoms_set)
+                annotations_with_only_known_preds.append(
+                    curr_known_preds_atoms_traj)
+            for ll_traj, atoms in zip(trajectories,
+                                      annotations_with_only_known_preds):
+                ground_atom_dataset.append((ll_traj, atoms))
         self._nsrts, self._segmented_trajs, self._seg_to_nsrt = \
             learn_nsrts_from_data(trajectories,
                                   self._train_tasks,

--- a/predicators/approaches/nsrt_learning_approach.py
+++ b/predicators/approaches/nsrt_learning_approach.py
@@ -75,25 +75,25 @@ class NSRTLearningApproach(BilevelPlanningApproach):
                 trajectories, self._get_current_predicates())
             utils.save_ground_atom_dataset(ground_atom_dataset, dataset_fname)
         elif CFG.offline_data_method in ["demo+labelled_atoms", "img_demos"]:
-            # In this case, the annotations aren't basically ground atoms!
+            # In this case, the annotations are basically ground atoms!
             # We can use these to make GroundAtomTrajectories.
             assert annotations is not None
             assert len(annotations) == len(trajectories)
             ground_atom_dataset = []
-            annotations_with_only_known_preds = []
-            known_preds = self._get_current_predicates()
+            annotations_with_only_selected_preds = []
+            selected_preds = self._get_current_predicates()
             for atoms_traj in annotations:
-                curr_known_preds_atoms_traj = []
+                curr_selected_preds_atoms_traj = []
                 for atoms_set in atoms_traj:
-                    curr_known_preds_atoms_set = set(
+                    curr_selected_preds_atoms_set = set(
                         atom for atom in atoms_set
-                        if atom.predicate in known_preds)
-                    curr_known_preds_atoms_traj.append(
-                        curr_known_preds_atoms_set)
-                annotations_with_only_known_preds.append(
-                    curr_known_preds_atoms_traj)
+                        if atom.predicate in selected_preds)
+                    curr_selected_preds_atoms_traj.append(
+                        curr_selected_preds_atoms_set)
+                annotations_with_only_selected_preds.append(
+                    curr_selected_preds_atoms_traj)
             for ll_traj, atoms in zip(trajectories,
-                                      annotations_with_only_known_preds):
+                                      annotations_with_only_selected_preds):
                 ground_atom_dataset.append((ll_traj, atoms))
         self._nsrts, self._segmented_trajs, self._seg_to_nsrt = \
             learn_nsrts_from_data(trajectories,

--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -197,7 +197,7 @@ def test_invention_from_txt_file():
     # invention to not select any of the predicates (only select the goal)
     # predicates.
     assert len(approach._get_current_predicates()) == 1  # pylint:disable=protected-access
-    assert approach._get_current_predicates() == env.goal_predicates
+    assert approach._get_current_predicates() == env.goal_predicates  # pylint:disable=protected-access
 
 
 def test_euclidean_grammar():

--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -15,14 +15,14 @@ from predicators.approaches.grammar_search_invention_approach import \
     _halving_constant_generator, _NegationClassifier, _PredicateGrammar, \
     _SingleAttributeCompareClassifier, \
     _SingleFeatureInequalitiesPredicateGrammar, _UnaryFreeForallClassifier
+from predicators.datasets import create_dataset
 from predicators.envs.cover import CoverEnv
 from predicators.envs.stick_button import StickButtonMovementEnv
+from predicators.envs.vlm_envs import IceTeaMakingEnv
 from predicators.ground_truth_models import get_gt_options
 from predicators.settings import CFG
 from predicators.structs import Action, Dataset, LowLevelTrajectory, Object, \
     Predicate, State, Type
-from predicators.envs.vlm_envs import IceTeaMakingEnv
-from predicators.datasets import create_dataset
 
 
 @pytest.mark.parametrize("segmenter", ["atom_changes", "contacts"])
@@ -192,7 +192,7 @@ def test_invention_from_txt_file():
                                               env.types, env.action_space,
                                               train_tasks)
     approach.learn_from_offline_dataset(loaded_dataset)
-    assert len(approach._get_current_predicates()) == 1
+    assert len(approach._get_current_predicates()) == 1  # pylint:disable=protected-access
 
 
 def test_euclidean_grammar():

--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -192,7 +192,12 @@ def test_invention_from_txt_file():
                                               env.types, env.action_space,
                                               train_tasks)
     approach.learn_from_offline_dataset(loaded_dataset)
+    # The ice_tea_making__demo+labelled_atoms__manual__1.txt happens to
+    # set all atoms to True at all timesteps, and so we expect predicate
+    # invention to not select any of the predicates (only select the goal)
+    # predicates.
     assert len(approach._get_current_predicates()) == 1  # pylint:disable=protected-access
+    assert approach._get_current_predicates() == env.goal_predicates
 
 
 def test_euclidean_grammar():


### PR DESCRIPTION
Previously, our approach would error out and die whenever we ran predicate invention via the newly-implemented txt file or img demos features. This is because segmentation called from `nsrt_learning_approach.py` tries to call `utils.abstract` on the proposed predicates, and can't (because they're VLM predicates and their classifiers haven't been implemented yet!). But of course, we know what the abstract states are for all the demonstrations, so this PR just passes that along correctly, and now `nsrt_learning` runs without erroring out!