### PR TITLE
Support VLM predicate invention in BurgerEnv

### DIFF
--- a/predicators/datasets/generate_atom_trajs_with_vlm.py
+++ b/predicators/datasets/generate_atom_trajs_with_vlm.py
@@ -638,6 +638,7 @@ def _query_vlm_to_generate_ground_atoms_trajs(
         # We now parse and sanitize this set of atoms.
         atom_proposals_set = _parse_unique_atom_proposals_from_list(
             atom_strs_proposals_list, all_task_objs)
+        import pdb; pdb.set_trace()
     else:  # pragma: no cover.
         atom_proposals_set = env.get_vlm_debug_atom_strs(train_tasks)
     assert len(atom_proposals_set) > 0, "Atom proposals set is empty!"

--- a/predicators/datasets/generate_atom_trajs_with_vlm.py
+++ b/predicators/datasets/generate_atom_trajs_with_vlm.py
@@ -661,9 +661,8 @@ def _query_vlm_to_generate_ground_atoms_trajs(
     # by curly brackets.
     structured_state_trajs = []
     state_trajs: Optional[List[List[State]]] = []
-    # for atom_traj, io_traj in zip(atom_labels, image_option_trajs,
-    #                               strict=True):
-    for atom_traj, io_traj in zip(atom_labels, image_option_trajs):
+    for atom_traj, io_traj in zip(atom_labels, image_option_trajs,
+                                  strict=True):
         atoms_txt_strs = [
             '{' + curr_ts_atoms_txt + '}' for curr_ts_atoms_txt in atom_traj
         ]

--- a/predicators/datasets/generate_atom_trajs_with_vlm.py
+++ b/predicators/datasets/generate_atom_trajs_with_vlm.py
@@ -717,6 +717,7 @@ def create_ground_atom_data_from_generated_demos(
         # each action in the trajectory is linked to an option that isn't
         # None.
         segments = _segment_with_option_changes(traj, set(), None)
+        # import pdb; pdb.set_trace()
         curr_traj_states_for_vlm: List[State] = []
         curr_traj_actions_for_vlm: List[Action] = []
         total_num_segment_states = 0
@@ -747,6 +748,7 @@ def create_ground_atom_data_from_generated_demos(
                 PIL.Image.fromarray(img_arr)  # type: ignore
                 for img_arr in state.simulator_state["image"]
             ])
+            # state_imgs.append([img for img in state.simulator_state["image"]])
         img_option_trajs.append(
             ImageOptionTrajectory(
                 set(traj.states[0]), state_imgs,

--- a/predicators/datasets/generate_atom_trajs_with_vlm.py
+++ b/predicators/datasets/generate_atom_trajs_with_vlm.py
@@ -641,7 +641,6 @@ def _query_vlm_to_generate_ground_atoms_trajs(
     else:  # pragma: no cover.
         atom_proposals_set = env.get_vlm_debug_atom_strs(train_tasks)
     assert len(atom_proposals_set) > 0, "Atom proposals set is empty!"
-    import pdb; pdb.set_trace()
     # Given this set of unique atom proposals, we now ask the VLM
     # to label these in every scene from the demonstrations.
     # NOTE: we convert to a sorted list here to get rid of randomness from set
@@ -741,10 +740,11 @@ def create_ground_atom_data_from_generated_demos(
         # and that the image for each state is access by the key "image".
         state_imgs: List[List[PIL.Image.Image]] = []
         for state in curr_traj_states_for_vlm:
-            assert "image" in state.simulator_state
+            assert state.simulator_state is not None
+            assert "images" in state.simulator_state
             state_imgs.append([
                 PIL.Image.fromarray(img_arr)  # type: ignore
-                for img_arr in state.simulator_state["image"]
+                for img_arr in state.simulator_state["images"]
             ])
         img_option_trajs.append(
             ImageOptionTrajectory(

--- a/predicators/datasets/generate_atom_trajs_with_vlm.py
+++ b/predicators/datasets/generate_atom_trajs_with_vlm.py
@@ -737,7 +737,7 @@ def create_ground_atom_data_from_generated_demos(
         curr_traj_states_for_vlm.append(traj.states[-1])
         # Pull out the images within the states we've saved for the trajectory.
         # We assume that the state's simulator_state attribute is a dictionary,
-        # and that the image for each state is access by the key "image".
+        # and that the images for each state are accessed by the key "images".
         state_imgs: List[List[PIL.Image.Image]] = []
         for state in curr_traj_states_for_vlm:
             assert state.simulator_state is not None

--- a/predicators/datasets/generate_atom_trajs_with_vlm.py
+++ b/predicators/datasets/generate_atom_trajs_with_vlm.py
@@ -638,10 +638,10 @@ def _query_vlm_to_generate_ground_atoms_trajs(
         # We now parse and sanitize this set of atoms.
         atom_proposals_set = _parse_unique_atom_proposals_from_list(
             atom_strs_proposals_list, all_task_objs)
-        import pdb; pdb.set_trace()
     else:  # pragma: no cover.
         atom_proposals_set = env.get_vlm_debug_atom_strs(train_tasks)
     assert len(atom_proposals_set) > 0, "Atom proposals set is empty!"
+    import pdb; pdb.set_trace()
     # Given this set of unique atom proposals, we now ask the VLM
     # to label these in every scene from the demonstrations.
     # NOTE: we convert to a sorted list here to get rid of randomness from set
@@ -661,8 +661,9 @@ def _query_vlm_to_generate_ground_atoms_trajs(
     # by curly brackets.
     structured_state_trajs = []
     state_trajs: Optional[List[List[State]]] = []
-    for atom_traj, io_traj in zip(atom_labels, image_option_trajs,
-                                  strict=True):
+    # for atom_traj, io_traj in zip(atom_labels, image_option_trajs,
+    #                               strict=True):
+    for atom_traj, io_traj in zip(atom_labels, image_option_trajs):
         atoms_txt_strs = [
             '{' + curr_ts_atoms_txt + '}' for curr_ts_atoms_txt in atom_traj
         ]
@@ -717,7 +718,6 @@ def create_ground_atom_data_from_generated_demos(
         # each action in the trajectory is linked to an option that isn't
         # None.
         segments = _segment_with_option_changes(traj, set(), None)
-        # import pdb; pdb.set_trace()
         curr_traj_states_for_vlm: List[State] = []
         curr_traj_actions_for_vlm: List[Action] = []
         total_num_segment_states = 0
@@ -735,8 +735,7 @@ def create_ground_atom_data_from_generated_demos(
                 ("WARNING: there are fewer total states after option-based "
                  "segmentation than there are in the original trajectory. "
                  "Likely there is an issue with segmentation!"))
-        # We manually add the final two states (initial state and terminal
-        # state of the final option).
+        # We manually add the final state of the final option.
         curr_traj_states_for_vlm.append(traj.states[-1])
         # Pull out the images within the states we've saved for the trajectory.
         # We assume that the state's simulator_state attribute is a dictionary,
@@ -748,7 +747,6 @@ def create_ground_atom_data_from_generated_demos(
                 PIL.Image.fromarray(img_arr)  # type: ignore
                 for img_arr in state.simulator_state["image"]
             ])
-            # state_imgs.append([img for img in state.simulator_state["image"]])
         img_option_trajs.append(
             ImageOptionTrajectory(
                 set(traj.states[0]), state_imgs,

--- a/predicators/datasets/generate_atom_trajs_with_vlm.py
+++ b/predicators/datasets/generate_atom_trajs_with_vlm.py
@@ -737,15 +737,14 @@ def create_ground_atom_data_from_generated_demos(
         # state of the final option).
         curr_traj_states_for_vlm.append(traj.states[-1])
         # Pull out the images within the states we've saved for the trajectory.
-        # We assume that images are saved in the state's simulator_state
-        # field.
+        # We assume that the state's simulator_state attribute is a dictionary,
+        # and that the image for each state is access by the key "image".
         state_imgs: List[List[PIL.Image.Image]] = []
         for state in curr_traj_states_for_vlm:
-            assert isinstance(state.simulator_state, List)
-            assert len(state.simulator_state) > 0
+            assert "image" in state.simulator_state
             state_imgs.append([
                 PIL.Image.fromarray(img_arr)  # type: ignore
-                for img_arr in state.simulator_state
+                for img_arr in state.simulator_state["image"]
             ])
         img_option_trajs.append(
             ImageOptionTrajectory(

--- a/predicators/envs/burger.py
+++ b/predicators/envs/burger.py
@@ -111,7 +111,7 @@ class BurgerEnv(BaseEnv):
         ], self._GoalHack_holds)
 
         # Static objects (exist no matter the settings)
-        self._robot = Object("robby", self._robot_type)
+        self._robot = Object("robot", self._robot_type)
         self._grill = Object("grill", self._grill_type)
         self._cutting_board = Object("cutting_board", self._cutting_board_type)
 

--- a/predicators/envs/burger.py
+++ b/predicators/envs/burger.py
@@ -178,10 +178,10 @@ class BurgerEnv(BaseEnv):
         goal = {
             GroundAtom(self._On, [patty, bottom_bun]),
             GroundAtom(self._On, [cheese, patty]),
-            # GroundAtom(self._On, [tomato, cheese]),
-            # GroundAtom(self._On, [top_bun, tomato]),
+            GroundAtom(self._On, [tomato, cheese]),
+            GroundAtom(self._On, [top_bun, tomato]),
             GroundAtom(self._IsCooked, [patty]),
-            # GroundAtom(self._IsSliced, [tomato]),
+            GroundAtom(self._IsSliced, [tomato]),
             # GroundAtom(self._GoalHack, [bottom_bun, patty, cheese, tomato,
             #     top_bun])
         }

--- a/predicators/envs/burger.py
+++ b/predicators/envs/burger.py
@@ -58,7 +58,7 @@ class BurgerEnv(BaseEnv):
     _item_type = Type("item", [], _object_type)
     _station_type = Type("station", [], _object_type)
 
-    _robot_type = Type("robot", ["row", "col", "fingers", "dir"])
+    _robot_type = Type("robot", ["row", "col", "z", "fingers", "dir"], _object_type)
 
     _patty_type = Type("patty", ["row", "col", "z"], _item_type)
     _tomato_type = Type("tomato", ["row", "col", "z"], _item_type)
@@ -141,6 +141,7 @@ class BurgerEnv(BaseEnv):
         state_dict[self._robot] = {
             "row": 2,
             "col": 2,
+            "z": 0,
             "fingers": 0.0,
             "dir": 3
         }
@@ -415,6 +416,8 @@ class BurgerEnv(BaseEnv):
                     continue
             ox, oy = self.get_position(obj, state)
             if abs(new_rx - ox) < 1e-3 and abs(new_ry - oy) < 1e-3:
+
+                next_state.simulator_state["image"] = self.render_state(next_state, DefaultTask)
                 return next_state
 
         # No collision detected, so we can move the robot.
@@ -486,7 +489,7 @@ class BurgerEnv(BaseEnv):
                 next_state.set(held_item, "z", new_z)
 
         # Update the image
-        next_state.simulator_state["image"] = self.render_state(state, DefaultTask)
+        next_state.simulator_state["image"] = self.render_state(next_state, DefaultTask)
 
         return next_state
 

--- a/predicators/envs/burger.py
+++ b/predicators/envs/burger.py
@@ -6,22 +6,23 @@ Nicole Thean (https://github.com/nicolethean).
 """
 
 import copy
-import logging
 import io
+import logging
 from typing import Callable, List, Optional, Sequence, Set, Tuple
 
-from PIL import Image
 import matplotlib
 import matplotlib.image as mpimg
 import matplotlib.pyplot as plt
 import numpy as np
 from gym.spaces import Box
+from PIL import Image
 
 from predicators import utils
 from predicators.envs import BaseEnv
 from predicators.settings import CFG
-from predicators.structs import Action, EnvironmentTask, GroundAtom, Object, \
-    Predicate, State, Type, DefaultEnvironmentTask, Observation, Video
+from predicators.structs import Action, DefaultEnvironmentTask, \
+    EnvironmentTask, GroundAtom, Object, Observation, Predicate, State, Type, \
+    Video
 
 
 class BurgerEnv(BaseEnv):
@@ -59,7 +60,7 @@ class BurgerEnv(BaseEnv):
     _station_type = Type("station", [], _object_type)
 
     _robot_type = Type("robot", ["row", "col", "z", "fingers", "dir"],
-        _object_type)
+                       _object_type)
 
     _patty_type = Type("patty", ["row", "col", "z"], _item_type)
     _tomato_type = Type("tomato", ["row", "col", "z"], _item_type)
@@ -191,8 +192,8 @@ class BurgerEnv(BaseEnv):
             state.simulator_state["state"] = hidden_state
             # A DefaultEnvironmentTask is a dummy environment task. Our render
             # function does not use the task argument, so this is ok.
-            state.simulator_state["images"] = self.render_state(state,
-                DefaultEnvironmentTask)
+            state.simulator_state["images"] = self.render_state(
+                state, DefaultEnvironmentTask)
             # Recall that a EnvironmentTask consists of an Observation and a
             # GoalDescription, both of whose types are Any.
             tasks.append(EnvironmentTask(state, goal))
@@ -248,15 +249,13 @@ class BurgerEnv(BaseEnv):
         patty, = objects
         assert state.simulator_state is not None
         assert "state" in state.simulator_state
-        return state.simulator_state["state"][patty][
-            "is_cooked"] > 0.5
+        return state.simulator_state["state"][patty]["is_cooked"] > 0.5
 
     def _IsSliced_holds(self, state: State, objects: Sequence[Object]) -> bool:
         tomato, = objects
         assert state.simulator_state is not None
         assert "state" in state.simulator_state
-        return state.simulator_state["state"][tomato][
-            "is_sliced"] > 0.5
+        return state.simulator_state["state"][tomato]["is_sliced"] > 0.5
 
     def _HandEmpty_holds(self, state: State,
                          objects: Sequence[Object]) -> bool:
@@ -447,10 +446,12 @@ class BurgerEnv(BaseEnv):
                                  [self._robot, item]) and interact > 0.5:
                 if item.is_instance(self._patty_type) and self._On_holds(
                         state, [item, self._grill]):
-                    next_state.simulator_state["state"][item]["is_cooked"] = 1.0
+                    next_state.simulator_state["state"][item][
+                        "is_cooked"] = 1.0
                 elif item.is_instance(self._tomato_type) and self._On_holds(
                         state, [item, self._cutting_board]):
-                    next_state.simulator_state["state"][item]["is_sliced"] = 1.0
+                    next_state.simulator_state["state"][item][
+                        "is_sliced"] = 1.0
 
         # Handle picking.
         if pickplace > 0.5 and self._HandEmpty_holds(state, [self._robot]):
@@ -495,8 +496,8 @@ class BurgerEnv(BaseEnv):
 
         # Update the image
         assert next_state.simulator_state is not None
-        next_state.simulator_state["images"] = self.render_state(next_state,
-            DefaultEnvironmentTask)
+        next_state.simulator_state["images"] = self.render_state(
+            next_state, DefaultEnvironmentTask)
 
         return next_state
 
@@ -645,7 +646,6 @@ class BurgerEnv(BaseEnv):
 
         buf.close()
         jpeg_buf.close()
-
         return [ret_arr]
 
     def _copy_observation(self, obs: Observation) -> Observation:
@@ -665,7 +665,7 @@ class BurgerEnv(BaseEnv):
         # Rather than have the observation be the state + the image, we just
         # package the image inside the state's simulator_state.
         self._current_observation = self.simulate(self._current_observation,
-            action)
+                                                  action)
         return self._copy_observation(self._current_observation)
 
     def get_event_to_action_fn(

--- a/predicators/envs/burger.py
+++ b/predicators/envs/burger.py
@@ -181,8 +181,8 @@ class BurgerEnv(BaseEnv):
             # GroundAtom(self._On, [top_bun, tomato]),
             GroundAtom(self._IsCooked, [patty]),
             # GroundAtom(self._IsSliced, [tomato]),
-            GroundAtom(self._GoalHack, [bottom_bun, patty, cheese, tomato,
-                top_bun])
+            # GroundAtom(self._GoalHack, [bottom_bun, patty, cheese, tomato,
+            #     top_bun])
         }
 
         for _ in range(num):

--- a/predicators/envs/kitchen.py
+++ b/predicators/envs/kitchen.py
@@ -343,6 +343,7 @@ README of that repo suggests!"
                     "angle": angle
                 }
         state = utils.create_state_from_dict(state_dict)
+        state.simulator_state = {}
         return state
 
     def goal_reached(self) -> bool:

--- a/predicators/perception/kitchen_perceiver.py
+++ b/predicators/perception/kitchen_perceiver.py
@@ -52,7 +52,8 @@ class KitchenPerceiver(BasePerceiver):
 
     def _observation_to_state(self, obs: Observation) -> State:
         state = KitchenEnv.state_info_to_state(obs["state_info"])
-        state.simulator_state = obs["obs_images"]
+        assert state.simulator_state is not None
+        state.simulator_state["images"] = obs["obs_images"]
         return state
 
     def render_mental_images(self, observation: Observation,

--- a/predicators/pretrained_model_interface.py
+++ b/predicators/pretrained_model_interface.py
@@ -267,7 +267,6 @@ class GoogleGeminiVLM(VisionLanguageModel):
             seed: int,
             stop_token: Optional[str] = None,
             num_completions: int = 1) -> List[str]:  # pragma: no cover
-        import pdb; pdb.set_trace()
         del seed, stop_token  # unused
         assert imgs is not None
         generation_config = genai.types.GenerationConfig(  # pylint:disable=no-member
@@ -277,7 +276,6 @@ class GoogleGeminiVLM(VisionLanguageModel):
             [prompt] + imgs,
             generation_config=generation_config)  # type: ignore
         response.resolve()
-        import pdb; pdb.set_trace()
         return [response.text]
 
 

--- a/predicators/pretrained_model_interface.py
+++ b/predicators/pretrained_model_interface.py
@@ -130,9 +130,8 @@ class PretrainedLargeModel(abc.ABC):
 
         logging.debug(f"Querying model {model_id} with new prompt.")
         # Query the model.
-        completions = self._sample_completions(prompt, imgs, temperature,
-                                               seed, stop_token,
-                                               num_completions)
+        completions = self._sample_completions(prompt, imgs, temperature, seed,
+                                               stop_token, num_completions)
         return completions
 
 

--- a/predicators/pretrained_model_interface.py
+++ b/predicators/pretrained_model_interface.py
@@ -85,9 +85,11 @@ class PretrainedLargeModel(abc.ABC):
             img_hash_list: List[str] = []
             for img in imgs:
                 img_hash_list.append(str(imagehash.phash(img)))
-            # NOTE: it's very possible that this string gets too long and this
-            # causes significant problems for us. We can fix this when it
-            # comes up by hashing this string to a shorter string, using e.g.
+            # NOTE: it's possible that this string (the concatenated hashes of
+            # each image) is very long. This would make the final cache
+            # foldername long. In many operating systems, the maximum folder
+            # name length is 255 characters. To shorten this foldername more, we
+            # can hash this string into a shorter string. For example, look at
             # https://stackoverflow.com/questions/57263436/hash-like-string-shortener-with-decoder  # pylint:disable=line-too-long
             imgs_id = hash("".join(img_hash_list))
             cache_foldername += f"{imgs_id}"

--- a/predicators/pretrained_model_interface.py
+++ b/predicators/pretrained_model_interface.py
@@ -69,62 +69,62 @@ class PretrainedLargeModel(abc.ABC):
         that does not expose the ability to set a random seed. Responses
         are saved to disk.
         """
-        # # Set up the cache file.
-        # assert _CACHE_SEP not in prompt
-        # os.makedirs(CFG.pretrained_model_prompt_cache_dir, exist_ok=True)
+        # Set up the cache file.
+        assert _CACHE_SEP not in prompt
+        os.makedirs(CFG.pretrained_model_prompt_cache_dir, exist_ok=True)
         model_id = self.get_id()
-        # prompt_id = hash(prompt)
-        # config_id = f"{temperature}_{seed}_{num_completions}_" + \
-        #             f"{stop_token}"
-        # # If the temperature is 0, the seed does not matter.
-        # if temperature == 0.0:
-        #     config_id = f"most_likely_{num_completions}_{stop_token}"
-        # cache_foldername = f"{model_id}_{config_id}_{prompt_id}"
-        # if imgs is not None:
-        #     # We also need to hash all the images in the prompt.
-        #     img_hash_list: List[str] = []
-        #     for img in imgs:
-        #         img_hash_list.append(str(imagehash.phash(img)))
-        #     # NOTE: it's very possible that this string gets too long and this
-        #     # causes significant problems for us. We can fix this when it
-        #     # comes up by hashing this string to a shorter string, using e.g.
-        #     # https://stackoverflow.com/questions/57263436/hash-like-string-shortener-with-decoder  # pylint:disable=line-too-long
-        #     imgs_id = "".join(img_hash_list)
-        #     cache_foldername += f"{imgs_id}"
-        # cache_folderpath = os.path.join(CFG.pretrained_model_prompt_cache_dir,
-        #                                 cache_foldername)
-        # os.makedirs(cache_folderpath, exist_ok=True)
-        # cache_filename = "prompt.txt"
-        # cache_filepath = os.path.join(CFG.pretrained_model_prompt_cache_dir,
-        #                               cache_foldername, cache_filename)
-        # if not os.path.exists(cache_filepath):
-        #     if CFG.llm_use_cache_only:
-        #         raise ValueError("No cached response found for prompt.")
-        #     logging.debug(f"Querying model {model_id} with new prompt.")
-        #     # Query the model.
-        #     completions = self._sample_completions(prompt, imgs, temperature,
-        #                                            seed, stop_token,
-        #                                            num_completions)
-        #     # Cache the completion.
-        #     cache_str = prompt + _CACHE_SEP + _CACHE_SEP.join(completions)
-        #     with open(cache_filepath, 'w', encoding='utf-8') as f:
-        #         f.write(cache_str)
-        #     if imgs is not None:
-        #         # Also save the images for easy debugging.
-        #         imgs_folderpath = os.path.join(cache_folderpath, "imgs")
-        #         os.makedirs(imgs_folderpath, exist_ok=True)
-        #         for i, img in enumerate(imgs):
-        #             filename_suffix = str(i) + ".jpg"
-        #             img.save(os.path.join(imgs_folderpath, filename_suffix))
-        #     logging.debug(f"Saved model response to {cache_filepath}.")
-        # # Load the saved completion.
-        # with open(cache_filepath, 'r', encoding='utf-8') as f:
-        #     cache_str = f.read()
-        # logging.debug(f"Loaded model response from {cache_filepath}.")
-        # assert cache_str.count(_CACHE_SEP) == num_completions
-        # cached_prompt, completion_strs = cache_str.split(_CACHE_SEP, 1)
-        # assert cached_prompt == prompt
-        # completions = completion_strs.split(_CACHE_SEP)
+        prompt_id = hash(prompt)
+        config_id = f"{temperature}_{seed}_{num_completions}_" + \
+                    f"{stop_token}"
+        # If the temperature is 0, the seed does not matter.
+        if temperature == 0.0:
+            config_id = f"most_likely_{num_completions}_{stop_token}"
+        cache_foldername = f"{model_id}_{config_id}_{prompt_id}"
+        if imgs is not None:
+            # We also need to hash all the images in the prompt.
+            img_hash_list: List[str] = []
+            for img in imgs:
+                img_hash_list.append(str(imagehash.phash(img)))
+            # NOTE: it's very possible that this string gets too long and this
+            # causes significant problems for us. We can fix this when it
+            # comes up by hashing this string to a shorter string, using e.g.
+            # https://stackoverflow.com/questions/57263436/hash-like-string-shortener-with-decoder  # pylint:disable=line-too-long
+            imgs_id = hash("".join(img_hash_list))
+            cache_foldername += f"{imgs_id}"
+        cache_folderpath = os.path.join(CFG.pretrained_model_prompt_cache_dir,
+                                        cache_foldername)
+        os.makedirs(cache_folderpath, exist_ok=True)
+        cache_filename = "prompt.txt"
+        cache_filepath = os.path.join(CFG.pretrained_model_prompt_cache_dir,
+                                      cache_foldername, cache_filename)
+        if not os.path.exists(cache_filepath):
+            if CFG.llm_use_cache_only:
+                raise ValueError("No cached response found for prompt.")
+            logging.debug(f"Querying model {model_id} with new prompt.")
+            # Query the model.
+            completions = self._sample_completions(prompt, imgs, temperature,
+                                                   seed, stop_token,
+                                                   num_completions)
+            # Cache the completion.
+            cache_str = prompt + _CACHE_SEP + _CACHE_SEP.join(completions)
+            with open(cache_filepath, 'w', encoding='utf-8') as f:
+                f.write(cache_str)
+            if imgs is not None:
+                # Also save the images for easy debugging.
+                imgs_folderpath = os.path.join(cache_folderpath, "imgs")
+                os.makedirs(imgs_folderpath, exist_ok=True)
+                for i, img in enumerate(imgs):
+                    filename_suffix = str(i) + ".jpg"
+                    img.save(os.path.join(imgs_folderpath, filename_suffix))
+            logging.debug(f"Saved model response to {cache_filepath}.")
+        # Load the saved completion.
+        with open(cache_filepath, 'r', encoding='utf-8') as f:
+            cache_str = f.read()
+        logging.debug(f"Loaded model response from {cache_filepath}.")
+        assert cache_str.count(_CACHE_SEP) == num_completions
+        cached_prompt, completion_strs = cache_str.split(_CACHE_SEP, 1)
+        assert cached_prompt == prompt
+        completions = completion_strs.split(_CACHE_SEP)
 
         logging.debug(f"Querying model {model_id} with new prompt.")
         # Query the model.

--- a/predicators/pretrained_model_interface.py
+++ b/predicators/pretrained_model_interface.py
@@ -69,62 +69,68 @@ class PretrainedLargeModel(abc.ABC):
         that does not expose the ability to set a random seed. Responses
         are saved to disk.
         """
-        # Set up the cache file.
-        assert _CACHE_SEP not in prompt
-        os.makedirs(CFG.pretrained_model_prompt_cache_dir, exist_ok=True)
+        # # Set up the cache file.
+        # assert _CACHE_SEP not in prompt
+        # os.makedirs(CFG.pretrained_model_prompt_cache_dir, exist_ok=True)
         model_id = self.get_id()
-        prompt_id = hash(prompt)
-        config_id = f"{temperature}_{seed}_{num_completions}_" + \
-                    f"{stop_token}"
-        # If the temperature is 0, the seed does not matter.
-        if temperature == 0.0:
-            config_id = f"most_likely_{num_completions}_{stop_token}"
-        cache_foldername = f"{model_id}_{config_id}_{prompt_id}"
-        if imgs is not None:
-            # We also need to hash all the images in the prompt.
-            img_hash_list: List[str] = []
-            for img in imgs:
-                img_hash_list.append(str(imagehash.phash(img)))
-            # NOTE: it's very possible that this string gets too long and this
-            # causes significant problems for us. We can fix this when it
-            # comes up by hashing this string to a shorter string, using e.g.
-            # https://stackoverflow.com/questions/57263436/hash-like-string-shortener-with-decoder  # pylint:disable=line-too-long
-            imgs_id = "".join(img_hash_list)
-            cache_foldername += f"{imgs_id}"
-        cache_folderpath = os.path.join(CFG.pretrained_model_prompt_cache_dir,
-                                        cache_foldername)
-        os.makedirs(cache_folderpath, exist_ok=True)
-        cache_filename = "prompt.txt"
-        cache_filepath = os.path.join(CFG.pretrained_model_prompt_cache_dir,
-                                      cache_foldername, cache_filename)
-        if not os.path.exists(cache_filepath):
-            if CFG.llm_use_cache_only:
-                raise ValueError("No cached response found for prompt.")
-            logging.debug(f"Querying model {model_id} with new prompt.")
-            # Query the model.
-            completions = self._sample_completions(prompt, imgs, temperature,
-                                                   seed, stop_token,
-                                                   num_completions)
-            # Cache the completion.
-            cache_str = prompt + _CACHE_SEP + _CACHE_SEP.join(completions)
-            with open(cache_filepath, 'w', encoding='utf-8') as f:
-                f.write(cache_str)
-            if imgs is not None:
-                # Also save the images for easy debugging.
-                imgs_folderpath = os.path.join(cache_folderpath, "imgs")
-                os.makedirs(imgs_folderpath, exist_ok=True)
-                for i, img in enumerate(imgs):
-                    filename_suffix = str(i) + ".jpg"
-                    img.save(os.path.join(imgs_folderpath, filename_suffix))
-            logging.debug(f"Saved model response to {cache_filepath}.")
-        # Load the saved completion.
-        with open(cache_filepath, 'r', encoding='utf-8') as f:
-            cache_str = f.read()
-        logging.debug(f"Loaded model response from {cache_filepath}.")
-        assert cache_str.count(_CACHE_SEP) == num_completions
-        cached_prompt, completion_strs = cache_str.split(_CACHE_SEP, 1)
-        assert cached_prompt == prompt
-        completions = completion_strs.split(_CACHE_SEP)
+        # prompt_id = hash(prompt)
+        # config_id = f"{temperature}_{seed}_{num_completions}_" + \
+        #             f"{stop_token}"
+        # # If the temperature is 0, the seed does not matter.
+        # if temperature == 0.0:
+        #     config_id = f"most_likely_{num_completions}_{stop_token}"
+        # cache_foldername = f"{model_id}_{config_id}_{prompt_id}"
+        # if imgs is not None:
+        #     # We also need to hash all the images in the prompt.
+        #     img_hash_list: List[str] = []
+        #     for img in imgs:
+        #         img_hash_list.append(str(imagehash.phash(img)))
+        #     # NOTE: it's very possible that this string gets too long and this
+        #     # causes significant problems for us. We can fix this when it
+        #     # comes up by hashing this string to a shorter string, using e.g.
+        #     # https://stackoverflow.com/questions/57263436/hash-like-string-shortener-with-decoder  # pylint:disable=line-too-long
+        #     imgs_id = "".join(img_hash_list)
+        #     cache_foldername += f"{imgs_id}"
+        # cache_folderpath = os.path.join(CFG.pretrained_model_prompt_cache_dir,
+        #                                 cache_foldername)
+        # os.makedirs(cache_folderpath, exist_ok=True)
+        # cache_filename = "prompt.txt"
+        # cache_filepath = os.path.join(CFG.pretrained_model_prompt_cache_dir,
+        #                               cache_foldername, cache_filename)
+        # if not os.path.exists(cache_filepath):
+        #     if CFG.llm_use_cache_only:
+        #         raise ValueError("No cached response found for prompt.")
+        #     logging.debug(f"Querying model {model_id} with new prompt.")
+        #     # Query the model.
+        #     completions = self._sample_completions(prompt, imgs, temperature,
+        #                                            seed, stop_token,
+        #                                            num_completions)
+        #     # Cache the completion.
+        #     cache_str = prompt + _CACHE_SEP + _CACHE_SEP.join(completions)
+        #     with open(cache_filepath, 'w', encoding='utf-8') as f:
+        #         f.write(cache_str)
+        #     if imgs is not None:
+        #         # Also save the images for easy debugging.
+        #         imgs_folderpath = os.path.join(cache_folderpath, "imgs")
+        #         os.makedirs(imgs_folderpath, exist_ok=True)
+        #         for i, img in enumerate(imgs):
+        #             filename_suffix = str(i) + ".jpg"
+        #             img.save(os.path.join(imgs_folderpath, filename_suffix))
+        #     logging.debug(f"Saved model response to {cache_filepath}.")
+        # # Load the saved completion.
+        # with open(cache_filepath, 'r', encoding='utf-8') as f:
+        #     cache_str = f.read()
+        # logging.debug(f"Loaded model response from {cache_filepath}.")
+        # assert cache_str.count(_CACHE_SEP) == num_completions
+        # cached_prompt, completion_strs = cache_str.split(_CACHE_SEP, 1)
+        # assert cached_prompt == prompt
+        # completions = completion_strs.split(_CACHE_SEP)
+
+        logging.debug(f"Querying model {model_id} with new prompt.")
+        # Query the model.
+        completions = self._sample_completions(prompt, imgs, temperature,
+                                               seed, stop_token,
+                                               num_completions)
         return completions
 
 
@@ -261,6 +267,7 @@ class GoogleGeminiVLM(VisionLanguageModel):
             seed: int,
             stop_token: Optional[str] = None,
             num_completions: int = 1) -> List[str]:  # pragma: no cover
+        import pdb; pdb.set_trace()
         del seed, stop_token  # unused
         assert imgs is not None
         generation_config = genai.types.GenerationConfig(  # pylint:disable=no-member
@@ -270,6 +277,7 @@ class GoogleGeminiVLM(VisionLanguageModel):
             [prompt] + imgs,
             generation_config=generation_config)  # type: ignore
         response.resolve()
+        import pdb; pdb.set_trace()
         return [response.text]
 
 

--- a/predicators/pretrained_model_interface.py
+++ b/predicators/pretrained_model_interface.py
@@ -127,11 +127,6 @@ class PretrainedLargeModel(abc.ABC):
         cached_prompt, completion_strs = cache_str.split(_CACHE_SEP, 1)
         assert cached_prompt == prompt
         completions = completion_strs.split(_CACHE_SEP)
-
-        logging.debug(f"Querying model {model_id} with new prompt.")
-        # Query the model.
-        completions = self._sample_completions(prompt, imgs, temperature, seed,
-                                               stop_token, num_completions)
         return completions
 
 

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -2246,8 +2246,8 @@ def query_vlm_for_atom_vals(
     # This only works if state.simulator_state is some list of images that the
     # vlm can be called on.
     assert state.simulator_state is not None
-    assert isinstance(state.simulator_state, List)
-    imgs = state.simulator_state
+    assert isinstance(state.simulator_state["images"], List)
+    imgs = state.simulator_state["images"]
     vlm_atoms = sorted(vlm_atoms)
     atom_queries_str = "\n* "
     atom_queries_str += "\n* ".join(atom.get_vlm_query_str()

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -733,7 +733,8 @@ def test_create_ground_atom_data_from_generated_demos():
     dataset = create_dataset(env, train_tasks, options, predicates)
     assert len(dataset.trajectories) == 1
     for state in dataset.trajectories[0].states:
-        state.simulator_state = [np.zeros((32, 32), dtype=np.uint8)]
+        state.simulator_state = {}
+        state.simulator_state["images"] = [np.zeros((32, 32), dtype=np.uint8)]
     vlm = _DummyVLM()
     vlm_dataset = create_ground_atom_data_from_generated_demos(
         dataset, env, predicates, train_tasks, vlm)

--- a/tests/envs/test_burger.py
+++ b/tests/envs/test_burger.py
@@ -30,6 +30,7 @@ def test_burger():
     for task in env.get_test_tasks():
         for obj in task.init:
             assert len(obj.type.feature_names) == len(task.init[obj])
+
     assert len(env.predicates) == 12
     assert len(env.goal_predicates) == 3
     assert env.get_name() == "burger"
@@ -39,6 +40,7 @@ def test_burger():
     nsrts = get_gt_nsrts(env.get_name(), env.predicates, options)
     assert len(nsrts) == 15
     task = env.get_train_tasks()[0]
+
     MoveWhenFacingOneStack = [
         n for n in nsrts if n.name == "MoveWhenFacingOneStack"
     ][0]
@@ -72,7 +74,7 @@ def test_burger():
 
     grill = [obj for obj in task.init if obj.name == "grill"][0]
     patty = [obj for obj in task.init if obj.name == "patty"][0]
-    robot = [obj for obj in task.init if obj.name == "robby"][0]
+    robot = [obj for obj in task.init if obj.name == "robot"][0]
     tomato = [obj for obj in task.init if obj.name == "tomato"][0]
     cutting_board = [obj for obj in task.init
                      if obj.name == "cutting_board"][0]

--- a/tests/envs/test_burger.py
+++ b/tests/envs/test_burger.py
@@ -30,7 +30,6 @@ def test_burger():
     for task in env.get_test_tasks():
         for obj in task.init:
             assert len(obj.type.feature_names) == len(task.init[obj])
-
     assert len(env.predicates) == 12
     assert len(env.goal_predicates) == 3
     assert env.get_name() == "burger"
@@ -40,7 +39,6 @@ def test_burger():
     nsrts = get_gt_nsrts(env.get_name(), env.predicates, options)
     assert len(nsrts) == 15
     task = env.get_train_tasks()[0]
-
     MoveWhenFacingOneStack = [
         n for n in nsrts if n.name == "MoveWhenFacingOneStack"
     ][0]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2390,7 +2390,7 @@ def test_create_pddl():
                                           "spanner")
     assert domain_str == """(define (domain spanner)
   (:requirements :typing)
-  (:types
+  (:types 
     man nut spanner - locatable
     monkey
     locatable location - object)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1125,7 +1125,9 @@ def test_abstract():
     vlm_pred = VLMPredicate("IsFishy", [], lambda s, o: NotImplementedError,
                             lambda o: "is_fishy")
     vlm_state = state.copy()
-    vlm_state.simulator_state = [np.zeros((30, 30, 3), dtype=np.uint8)]
+    vlm_state.simulator_state = {
+        "images": [np.zeros((30, 30, 3), dtype=np.uint8)]
+    }
     vlm_atoms_set = utils.abstract(vlm_state, [vlm_pred], _DummyVLM())
     assert len(vlm_atoms_set) == 1
     assert "IsFishy" in str(vlm_atoms_set)
@@ -2388,7 +2390,7 @@ def test_create_pddl():
                                           "spanner")
     assert domain_str == """(define (domain spanner)
   (:requirements :typing)
-  (:types 
+  (:types
     man nut spanner - locatable
     monkey
     locatable location - object)


### PR DESCRIPTION
Before we can get geometric + VLM predicate invention working in BurgerEnv, we need VLM predicate invention without geometric predicates working in BurgerEnv. This PR gets VLM predicate invention to run in BurgerEnv -- it does not yet work well (the predicate proposals are decent but the labeling isn't good enough yet) -- but at least it runs: we see `Cooked` and `Holding` generated as VLM predicates, but `Cooked` is not labeled accurately. 

For example, you can run `python predicators/main.py --env burger --approach grammar_search_invention --seed 0 --num_train_tasks 1 --num_test_tasks 1 --bilevel_plan_without_sim True --offline_data_method demo_with_vlm_imgs --vlm_model_name gemini-1.5-pro-latest --segmenter every_step --grammar_search_vlm_atom_proposal_prompt_type options_labels_whole_traj --grammar_search_vlm_atom_label_prompt_type img_option_diffs --grammar_search_task_planning_timeout 10.0 --sesame_max_skeletons_optimized 200 --disable_harmlessness_check True --sesame_task_planner fdopt --excluded_predicates all --option_model_terminate_on_repeat False --grammar_search_vlm_atom_proposal_use_debug False`.

Main changes:
- Now hashing the concatenated image ids that contribute to the cache foldername for the cached VLM output (was getting filename too long issues on my mac).
- Recall that in BurgerEnv we put state information that we want to provide only to the oracle and not to the agent, in `State.simulator_state` (well, now `State.simulator_state["state"]` as of this PR). The current VLM predicate invention pipeline is using `State.simulator_state` to store the images associated with each state. So we just needed to slightly modify `State.simulator_state` to hold both of these -- now the images go in `State.simulator_state["images"]`.
- Some funky code to convert matplotlib fig to PIL.Image. 