### PR TITLE
Test-time VLM Predicate evaluation

### DIFF
--- a/predicators/datasets/generate_atom_trajs_with_vlm.py
+++ b/predicators/datasets/generate_atom_trajs_with_vlm.py
@@ -20,7 +20,7 @@ from predicators.pretrained_model_interface import GoogleGeminiVLM, \
 from predicators.settings import CFG
 from predicators.structs import Action, Dataset, GroundAtom, \
     ImageOptionTrajectory, LowLevelTrajectory, Object, ParameterizedOption, \
-    State, Task, VLMPredicate, _Option
+    State, Task, _Option
 
 
 def _generate_prompt_for_atom_proposals(
@@ -274,12 +274,7 @@ def _parse_structured_state_into_ground_atoms(
         assert obj_type.name == "object"
     assert obj_type is not None
 
-    def _stripped_classifier(
-            state: State,
-            objects: Sequence[Object]) -> bool:  # pragma: no cover.
-        raise Exception("Stripped classifier should never be called!")
-
-    def _vlm_query_str(pred_name: str, objects: Sequence[Object]) -> str:
+    def _get_vlm_query_str(pred_name: str, objects: Sequence[Object]) -> str:
         return pred_name + "(" + ", ".join(
             str(obj.name) for obj in objects) + ")"  # pragma: no cover
 
@@ -317,9 +312,10 @@ def _parse_structured_state_into_ground_atoms(
                             for obj_name in obj_args:
                                 curr_obj = curr_obj_name_to_obj[obj_name]
                                 pred_types.append(curr_obj.type)
-                            pred_name_to_pred[pred_name] = VLMPredicate(
-                                pred_name, pred_types, _stripped_classifier,
-                                partial(_vlm_query_str, pred_name))
+                            pred_name_to_pred[
+                                pred_name] = utils.create_vlm_predicate(
+                                    pred_name, pred_types,
+                                    partial(_get_vlm_query_str, pred_name))
                     else:
                         # In this case, we need to make a predicate that
                         # takes in the generic 'object' type such that
@@ -335,10 +331,10 @@ def _parse_structured_state_into_ground_atoms(
                                 assert num_args == len(obj_args)
                         # Given this, add one new predicate with num_args
                         # number of 'object' type arguments.
-                        pred_name_to_pred[pred_name] = VLMPredicate(
-                            pred_name, [obj_type for _ in range(num_args)],
-                            _stripped_classifier,
-                            partial(_vlm_query_str, pred_name))
+                        pred_name_to_pred[
+                            pred_name] = utils.create_vlm_predicate(
+                                pred_name, [obj_type for _ in range(num_args)],
+                                partial(_get_vlm_query_str, pred_name))
 
                 # Given that we've now built up predicates and object
                 # dictionaries. We can now convert the current state into

--- a/predicators/datasets/generate_atom_trajs_with_vlm.py
+++ b/predicators/datasets/generate_atom_trajs_with_vlm.py
@@ -5,6 +5,7 @@ import glob
 import logging
 import os
 import re
+from functools import partial
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Set, Tuple
 
@@ -19,7 +20,7 @@ from predicators.pretrained_model_interface import GoogleGeminiVLM, \
 from predicators.settings import CFG
 from predicators.structs import Action, Dataset, GroundAtom, \
     ImageOptionTrajectory, LowLevelTrajectory, Object, ParameterizedOption, \
-    Predicate, State, Task, _Option
+    State, Task, VLMPredicate, _Option
 
 
 def _generate_prompt_for_atom_proposals(
@@ -278,6 +279,10 @@ def _parse_structured_state_into_ground_atoms(
             objects: Sequence[Object]) -> bool:  # pragma: no cover.
         raise Exception("Stripped classifier should never be called!")
 
+    def _vlm_query_str(pred_name: str, objects: Sequence[Object]) -> str:
+        return pred_name + "(" + ", ".join(
+            str(obj.name) for obj in objects) + ")"  # pragma: no cover
+
     pred_name_to_pred = {}
     atoms_trajs = []
     # Loop through all trajectories in the structured_state_trajs and convert
@@ -312,8 +317,9 @@ def _parse_structured_state_into_ground_atoms(
                             for obj_name in obj_args:
                                 curr_obj = curr_obj_name_to_obj[obj_name]
                                 pred_types.append(curr_obj.type)
-                            pred_name_to_pred[pred_name] = Predicate(
-                                pred_name, pred_types, _stripped_classifier)
+                            pred_name_to_pred[pred_name] = VLMPredicate(
+                                pred_name, pred_types, _stripped_classifier,
+                                partial(_vlm_query_str, pred_name))
                     else:
                         # In this case, we need to make a predicate that
                         # takes in the generic 'object' type such that
@@ -329,9 +335,10 @@ def _parse_structured_state_into_ground_atoms(
                                 assert num_args == len(obj_args)
                         # Given this, add one new predicate with num_args
                         # number of 'object' type arguments.
-                        pred_name_to_pred[pred_name] = Predicate(
+                        pred_name_to_pred[pred_name] = VLMPredicate(
                             pred_name, [obj_type for _ in range(num_args)],
-                            _stripped_classifier)
+                            _stripped_classifier,
+                            partial(_vlm_query_str, pred_name))
 
                 # Given that we've now built up predicates and object
                 # dictionaries. We can now convert the current state into

--- a/predicators/envs/kitchen.py
+++ b/predicators/envs/kitchen.py
@@ -220,7 +220,7 @@ README of that repo suggests!"
             VLMPredicate(
                 "KettleOnTopStove", [cls.kettle_type],
                 lambda s, o: NotImplementedError("shouldn't be calling this!"),
-                "kettle_ontop_stove")
+                lambda o: "kettle_ontop_stove()")
         }
 
         return {p.name: p for p in preds}

--- a/predicators/envs/kitchen.py
+++ b/predicators/envs/kitchen.py
@@ -19,7 +19,7 @@ from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
 from predicators.structs import Action, EnvironmentTask, Image, Object, \
-    Observation, Predicate, State, Type, Video, VLMPredicate
+    Observation, Predicate, State, Type, Video
 
 _TRACKED_SITES = [
     "hinge_site1", "hinge_site2", "kettle_site", "microhandle_site",
@@ -217,10 +217,6 @@ README of that repo suggests!"
             Predicate("TurnedOff", [cls.on_off_type], cls.Off_holds),
             Predicate("Open", [cls.on_off_type], cls.Open_holds),
             Predicate("Closed", [cls.on_off_type], cls.Closed_holds),
-            VLMPredicate(
-                "KettleOnTopStove", [cls.kettle_type],
-                lambda s, o: NotImplementedError("shouldn't be calling this!"),
-                lambda o: "kettle_ontop_stove()")
         }
 
         return {p.name: p for p in preds}

--- a/predicators/envs/kitchen.py
+++ b/predicators/envs/kitchen.py
@@ -19,7 +19,7 @@ from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
 from predicators.structs import Action, EnvironmentTask, Image, Object, \
-    Observation, Predicate, State, Type, Video
+    Observation, Predicate, State, Type, Video, VLMPredicate
 
 _TRACKED_SITES = [
     "hinge_site1", "hinge_site2", "kettle_site", "microhandle_site",
@@ -217,7 +217,12 @@ README of that repo suggests!"
             Predicate("TurnedOff", [cls.on_off_type], cls.Off_holds),
             Predicate("Open", [cls.on_off_type], cls.Open_holds),
             Predicate("Closed", [cls.on_off_type], cls.Closed_holds),
+            VLMPredicate(
+                "KettleOnTopStove", [cls.kettle_type],
+                lambda s, o: NotImplementedError("shouldn't be calling this!"),
+                "kettle_ontop_stove")
         }
+
         return {p.name: p for p in preds}
 
     @property
@@ -256,7 +261,8 @@ README of that repo suggests!"
         if self._using_gui:
             self._gym_env.render()
         self._current_observation = {
-            "state_info": self.get_object_centric_state_info()
+            "state_info": self.get_object_centric_state_info(),
+            "obs_images": [self._gym_env.render()]
         }
         return self._copy_observation(self._current_observation)
 
@@ -348,7 +354,10 @@ README of that repo suggests!"
 
     def _reset_initial_state_from_seed(self, seed: int) -> Observation:
         self._gym_env.reset(seed=seed)
-        return {"state_info": self.get_object_centric_state_info()}
+        return {
+            "state_info": self.get_object_centric_state_info(),
+            "obs_images": [self._gym_env.render()]
+        }
 
     @classmethod
     def _AtPreTurn_holds(cls, state: State, objects: Sequence[Object],

--- a/predicators/execution_monitoring/expected_atoms_monitor.py
+++ b/predicators/execution_monitoring/expected_atoms_monitor.py
@@ -3,10 +3,11 @@ suggest replanning when the expected atoms check is not met."""
 
 import logging
 
+from predicators import utils
 from predicators.execution_monitoring.base_execution_monitor import \
     BaseExecutionMonitor
 from predicators.settings import CFG
-from predicators.structs import State
+from predicators.structs import State, VLMPredicate
 
 
 class ExpectedAtomsExecutionMonitor(BaseExecutionMonitor):
@@ -30,9 +31,20 @@ class ExpectedAtomsExecutionMonitor(BaseExecutionMonitor):
         self._curr_plan_timestep += 1
         # If the expected atoms are a subset of the current atoms, then
         # we don't have to replan.
-        # TODO: replace with something that's smarter and batches VLM predicate
-        # calls!
-        unsat_atoms = {a for a in next_expected_atoms if not a.holds(state)}
+        next_expected_vlm_atoms = set(
+            atom for atom in next_expected_atoms
+            if isinstance(atom.predicate, VLMPredicate))
+        non_vlm_unsat_atoms = {
+            a
+            for a in (next_expected_atoms - next_expected_vlm_atoms)
+            if not a.holds(state)
+        }
+        vlm_unsat_atoms = set()
+        if len(next_expected_vlm_atoms) > 0:
+            vlm_unsat_atoms = utils.query_vlm_for_atom_vals(
+                sorted(list(next_expected_vlm_atoms)),
+                state)  # pragma: no cover.
+        unsat_atoms = non_vlm_unsat_atoms | vlm_unsat_atoms
         if not unsat_atoms:
             return False
         logging.info(

--- a/predicators/execution_monitoring/expected_atoms_monitor.py
+++ b/predicators/execution_monitoring/expected_atoms_monitor.py
@@ -42,8 +42,7 @@ class ExpectedAtomsExecutionMonitor(BaseExecutionMonitor):
         vlm_unsat_atoms = set()
         if len(next_expected_vlm_atoms) > 0:
             vlm_unsat_atoms = utils.query_vlm_for_atom_vals(
-                sorted(list(next_expected_vlm_atoms)),
-                state)  # pragma: no cover.
+                next_expected_vlm_atoms, state)  # pragma: no cover
         unsat_atoms = non_vlm_unsat_atoms | vlm_unsat_atoms
         if not unsat_atoms:
             return False

--- a/predicators/execution_monitoring/expected_atoms_monitor.py
+++ b/predicators/execution_monitoring/expected_atoms_monitor.py
@@ -30,6 +30,8 @@ class ExpectedAtomsExecutionMonitor(BaseExecutionMonitor):
         self._curr_plan_timestep += 1
         # If the expected atoms are a subset of the current atoms, then
         # we don't have to replan.
+        # TODO: replace with something that's smarter and batches VLM predicate
+        # calls!
         unsat_atoms = {a for a in next_expected_atoms if not a.holds(state)}
         if not unsat_atoms:
             return False

--- a/predicators/perception/kitchen_perceiver.py
+++ b/predicators/perception/kitchen_perceiver.py
@@ -48,7 +48,9 @@ class KitchenPerceiver(BasePerceiver):
         return self._observation_to_state(observation)
 
     def _observation_to_state(self, obs: Observation) -> State:
-        return KitchenEnv.state_info_to_state(obs["state_info"])
+        state = KitchenEnv.state_info_to_state(obs["state_info"])
+        state.simulator_state = obs["obs_images"]
+        return state
 
     def render_mental_images(self, observation: Observation,
                              env_task: EnvironmentTask) -> Video:

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -311,27 +311,10 @@ class VLMPredicate(Predicate):
     classifier (i.e., one that returns simply raises some kind of error instead
     of actually outputting a value of any kind).
     """
-    _vlm_query_str: str  # NOTE: this is often an f-string of some kind!
+    get_vlm_query_str: Callable[[Sequence[Object]], str]
 
     def __hash__(self) -> int:
         return self._hash
-
-    def get_vlm_query_str(self, objects: Sequence[Object]) -> str:
-        """Get the string necessary to query a VLM to get the truth value of
-        this predicate."""
-        # The VLM query string can fall into 1 of 3 categories:
-        # (1) it isn't an f-string that needs substitution in any way.
-        if "{" not in self._vlm_query_str:
-            return self._vlm_query_str
-        # (2) it is an f-string, and has a single argument called 'objs'
-        elif "{objs}" in self._vlm_query_str:
-            return self._vlm_query_str.format(
-                objs=[obj.name for obj in objects])
-        # (3) it is an f-strong and has one argument for every single object in
-        # 'objects', In this case, pass in these objects one by one.
-        else:
-            assert self._vlm_query_str.count("{") == len(objects)
-            return self._vlm_query_str.format(obj.name for obj in objects)
 
 
 @dataclass(frozen=True, repr=False, eq=False)

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -209,7 +209,7 @@ class State:
 DefaultState = State({})
 
 
-@dataclass(frozen=True, order=True, repr=False)
+@dataclass(frozen=True, order=False, repr=False)
 class Predicate:
     """Struct defining a predicate (a lifted classifier over states)."""
     name: str
@@ -301,8 +301,11 @@ class Predicate:
         # Separate this into a named function for pickling reasons.
         return not self._classifier(state, objects)
 
+    def __lt__(self, other: Predicate) -> bool:
+        return str(self) < str(other)
 
-@dataclass(frozen=True, order=True, repr=False)
+
+@dataclass(frozen=True, order=False, repr=False)
 class VLMPredicate(Predicate):
     """Struct defining a predicate that calls a VLM as part of returning its
     truth value.
@@ -427,7 +430,7 @@ class GroundAtom(_Atom):
         """If this GroundAtom is associated with a VLMPredicate, then get the
         string that will be used to query the VLM."""
         assert isinstance(self.predicate, VLMPredicate)
-        return self.predicate.get_vlm_query_str(self.objects)
+        return self.predicate.get_vlm_query_str(self.objects)  # pylint:disable=no-member
 
 
 @dataclass(frozen=True, eq=False)

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -305,7 +305,7 @@ class Predicate:
         return str(self) < str(other)
 
 
-@dataclass(frozen=True, order=False, repr=False)
+@dataclass(frozen=True, order=False, repr=False, eq=False)
 class VLMPredicate(Predicate):
     """Struct defining a predicate that calls a VLM as part of returning its
     truth value.
@@ -315,9 +315,6 @@ class VLMPredicate(Predicate):
     of actually outputting a value of any kind).
     """
     get_vlm_query_str: Callable[[Sequence[Object]], str]
-
-    def __hash__(self) -> int:
-        return self._hash
 
 
 @dataclass(frozen=True, repr=False, eq=False)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,12 +17,33 @@ from predicators.envs.pddl_env import ProceduralTasksGripperPDDLEnv, \
 from predicators.ground_truth_models import _get_predicates_by_names, \
     get_gt_nsrts, get_gt_options
 from predicators.nsrt_learning.segmentation import segment_trajectory
+from predicators.pretrained_model_interface import VisionLanguageModel
 from predicators.settings import CFG
 from predicators.structs import NSRT, Action, DefaultState, DummyOption, \
     GroundAtom, LowLevelTrajectory, ParameterizedOption, Predicate, Segment, \
-    State, STRIPSOperator, Type, Variable
+    State, STRIPSOperator, Type, Variable, VLMPredicate
 from predicators.utils import GoalCountHeuristic, _PyperplanHeuristicWrapper, \
     _TaskPlanningHeuristic
+
+
+class _DummyVLM(VisionLanguageModel):
+
+    def get_id(self):
+        return "dummy"
+
+    def _sample_completions(self,
+                            prompt,
+                            imgs,
+                            temperature,
+                            seed,
+                            stop_token=None,
+                            num_completions=1):
+        del prompt, imgs, temperature, seed, stop_token  # unused.
+        completions = []
+        for _ in range(num_completions):
+            completion = "is_fishy: True."
+            completions.append(completion)
+        return completions
 
 
 @pytest.mark.parametrize("max_groundings,exp_num_true,exp_num_false",
@@ -1099,6 +1120,15 @@ def test_abstract():
     }
     # Wrapping a predicate should destroy its classifier.
     assert not utils.abstract(state, {wrapped_pred1, wrapped_pred2})
+    # Now, test the case where we abstract using a VLM predicate.
+    utils.reset_config({"seed": 123})
+    vlm_pred = VLMPredicate("IsFishy", [], lambda s, o: NotImplementedError,
+                            lambda o: "is_fishy")
+    vlm_state = state.copy()
+    vlm_state.simulator_state = [np.zeros((30, 30, 3), dtype=np.uint8)]
+    vlm_atoms_set = utils.abstract(vlm_state, [vlm_pred], _DummyVLM())
+    assert len(vlm_atoms_set) == 1
+    assert "IsFishy" in str(vlm_atoms_set)
 
 
 def test_create_new_variables():


### PR DESCRIPTION
Implements a new `VLMPredicate` class that can be called at test time, makes sure that these are called during abstraction in a batched fashion (implements a new `utils` function for this), modifies execution monitor accordingly.