### PR TITLE
Making "combined" options and NSRT's for kitchen

### DIFF
--- a/predicators/ground_truth_models/kitchen/nsrts.py
+++ b/predicators/ground_truth_models/kitchen/nsrts.py
@@ -99,7 +99,7 @@ class KitchenGroundTruthNSRTFactory(GroundTruthNSRTFactory):
                                          delete_effects, ignore_effects,
                                          option, option_vars,
                                          moveto_preturnoff_sampler)
-        nsrts.add(move_to_pre_turn_off_nsrt)
+        
 
         # MoveToPreTurnOn
         parameters = [gripper, on_off_obj]
@@ -125,7 +125,6 @@ class KitchenGroundTruthNSRTFactory(GroundTruthNSRTFactory):
                                         preconditions, add_effects,
                                         delete_effects, ignore_effects, option,
                                         option_vars, moveto_preturnon_sampler)
-        nsrts.add(move_to_pre_turn_on_nsrt)
 
         # MoveToPrePushOnTop
         parameters = [gripper, kettle]
@@ -155,7 +154,6 @@ class KitchenGroundTruthNSRTFactory(GroundTruthNSRTFactory):
                                             delete_effects, ignore_effects,
                                             option, option_vars,
                                             moveto_prepushontop_sampler)
-        nsrts.add(move_to_pre_push_on_top_nsrt)
 
         # MoveToPrePullKettle
         parameters = [gripper, kettle]
@@ -184,7 +182,6 @@ class KitchenGroundTruthNSRTFactory(GroundTruthNSRTFactory):
                                             delete_effects, ignore_effects,
                                             option, option_vars,
                                             moveto_prepullkettle_sampler)
-        nsrts.add(move_to_pre_pull_kettle_nsrt)
 
         # PushObjOnObjForward
         parameters = [gripper, kettle, surface_from, surface_to]
@@ -219,7 +216,6 @@ class KitchenGroundTruthNSRTFactory(GroundTruthNSRTFactory):
                                             delete_effects, ignore_effects,
                                             option, option_vars,
                                             push_obj_on_obj_forward_sampler)
-        nsrts.add(push_obj_on_obj_forward_nsrt)
 
         # PushObjOnObjForwardToBoilKettle
         parameters = [gripper, kettle, surface_from, surface_to, knob]
@@ -247,7 +243,6 @@ class KitchenGroundTruthNSRTFactory(GroundTruthNSRTFactory):
                                             ignore_effects, option,
                                             option_vars,
                                             push_obj_on_obj_forward_sampler)
-        nsrts.add(push_obj_on_obj_forward_nsrt)
 
         # PullKettle
         parameters = [gripper, kettle, surface_from, surface_to]
@@ -279,7 +274,6 @@ class KitchenGroundTruthNSRTFactory(GroundTruthNSRTFactory):
         pull_kettle_nsrt = NSRT("PullKettle", parameters, preconditions,
                                 add_effects, delete_effects, ignore_effects,
                                 option, option_vars, pull_kettle_sampler)
-        nsrts.add(pull_kettle_nsrt)
 
         # TurnOffSwitch
         parameters = [gripper, switch]
@@ -313,7 +307,6 @@ class KitchenGroundTruthNSRTFactory(GroundTruthNSRTFactory):
                                     add_effects, delete_effects,
                                     ignore_effects, option, option_vars,
                                     switch_turn_sampler)
-        nsrts.add(turn_off_switch_nsrt)
 
         # TurnOnSwitch
         parameters = [gripper, switch]
@@ -332,7 +325,6 @@ class KitchenGroundTruthNSRTFactory(GroundTruthNSRTFactory):
         turn_on_switch_nsrt = NSRT("TurnOnSwitch", parameters, preconditions,
                                    add_effects, delete_effects, ignore_effects,
                                    option, option_vars, switch_turn_sampler)
-        nsrts.add(turn_on_switch_nsrt)
 
         # TurnOnKnob
         parameters = [gripper, knob]
@@ -363,7 +355,6 @@ class KitchenGroundTruthNSRTFactory(GroundTruthNSRTFactory):
         turn_on_knob_nsrt = NSRT("TurnOnKnob", parameters, preconditions,
                                  add_effects, delete_effects, ignore_effects,
                                  option, option_vars, knob_turn_on_sampler)
-        nsrts.add(turn_on_knob_nsrt)
 
         # TurnOnKnobAndBoilKettle
         parameters = [gripper, knob, surface_to, kettle]
@@ -387,7 +378,6 @@ class KitchenGroundTruthNSRTFactory(GroundTruthNSRTFactory):
                                  preconditions, add_effects, delete_effects,
                                  ignore_effects, option, option_vars,
                                  knob_turn_on_sampler)
-        nsrts.add(turn_on_knob_nsrt)
 
         # TurnOffKnob
         parameters = [gripper, knob]
@@ -417,7 +407,6 @@ class KitchenGroundTruthNSRTFactory(GroundTruthNSRTFactory):
         turn_off_knob_nsrt = NSRT("TurnOffKnob", parameters, preconditions,
                                   add_effects, delete_effects, ignore_effects,
                                   option, option_vars, knob_turn_off_sampler)
-        nsrts.add(turn_off_knob_nsrt)
 
         # PushOpenHingeDoor
         parameters = [gripper, hinge_door]
@@ -459,7 +448,6 @@ class KitchenGroundTruthNSRTFactory(GroundTruthNSRTFactory):
                                          delete_effects, ignore_effects,
                                          option, option_vars,
                                          push_open_hinge_door_sampler)
-        nsrts.add(push_open_hinge_door_nsrt)
 
         # PushCloseHingeDoor
         parameters = [gripper, hinge_door]
@@ -499,6 +487,21 @@ class KitchenGroundTruthNSRTFactory(GroundTruthNSRTFactory):
                                           delete_effects, ignore_effects,
                                           option, option_vars,
                                           push_close_hinge_door_sampler)
+
+        # Add all the NSRTs
+        nsrts.add(move_to_pre_push_on_top_nsrt)
+        nsrts.add(move_to_pre_pull_kettle_nsrt)
+        nsrts.add(push_obj_on_obj_forward_nsrt)
+        nsrts.add(push_obj_on_obj_forward_nsrt)
+        nsrts.add(pull_kettle_nsrt)
+        nsrts.add(turn_off_switch_nsrt)
+        nsrts.add(turn_on_switch_nsrt)
+        nsrts.add(turn_on_knob_nsrt)
+        nsrts.add(turn_on_knob_nsrt)
+        nsrts.add(turn_off_knob_nsrt)
+        nsrts.add(push_open_hinge_door_nsrt)
+        nsrts.add(move_to_pre_turn_on_nsrt)
+        nsrts.add(move_to_pre_turn_off_nsrt)
         nsrts.add(push_close_hinge_door_nsrt)
 
         return nsrts

--- a/predicators/ground_truth_models/kitchen/options.py
+++ b/predicators/ground_truth_models/kitchen/options.py
@@ -143,7 +143,7 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
 
         # Create copies just to preserve one-to-one-ness with NSRTs.
         for suffix in ["PreTurnOn", "PreTurnOff"]:
-            nsrt = ParameterizedOption(
+            opt = ParameterizedOption(
                 f"MoveTo{suffix}",
                 types=[gripper_type, on_off_type],
                 # Parameter is a position to move to relative to the object.
@@ -152,7 +152,7 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
                 initiable=_MoveTo_initiable,
                 terminal=_MoveTo_terminal)
 
-            options.add(nsrt)
+            options.add(opt)
 
         # MoveToPrePushOnTop (different type)
         def _MoveToPrePushOnTop_initiable(state: State, memory: Dict,
@@ -271,6 +271,44 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
             terminal=_PushObjOnObjForward_terminal)
 
         options.add(PushObjOnObjForward)
+
+        # PushKettleOntoBurner
+        def _PushKettleOntoBurner_initiable(state: State, memory: Dict,
+                              objects: Sequence[Object],
+                              params: Array) -> bool:
+            gripper, obj, _ = objects
+            memory["gripper_infront_kettle"] = False
+            return _MoveTo_initiable(state, memory, [gripper, obj], params[:3])
+
+        def _PushKettleOntoBurner_policy(state: State, memory: Dict,
+                                        objects: Sequence[Object],
+                                        params: Array) -> Action:
+            gripper, obj, _ = objects
+            if not memory["gripper_infront_kettle"]:
+                # Check if the MoveTo option has terminated.
+                if _MoveTo_terminal(state, memory, [gripper, obj], params[:3]):
+                    memory["gripper_infront_kettle"] = True
+                else:
+                    return _MoveTo_policy(state, memory, [gripper, obj], params[:3])
+            return _PushObjOnObjForward_policy(state, memory, objects, params[3:])
+
+        def _PushKettleOntoBurner_terminal(state: State, memory: Dict,
+                                          objects: Sequence[Object],
+                                          params: Array) -> bool:
+            del memory, params  # unused
+            _, obj, obj2 = objects
+            return GroundAtom(OnTop, [obj, obj2]).holds(state)
+
+        PushKettleOntoBurner = ParameterizedOption(
+            "PushKettleOntoBurner",
+            types=[gripper_type, kettle_type, surface_type],
+            # Parameter is an angle for pushing forward.
+            params_space=Box(-np.pi, np.pi, (4, )),
+            policy=_PushKettleOntoBurner_policy,
+            initiable=_PushKettleOntoBurner_initiable,
+            terminal=_PushKettleOntoBurner_terminal)
+
+        options.add(PushKettleOntoBurner)
 
         # PullKettle
         def _PullKettle_policy(state: State, memory: Dict,
@@ -407,6 +445,45 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
             initiable=lambda _1, _2, _3, _4: True,
             terminal=_TurnOnKnob_terminal)
         options.add(TurnOnKnob)
+
+        # MoveAndTurnOnKnob
+        def _MoveAndTurnOnKnob_initiable(state: State, memory: Dict,
+                              objects: Sequence[Object],
+                              params: Array) -> bool:
+            gripper, obj = objects
+            memory["gripper_infront_knob"] = False
+            return _MoveTo_initiable(state, memory, [gripper, obj], params[:3])
+        
+        def _MoveAndTurnOnKnob_policy(state: State, memory: Dict,
+                               objects: Sequence[Object],
+                               params: Array) -> Action:
+            gripper, obj = objects
+            if not memory["gripper_infront_knob"]:
+                # Check if the MoveTo option has terminated.
+                if _MoveTo_terminal(state, memory, [gripper, obj], params[:3]):
+                    memory["gripper_infront_knob"] = True
+                else:
+                    return _MoveTo_policy(state, memory, [gripper, obj], params[:3])
+            return _TurnOnKnob_policy(state, memory, objects, params[3:])
+
+        def _MoveAndTurnOnKnob_terminal(state: State, memory: Dict,
+                                 objects: Sequence[Object],
+                                 params: Array) -> bool:
+            del memory, params  # unused
+            _, obj = objects
+            # Use a more stringent threshold to avoid numerical issues.
+            return KitchenEnv.On_holds(state, [obj],
+                                       thresh_pad=cls.turn_knob_tol)
+
+        MoveAndTurnOnKnob = ParameterizedOption(
+            "MoveAndTurnOnKnob",
+            types=[gripper_type, knob_type],
+            # The parameter is a push direction angle with respect to x.
+            params_space=Box(-np.pi, np.pi, (1, )),
+            policy=_MoveAndTurnOnKnob_policy,
+            initiable=_MoveAndTurnOnKnob_initiable,
+            terminal=_MoveAndTurnOnKnob_terminal)
+        options.add(MoveAndTurnOnKnob)
 
         # TurnOffKnob
         def _TurnOffKnob_policy(state: State, memory: Dict,

--- a/predicators/ground_truth_models/kitchen/options.py
+++ b/predicators/ground_truth_models/kitchen/options.py
@@ -274,27 +274,29 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
 
         # PushKettleOntoBurner
         def _PushKettleOntoBurner_initiable(state: State, memory: Dict,
-                              objects: Sequence[Object],
-                              params: Array) -> bool:
+                                            objects: Sequence[Object],
+                                            params: Array) -> bool:
             gripper, obj, _ = objects
             memory["gripper_infront_kettle"] = False
             return _MoveTo_initiable(state, memory, [gripper, obj], params[:3])
 
         def _PushKettleOntoBurner_policy(state: State, memory: Dict,
-                                        objects: Sequence[Object],
-                                        params: Array) -> Action:
+                                         objects: Sequence[Object],
+                                         params: Array) -> Action:
             gripper, obj, _ = objects
             if not memory["gripper_infront_kettle"]:
                 # Check if the MoveTo option has terminated.
                 if _MoveTo_terminal(state, memory, [gripper, obj], params[:3]):
                     memory["gripper_infront_kettle"] = True
                 else:
-                    return _MoveTo_policy(state, memory, [gripper, obj], params[:3])
-            return _PushObjOnObjForward_policy(state, memory, objects, params[3:])
+                    return _MoveTo_policy(state, memory, [gripper, obj],
+                                          params[:3])
+            return _PushObjOnObjForward_policy(state, memory, objects,
+                                               params[3:])
 
         def _PushKettleOntoBurner_terminal(state: State, memory: Dict,
-                                          objects: Sequence[Object],
-                                          params: Array) -> bool:
+                                           objects: Sequence[Object],
+                                           params: Array) -> bool:
             del memory, params  # unused
             _, obj, obj2 = objects
             return GroundAtom(OnTop, [obj, obj2]).holds(state)
@@ -303,7 +305,8 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
             "PushKettleOntoBurner",
             types=[gripper_type, kettle_type, surface_type],
             # Parameter is an angle for pushing forward.
-            params_space=Box(-np.pi, np.pi, (4, )),
+            params_space=Box(np.array([-5.0, -5.0, -5.0, -np.pi]),
+                             np.array([5.0, 5.0, 5.0, np.pi]), (4, )),
             policy=_PushKettleOntoBurner_policy,
             initiable=_PushKettleOntoBurner_initiable,
             terminal=_PushKettleOntoBurner_terminal)
@@ -448,27 +451,28 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
 
         # MoveAndTurnOnKnob
         def _MoveAndTurnOnKnob_initiable(state: State, memory: Dict,
-                              objects: Sequence[Object],
-                              params: Array) -> bool:
+                                         objects: Sequence[Object],
+                                         params: Array) -> bool:
             gripper, obj = objects
             memory["gripper_infront_knob"] = False
             return _MoveTo_initiable(state, memory, [gripper, obj], params[:3])
-        
+
         def _MoveAndTurnOnKnob_policy(state: State, memory: Dict,
-                               objects: Sequence[Object],
-                               params: Array) -> Action:
+                                      objects: Sequence[Object],
+                                      params: Array) -> Action:
             gripper, obj = objects
             if not memory["gripper_infront_knob"]:
                 # Check if the MoveTo option has terminated.
                 if _MoveTo_terminal(state, memory, [gripper, obj], params[:3]):
                     memory["gripper_infront_knob"] = True
                 else:
-                    return _MoveTo_policy(state, memory, [gripper, obj], params[:3])
+                    return _MoveTo_policy(state, memory, [gripper, obj],
+                                          params[:3])
             return _TurnOnKnob_policy(state, memory, objects, params[3:])
 
         def _MoveAndTurnOnKnob_terminal(state: State, memory: Dict,
-                                 objects: Sequence[Object],
-                                 params: Array) -> bool:
+                                        objects: Sequence[Object],
+                                        params: Array) -> bool:
             del memory, params  # unused
             _, obj = objects
             # Use a more stringent threshold to avoid numerical issues.
@@ -479,7 +483,8 @@ class KitchenGroundTruthOptionFactory(GroundTruthOptionFactory):
             "MoveAndTurnOnKnob",
             types=[gripper_type, knob_type],
             # The parameter is a push direction angle with respect to x.
-            params_space=Box(-np.pi, np.pi, (1, )),
+            params_space=Box(np.array([-5.0, -5.0, -5.0, -np.pi]),
+                             np.array([5.0, 5.0, 5.0, np.pi]), (4, )),
             policy=_MoveAndTurnOnKnob_policy,
             initiable=_MoveAndTurnOnKnob_initiable,
             terminal=_MoveAndTurnOnKnob_terminal)

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -323,6 +323,7 @@ class GlobalSettings:
     kitchen_use_perfect_samplers = False
     kitchen_goals = "all"
     kitchen_render_set_of_marks = False
+    kitchen_use_combo_move_nsrts = False
 
     # sticky table env parameters
     sticky_table_num_tables = 5

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -390,7 +390,11 @@ class LiftedAtom(_Atom):
 
     def ground(self, sub: VarToObjSub) -> GroundAtom:
         """Create a GroundAtom with a given substitution."""
-        assert set(self.variables).issubset(set(sub.keys()))
+        try:
+            assert set(self.variables).issubset(set(sub.keys()))
+        except AssertionError:
+            import ipdb
+            ipdb.set_trace()
         return GroundAtom(self.predicate, [sub[v] for v in self.variables])
 
     def substitute(self, sub: VarToVarSub) -> LiftedAtom:

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -390,11 +390,7 @@ class LiftedAtom(_Atom):
 
     def ground(self, sub: VarToObjSub) -> GroundAtom:
         """Create a GroundAtom with a given substitution."""
-        try:
-            assert set(self.variables).issubset(set(sub.keys()))
-        except AssertionError:
-            import ipdb
-            ipdb.set_trace()
+        assert set(self.variables).issubset(set(sub.keys()))
         return GroundAtom(self.predicate, [sub[v] for v in self.variables])
 
     def substitute(self, sub: VarToVarSub) -> LiftedAtom:


### PR DESCRIPTION
One annoying thing about VLM-based predicate invention in kitchen is that the VLM is seemingly bad at labelling atom values after moving (because the arm introduces occlusions, etc. in a bunch of places). This PR introduces some new NSRTs and options that move the arm implicitly (e.g. instead of having separate `MoveToTurnOn` and `TurnOn` NSRTs, we now have one `MoveAndTurnOn` NSRT). The PR also introduces a new command line flag to toggle this on or or off. Currently, this is only implemented for `TurnOn` and `Push` skills, but will likely be extended to more in the future!