### PR TITLE
Allow different task goals for demonstrator vs agent

### DIFF
--- a/predicators/envs/base_env.py
+++ b/predicators/envs/base_env.py
@@ -77,14 +77,6 @@ class BaseEnv(abc.ABC):
         raise NotImplementedError("Override me!")
 
     @property
-    def goal_predicates_for_agent(self) -> Set[Predicate]:
-        """Get the subset of self.predicates that are used in goals for the
-        agent."""
-        # By default, task goals are described in terms of the same goal
-        # predicates for both the demonstrator and the agent.
-        return self.goal_predicates
-
-    @property
     @abc.abstractmethod
     def types(self) -> Set[Type]:
         """Get the set of types that are given with this environment."""

--- a/predicators/envs/base_env.py
+++ b/predicators/envs/base_env.py
@@ -77,7 +77,7 @@ class BaseEnv(abc.ABC):
         raise NotImplementedError("Override me!")
 
     @property
-    def goal_predicates_for_agent(self) ->Set[Predicate]:
+    def goal_predicates_for_agent(self) -> Set[Predicate]:
         """Get the subset of self.predicates that are used in goals for the
         agent."""
         # By default, task goals are described in terms of the same goal

--- a/predicators/envs/base_env.py
+++ b/predicators/envs/base_env.py
@@ -77,6 +77,14 @@ class BaseEnv(abc.ABC):
         raise NotImplementedError("Override me!")
 
     @property
+    def goal_predicates_for_agent(self) ->Set[Predicate]:
+        """Get the subset of self.predicates that are used in goals for the
+        agent."""
+        # By default, task goals are described in terms of the same goal
+        # predicates for both the demonstrator and the agent.
+        return self.goal_predicates
+
+    @property
     @abc.abstractmethod
     def types(self) -> Set[Type]:
         """Get the set of types that are given with this environment."""

--- a/predicators/envs/burger.py
+++ b/predicators/envs/burger.py
@@ -176,14 +176,25 @@ class BurgerEnv(BaseEnv):
         hidden_state[bottom_bun] = {"is_held": 0.0}
 
         goal = {
-            GroundAtom(self._On, [patty, bottom_bun]),
-            GroundAtom(self._On, [cheese, patty]),
-            GroundAtom(self._On, [tomato, cheese]),
-            GroundAtom(self._On, [top_bun, tomato]),
-            GroundAtom(self._IsCooked, [patty]),
-            GroundAtom(self._IsSliced, [tomato]),
+            # GroundAtom(self._On, [patty, bottom_bun]),
+            # GroundAtom(self._On, [cheese, patty]),
+            # GroundAtom(self._On, [tomato, cheese]),
+            # GroundAtom(self._On, [top_bun, tomato]),
+            # GroundAtom(self._IsCooked, [patty]),
+            # GroundAtom(self._IsSliced, [tomato]),
             # GroundAtom(self._GoalHack, [bottom_bun, patty, cheese, tomato,
             #     top_bun])
+
+            GroundAtom(self._On, [patty, bottom_bun]),
+            GroundAtom(self._On, [cheese, patty]),
+            GroundAtom(self._IsCooked, [patty]),
+        }
+
+        alt_goal = {
+            GroundAtom(self._On, [patty, bottom_bun]),
+            GroundAtom(self._On, [cheese, patty]),
+            GroundAtom(self._GoalHack, [bottom_bun, patty, cheese, tomato,
+                top_bun])
         }
 
         for _ in range(num):
@@ -196,7 +207,7 @@ class BurgerEnv(BaseEnv):
                 state, DefaultEnvironmentTask)
             # Recall that a EnvironmentTask consists of an Observation and a
             # GoalDescription, both of whose types are Any.
-            tasks.append(EnvironmentTask(state, goal))
+            tasks.append(EnvironmentTask(state, goal, _alt_goal_desc=alt_goal))
 
         return tasks
 
@@ -301,10 +312,10 @@ class BurgerEnv(BaseEnv):
         atoms = [
             self._On_holds(state, [patty, bottom]),
             self._On_holds(state, [cheese, patty]),
-            self._On_holds(state, [tomato, cheese]),
-            self._On_holds(state, [top, tomato]),
+            # self._On_holds(state, [tomato, cheese]),
+            # self._On_holds(state, [top, tomato]),
             self._IsCooked_holds(state, [patty]),
-            self._IsSliced_holds(state, [tomato])
+            # self._IsSliced_holds(state, [tomato])
         ]
         return all(atoms)
 

--- a/predicators/envs/burger.py
+++ b/predicators/envs/burger.py
@@ -184,7 +184,6 @@ class BurgerEnv(BaseEnv):
             # GroundAtom(self._IsSliced, [tomato]),
             # GroundAtom(self._GoalHack, [bottom_bun, patty, cheese, tomato,
             #     top_bun])
-
             GroundAtom(self._On, [patty, bottom_bun]),
             GroundAtom(self._On, [cheese, patty]),
             GroundAtom(self._IsCooked, [patty]),
@@ -193,8 +192,8 @@ class BurgerEnv(BaseEnv):
         alt_goal = {
             GroundAtom(self._On, [patty, bottom_bun]),
             GroundAtom(self._On, [cheese, patty]),
-            GroundAtom(self._GoalHack, [bottom_bun, patty, cheese, tomato,
-                top_bun])
+            GroundAtom(self._GoalHack,
+                       [bottom_bun, patty, cheese, tomato, top_bun])
         }
 
         for _ in range(num):
@@ -308,7 +307,8 @@ class BurgerEnv(BaseEnv):
         return True
 
     def _GoalHack_holds(self, state: State, objects: Sequence[Object]) -> bool:
-        bottom, patty, cheese, tomato, top = objects
+        # bottom, patty, cheese, tomato, top = objects
+        bottom, patty, cheese, _, _ = objects
         atoms = [
             self._On_holds(state, [patty, bottom]),
             self._On_holds(state, [cheese, patty]),

--- a/predicators/envs/burger.py
+++ b/predicators/envs/burger.py
@@ -207,7 +207,7 @@ class BurgerEnv(BaseEnv):
                 state, DefaultEnvironmentTask)
             # Recall that a EnvironmentTask consists of an Observation and a
             # GoalDescription, both of whose types are Any.
-            tasks.append(EnvironmentTask(state, goal, _alt_goal_desc=alt_goal))
+            tasks.append(EnvironmentTask(state, goal, alt_goal_desc=alt_goal))
 
         return tasks
 

--- a/predicators/main.py
+++ b/predicators/main.py
@@ -317,7 +317,9 @@ def _generate_interaction_results(
 
 
 def _run_testing(env: BaseEnv, cogman: CogMan) -> Metrics:
-    test_tasks = [task.replace_goal_with_alt_goal() for task in env.get_test_tasks()]
+    test_tasks = [
+        task.replace_goal_with_alt_goal() for task in env.get_test_tasks()
+    ]
     num_found_policy = 0
     num_solved = 0
     cogman.reset_metrics()

--- a/predicators/main.py
+++ b/predicators/main.py
@@ -107,11 +107,21 @@ def main() -> None:
     # information in training.
     perceiver = create_perceiver(CFG.perceiver)
     train_tasks = [perceiver.reset(t) for t in env_train_tasks]
-    # If train tasks have goals that involve excluded predicates, strip those
-    # predicate classifiers to prevent leaking information to the approaches.
-    stripped_train_tasks = [
-        utils.strip_task(task, preds) for task in train_tasks
+    if CFG.strip_train_tasks:
+        # If train tasks have goals that involve excluded predicates, strip those
+        # predicate classifiers to prevent leaking information to the approaches.
+        stripped_train_tasks = [
+            utils.strip_task(task, preds) for task in train_tasks
+        ]
+    # If the goals of the tasks that the approaches solve need to be described
+    # using predicates that differ from those in the goals of the tasks that the
+    # demonstrator solves, then replace those predicates accordingly. This is
+    # used in VLM predicate invention where we want to invent certain goal
+    # predicates that the demonstrator needed to solve the task.
+    approach_train_tasks = [
+        task.replace_goal_with_alt_goal() for task in train_tasks
     ]
+
     if CFG.option_learner == "no_learning":
         # If we are not doing option learning, pass in all the environment's
         # oracle options.

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -50,7 +50,7 @@ class GlobalSettings:
     # there is no goal for the agent to plan towards. This is intended to be
     # used by VLM predicate invention, where we want to invent goal predicates
     # and different task goals are provided to the agent and the demonstrator.
-    allow_exclude_goal_predicates = True
+    allow_exclude_goal_predicates = False
 
     # cover_multistep_options env parameters
     cover_multistep_action_limits = [-np.inf, np.inf]

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -46,6 +46,8 @@ class GlobalSettings:
     # your call to utils.reset_config().
     render_state_dpi = 150
     approach_wrapper = None
+    allow_exclude_goal_predicates = True
+    strip_train_tasks = False
 
     # cover_multistep_options env parameters
     cover_multistep_action_limits = [-np.inf, np.inf]

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -46,8 +46,11 @@ class GlobalSettings:
     # your call to utils.reset_config().
     render_state_dpi = 150
     approach_wrapper = None
+    # Normally, excluding goal predicates does not make sense, because then
+    # there is no goal for the agent to plan towards. This is intended to be
+    # used by VLM predicate invention, where we want to invent goal predicates
+    # and different task goals are provided to the agent and the demonstrator.
     allow_exclude_goal_predicates = True
-    strip_train_tasks = False
 
     # cover_multistep_options env parameters
     cover_multistep_action_limits = [-np.inf, np.inf]

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -435,7 +435,7 @@ class Task:
     # of the task presented to the demonstrator. In these cases, we will store
     # an "alternative goal" in this field and replace the goal with the
     # alternative goal before giving the task to the agent.
-    alt_goal: Optional[Set[GroundAtom]] = frozenset()
+    alt_goal: Optional[Set[GroundAtom]] = field(default_factory=set)
 
     def __post_init__(self) -> None:
         # Verify types.
@@ -447,13 +447,15 @@ class Task:
         return all(goal_atom.holds(state) for goal_atom in self.goal)
 
     def replace_goal_with_alt_goal(self) -> Task:
-        """Return a Task with the goal replaced with the alternative goal if it exists."""
+        """Return a Task with the goal replaced with the alternative goal if it
+        exists."""
         # We may not want the agent to access the goal predicates given to the
         # demonstrator. To prevent leakage of this information, we discard the
         # original goal.
         if self.alt_goal:
-            return Task(self.init, goal=self.alt_goal, alt_goal=frozenset())
+            return Task(self.init, goal=self.alt_goal)
         return self
+
 
 DefaultTask = Task(DefaultState, set())
 
@@ -471,17 +473,23 @@ class EnvironmentTask:
     init_obs: Observation
     goal_description: GoalDescription
     # See Task._alt_goal for the reason for this field.
-    alt_goal_desc: Optional[GoalDescription] = None
+    alt_goal_desc: Optional[GoalDescription] = field(default=None)
 
     @cached_property
     def task(self) -> Task:
         """Convenience method for environment tasks that are fully observed."""
-        # If the environment task can be converted to a task, then alt_goal_desc
-        # will be a set. In the case where replace_goal_with_alt_goal() is
-        # called before a perceiver turns this environment task into a task,
-        # then alt_goal_desc will be an empty frozenset -- this happens in
-        # _run_testing() in main.py.
-        assert isinstance(self.alt_goal_desc, (set, frozenset))
+        # If the environment task's goal is replaced with the alternative goal
+        # before turning the environment task into a task, then there's nothing
+        # particular to set the task's alt_goal field to.
+        if self.alt_goal_desc is None:
+            return Task(self.init, self.goal)
+        # If we turn the environment task into a task before replacing the goal
+        # with the alternative goal, we have to set the task's alt_goal field
+        # accordingly to leave open the possibility of doing that replacement
+        # later.
+        # Assumption: we currently assume the alternative goal description is
+        # always a set of ground atoms.
+        assert isinstance(self.alt_goal_desc, set)
         for atom in self.alt_goal_desc:
             assert isinstance(atom, GroundAtom)
         return Task(self.init, self.goal, alt_goal=self.alt_goal_desc)
@@ -501,14 +509,17 @@ class EnvironmentTask:
         return self.goal_description
 
     def replace_goal_with_alt_goal(self) -> EnvironmentTask:
-        """Return an EnvironmentTask with the goal description replaced with the
-        alternative goal description if it exists.
+        """Return an EnvironmentTask with the goal description replaced with
+        the alternative goal description if it exists.
 
-        See Task.replace_goal_with_alt_goal for the reason for this function.
+        See Task.replace_goal_with_alt_goal for the reason for this
+        function.
         """
         if self.alt_goal_desc is not None:
-            return EnvironmentTask(self.init_obs, goal_description=self.alt_goal_desc, alt_goal_desc=frozenset())
+            return EnvironmentTask(self.init_obs,
+                                   goal_description=self.alt_goal_desc)
         return self
+
 
 DefaultEnvironmentTask = EnvironmentTask(DefaultState, set())
 

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -479,8 +479,9 @@ class EnvironmentTask:
     def task(self) -> Task:
         """Convenience method for environment tasks that are fully observed."""
         # If the environment task's goal is replaced with the alternative goal
-        # before turning the environment task into a task, then there's nothing
-        # particular to set the task's alt_goal field to.
+        # before turning the environment task into a task, or no alternative
+        # goal exists, then there's nothing particular to set the task's
+        # alt_goal field to.
         if self.alt_goal_desc is None:
             return Task(self.init, self.goal)
         # If we turn the environment task into a task before replacing the goal

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -3499,7 +3499,7 @@ def parse_config_excluded_predicates(
             }
             if CFG.offline_data_method != "demo+ground_atoms":
                 if CFG.allow_exclude_goal_predicates:
-                    if env.goal_predicates.issubset(included):
+                    if not env.goal_predicates.issubset(included):
                         logging.info("Note: excluding goal predicates!")
                 else:
                     assert env.goal_predicates.issubset(included), \

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -3500,7 +3500,7 @@ def parse_config_excluded_predicates(
             if CFG.offline_data_method != "demo+ground_atoms":
                 if CFG.allow_exclude_goal_predicates:
                     if env.goal_predicates.issubset(included):
-                        logging.info(f"Note: excluding goal predicates!")
+                        logging.info("Note: excluding goal predicates!")
                 else:
                     assert env.goal_predicates.issubset(included), \
                     "Can't exclude a goal predicate!"
@@ -3827,12 +3827,10 @@ def add_text_to_draw_img(
                            )  # Slightly larger than text
     background_size = (text_width + 10, text_height + 10)
     # Draw the background rectangle
-    draw.rectangle([
-        background_position,
-        (background_position[0] + background_size[0],
-         background_position[1] + background_size[1])
-    ],
-                   fill="black")
+    draw.rectangle(
+        (background_position, (background_position[0] + background_size[0],
+                               background_position[1] + background_size[1])),
+        fill="black")
     # Add the text to the image
     draw.text(position, text, fill="red", font=font)
     return draw

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -2199,15 +2199,13 @@ def strip_predicate(predicate: Predicate) -> Predicate:
 
 
 def strip_task(task: Task, included_predicates: Set[Predicate]) -> Task:
-    """Create a new task where any excluded predicates have their classifiers
-    removed."""
+    """Create a new task where any excluded goal predicates have their
+    classifiers removed."""
     stripped_goal: Set[GroundAtom] = set()
     for atom in task.goal:
-        # The atom's goal is known.
         if atom.predicate in included_predicates:
             stripped_goal.add(atom)
             continue
-        # The atom's goal is unknown.
         stripped_pred = strip_predicate(atom.predicate)
         stripped_atom = GroundAtom(stripped_pred, atom.objects)
         stripped_goal.add(stripped_atom)
@@ -3500,6 +3498,8 @@ def parse_config_excluded_predicates(
                 for pred in env.predicates if pred.name not in excluded_names
             }
             if CFG.offline_data_method != "demo+ground_atoms":
+                if CFG.allow_exclude_goal_predicates and not env.goal_predicates.issubset(included):
+                    logging.info(f"Note: excluding goal predicates!")
                 assert env.goal_predicates.issubset(included), \
                     "Can't exclude a goal predicate!"
     else:

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -2209,7 +2209,7 @@ def strip_task(task: Task, included_predicates: Set[Predicate]) -> Task:
         stripped_pred = strip_predicate(atom.predicate)
         stripped_atom = GroundAtom(stripped_pred, atom.objects)
         stripped_goal.add(stripped_atom)
-    return Task(task.init, stripped_goal)
+    return Task(task.init, stripped_goal, alt_goal=task.alt_goal)
 
 
 def create_vlm_predicate(
@@ -3498,9 +3498,11 @@ def parse_config_excluded_predicates(
                 for pred in env.predicates if pred.name not in excluded_names
             }
             if CFG.offline_data_method != "demo+ground_atoms":
-                if CFG.allow_exclude_goal_predicates and not env.goal_predicates.issubset(included):
-                    logging.info(f"Note: excluding goal predicates!")
-                assert env.goal_predicates.issubset(included), \
+                if CFG.allow_exclude_goal_predicates:
+                    if env.goal_predicates.issubset(included):
+                        logging.info(f"Note: excluding goal predicates!")
+                else:
+                    assert env.goal_predicates.issubset(included), \
                     "Can't exclude a goal predicate!"
     else:
         excluded_names = set()

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -10,7 +10,8 @@ from predicators.structs import NSRT, PNAD, Action, DefaultState, \
     InteractionRequest, InteractionResult, LDLRule, LiftedAtom, \
     LiftedDecisionList, LowLevelTrajectory, Macro, Object, \
     ParameterizedOption, Predicate, Query, Segment, State, STRIPSOperator, \
-    Task, Type, Variable, _Atom, _GroundNSRT, _GroundSTRIPSOperator, _Option
+    Task, Type, Variable, _Atom, _GroundNSRT, _GroundSTRIPSOperator, _Option, \
+    EnvironmentTask
 
 
 def test_object_type():
@@ -300,6 +301,31 @@ def test_task(state):
     assert task2.init.allclose(state)
     assert task2.goal == goal2
     assert not task2.goal_holds(task.init)
+    # Test replacing goal with alternative goal.
+    pred3 = Predicate("AlternativeOn", [cup_type, plate_type], lambda s, o: True)
+    goal3 = {pred3([cup, plate])}
+    task3 = Task(state, goal=goal, alt_goal=goal3)
+    alt_task = task3.replace_goal_with_alt_goal()
+    assert alt_task.goal == goal3
+
+
+def test_environment_task(state):
+    """Tests for EnvironmentTask class."""
+    # Test replacing goal with alternative goal.
+    cup_type = Type("cup_type", ["feat1"])
+    cup = cup_type("cup")
+    plate_type = Type("plate_type", ["feat1"])
+    plate = plate_type("plate")
+    pred = Predicate("On", [cup_type, plate_type], lambda s, o: True)
+    pred2 = Predicate("AlternativeOn", [cup_type, plate_type], lambda s, o: True)
+    goal = {pred([cup, plate])}
+    alt_goal = {pred2([cup, plate])}
+    env_task = EnvironmentTask(state, goal_description=goal, alt_goal_desc=alt_goal)
+    task = env_task.task
+    assert task.alt_goal == alt_goal
+    alt_env_task = env_task.replace_goal_with_alt_goal()
+    assert alt_env_task.goal_description == alt_goal
+    assert alt_env_task.alt_goal_desc is None
 
 
 def test_option(state):

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -6,12 +6,11 @@ from gym.spaces import Box
 
 from predicators import utils
 from predicators.structs import NSRT, PNAD, Action, DefaultState, \
-    DemonstrationQuery, DummyOption, GroundAtom, GroundMacro, \
-    InteractionRequest, InteractionResult, LDLRule, LiftedAtom, \
+    DemonstrationQuery, DummyOption, EnvironmentTask, GroundAtom, \
+    GroundMacro, InteractionRequest, InteractionResult, LDLRule, LiftedAtom, \
     LiftedDecisionList, LowLevelTrajectory, Macro, Object, \
     ParameterizedOption, Predicate, Query, Segment, State, STRIPSOperator, \
-    Task, Type, Variable, _Atom, _GroundNSRT, _GroundSTRIPSOperator, _Option, \
-    EnvironmentTask
+    Task, Type, Variable, _Atom, _GroundNSRT, _GroundSTRIPSOperator, _Option
 
 
 def test_object_type():
@@ -302,7 +301,8 @@ def test_task(state):
     assert task2.goal == goal2
     assert not task2.goal_holds(task.init)
     # Test replacing goal with alternative goal.
-    pred3 = Predicate("AlternativeOn", [cup_type, plate_type], lambda s, o: True)
+    pred3 = Predicate("AlternativeOn", [cup_type, plate_type],
+                      lambda s, o: True)
     goal3 = {pred3([cup, plate])}
     task3 = Task(state, goal=goal, alt_goal=goal3)
     alt_task = task3.replace_goal_with_alt_goal()
@@ -317,10 +317,13 @@ def test_environment_task(state):
     plate_type = Type("plate_type", ["feat1"])
     plate = plate_type("plate")
     pred = Predicate("On", [cup_type, plate_type], lambda s, o: True)
-    pred2 = Predicate("AlternativeOn", [cup_type, plate_type], lambda s, o: True)
+    pred2 = Predicate("AlternativeOn", [cup_type, plate_type],
+                      lambda s, o: True)
     goal = {pred([cup, plate])}
     alt_goal = {pred2([cup, plate])}
-    env_task = EnvironmentTask(state, goal_description=goal, alt_goal_desc=alt_goal)
+    env_task = EnvironmentTask(state,
+                               goal_description=goal,
+                               alt_goal_desc=alt_goal)
     task = env_task.task
     assert task.alt_goal == alt_goal
     alt_env_task = env_task.replace_goal_with_alt_goal()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2390,7 +2390,7 @@ def test_create_pddl():
                                           "spanner")
     assert domain_str == """(define (domain spanner)
   (:requirements :typing)
-  (:types
+  (:types 
     man nut spanner - locatable
     monkey
     locatable location - object)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1028,7 +1028,7 @@ def test_strip_task():
     """Test for strip_task()."""
     env = CoverEnv()
     Covers, Holding = _get_predicates_by_names("cover", ["Covers", "Holding"])
-    task = env.get_train_tasks()[0]
+    task = env.get_train_tasks()[0].task
     block0, _, _, target0, _ = list(task.init)
     # Goal is Covers(block0, target0)
     assert len(task.goal) == 1
@@ -2390,7 +2390,7 @@ def test_create_pddl():
                                           "spanner")
     assert domain_str == """(define (domain spanner)
   (:requirements :typing)
-  (:types 
+  (:types
     man nut spanner - locatable
     monkey
     locatable location - object)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3236,13 +3236,21 @@ def test_parse_config_excluded_predicates():
         "HandEmpty", "Holding", "IsBlock", "IsTarget"
     ]
     assert sorted(p.name for p in excluded) == ["Covers"]
-    # Cannot exclude goal predicates otherwise..
+    # Cannot exclude goal predicates.
     utils.reset_config({
         "offline_data_method": "demo",
         "excluded_predicates": "Covers",
     })
     with pytest.raises(AssertionError):
         utils.parse_config_excluded_predicates(env)
+    # Can exclude goal predicates if allowed per the settings.
+    utils.reset_config({
+        "offline_data_method": "demo",
+        "excluded_predicates": "Covers",
+        "allow_exclude_goal_predicates": True
+    })
+    included, excluded = utils.parse_config_excluded_predicates(env)
+    assert [p.name for p in excluded] == ["Covers"]
 
 
 def test_null_sampler():


### PR DESCRIPTION
### Background:
When doing VLM predicate invention, we may want to invent goal predicates. In this case, we need some alternative way to describe the goal for the agent than the normal goal predicates. One (slightly hacky?) thing we can do is have a new goal predicate that evaluates to True when all of the actual goal predicates evaluate to True. We can't also have the demonstrator use this new goal predicate as their goal, because the oracle operators are defined in terms of the original goal predicates. Rather than rewrite the oracle operators in terms of this hacky new goal predicate, it makes sense to instead provide a way for the tasks to be in terms of different goal predicates for the agent versus the demonstrator. 

Conceptually, this seems ok. The demonstrator solved some tasks with some goals in mind. There's no reason we can't take those same trajectories and give it to an agent to learn from, but frame it in terms of goals that are described a bit differently than what the demonstrator had in mind. 

### Code-changes:
Goals for tasks are specified in an environment's `_get_tasks()` function. The alternative goals need to be set inside that function as well, because otherwise we wouldn't know how to ground the new goal predicates. We add a new field to the `EnvironmentTask` and `Task` classes for an alternative goal that can be set inside `_get_tasks()`. Then, in `main.py`, we replace the goal with the alternative goal for all the tasks that are given to the approach. We don't do this replacing for the tasks that are passed to the demonstrator. 

### Impact:
After this change, in BurgerEnv–– if we exclude `IsCooked`, we propose and consistently accurately label `Cooked(patty)` as a VLM predicate, and then solve an actual test task (which at the moment is the same as the train task, but at lest we go through the motions of querying the VLM at each timestep at test time). This is the first successful demonstration of the entire pipeline in BurgerEnv. 

^ to get this result, you can run:
`python predicators/main.py --env burger --approach grammar_search_invention --seed 0 --num_train_tasks 1 --num_test_tasks 1 --bilevel_plan_without_sim True --offline_data_method demo_with_vlm_imgs --vlm_model_name gemini-1.5-pro-latest --segmenter every_step --grammar_search_vlm_atom_proposal_prompt_type options_labels_whole_traj --grammar_search_vlm_atom_label_prompt_type img_option_diffs_label_history --grammar_search_task_planning_timeout 10.0 --sesame_max_skeletons_optimized 200 --disable_harmlessness_check True --sesame_task_planner fdopt --excluded_predicates IsCooked --option_model_terminate_on_repeat False --grammar_search_vlm_atom_proposal_use_debug False --allow_exclude_goal_predicates True`



