### PR TITLE
Fix annoying kitchen test time bug

### DIFF
--- a/predicators/envs/kitchen.py
+++ b/predicators/envs/kitchen.py
@@ -477,11 +477,12 @@ README of that repo suggests!"
     def On_holds(cls,
                  state: State,
                  objects: Sequence[Object],
-                 thresh_pad: float = 0.0) -> bool:
+                 thresh_pad: float = -0.03) -> bool:
         """Made public for use in ground-truth options."""
         obj = objects[0]
         if obj.is_instance(cls.knob_type):
-            return state.get(obj, "angle") < cls.on_angle_thresh - thresh_pad
+            ret_val = state.get(obj, "angle") < cls.on_angle_thresh - thresh_pad
+            return ret_val
         if obj.is_instance(cls.switch_type):
             return state.get(obj, "x") < cls.light_on_thresh - thresh_pad
         return False

--- a/predicators/envs/kitchen.py
+++ b/predicators/envs/kitchen.py
@@ -481,8 +481,7 @@ README of that repo suggests!"
         """Made public for use in ground-truth options."""
         obj = objects[0]
         if obj.is_instance(cls.knob_type):
-            ret_val = state.get(obj, "angle") < cls.on_angle_thresh - thresh_pad
-            return ret_val
+            return state.get(obj, "angle") < cls.on_angle_thresh - thresh_pad
         if obj.is_instance(cls.switch_type):
             return state.get(obj, "x") < cls.light_on_thresh - thresh_pad
         return False


### PR DESCRIPTION
I was seeing this strange behavior where even though we're outputting good plans at test-time and executing them correctly, we fail to solve test-tasks from time to time. e.g. this command:
```
python predicators/main.py --env kitchen --approach grammar_search_invention --seed 0 --num_train_tasks 1 --num_test_tasks 1 --bilevel_plan_without_sim True --perceiver kitchen --offline_data_method demo_with_vlm_imgs --vlm_model_name gemini-1.5-pro-latest --segmenter every_step --grammar_search_vlm_atom_proposal_prompt_type options_labels_whole_traj --grammar_search_task_planning_timeout 10.0 --sesame_max_skeletons_optimized 200 --excluded_predicates all --disable_harmlessness_check True --debug --kitchen_goals boil_kettle --kitchen_use_perfect_samplers True --grammar_search_vlm_atom_proposal_use_debug True --excluded_predicates Open --make_failure_videos
```

achieves 0/1 success rate at test time despite basically having all the predicates it needs.

Turns out this is because of weird drift in the state of the knob over time. We needed a small threshold to make this drift doesn't accidentally trip the classifier.

Now the above command achieves perfect success at test-time!