### PR TITLE
fix some minor prompting + parsing issues

### DIFF
--- a/predicators/datasets/generate_atom_trajs_with_vlm.py
+++ b/predicators/datasets/generate_atom_trajs_with_vlm.py
@@ -63,7 +63,8 @@ def _generate_prompt_for_atom_proposals(
             (prompt, [traj.imgs[i][0] for i in range(len(traj.imgs))]))
     elif CFG.grammar_search_vlm_atom_proposal_prompt_type == \
         "options_labels_whole_traj":
-        prompt += "\n".join(act.name + str(sorted(act.objects))
+        prompt += "\nSkills executed in trajectory:\n"
+        prompt += "\n".join(act.name + str(act.objects)
                             for act in traj.actions)
         # NOTE: exact same issue as described in the above note for
         # naive_whole_traj.
@@ -180,7 +181,7 @@ def _parse_unique_atom_proposals_from_list(
         assert len(atoms_proposal_for_traj) == 1
         curr_atoms_proposal = atoms_proposal_for_traj[0]
         # Regex pattern to match predicates
-        atom_match_pattern = r"\b[a-z_]+\([a-z0-9, ]+\)"
+        atom_match_pattern = r"\b[a-z_]+\([a-z0-9_, ]+\)"
         # Find all matches in the text
         matches = re.findall(atom_match_pattern,
                              curr_atoms_proposal,


### PR DESCRIPTION
Previously, we weren't labelling one of the atom proposal prompts with "Skills executed in trajectory" (rather, we directly just vomited the skills there out of context), and also we didn't parse out any predicates that had objects with `_` in them (because this didn't happen in our example!). This quick PR fixes these before I forget