### PR TITLE
Enable predicate invention with both geometric and VLM predicates

### DIFF
--- a/predicators/approaches/bridge_policy_approach.py
+++ b/predicators/approaches/bridge_policy_approach.py
@@ -288,7 +288,7 @@ class BridgePolicyApproach(OracleApproach):
                 states = [traj.states[0]]
                 atoms = atom_traj
             else:
-                states = utils.segment_trajectory_to_state_sequence(
+                states = utils.segment_trajectory_to_start_end_state_sequence(
                     segmented_traj)
                 atoms = utils.segment_trajectory_to_atoms_sequence(
                     segmented_traj)

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -1003,7 +1003,9 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
             atom_dataset, candidates = self._generate_atom_dataset_via_grammar(
                 dataset)
         elif CFG.offline_data_method == "geo_and_vlm":
-            pass
+            atom_dataset, candidates = self._generate_atom_dataset_via_grammar(
+                dataset)
+            import pdb; pdb.set_trace()
         else:
             # In this case, we're inventing over already-labelled atoms.
             atom_dataset, candidates = \

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -996,16 +996,19 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
         return (atom_dataset, candidates)
 
     def learn_from_offline_dataset(self, dataset: Dataset) -> None:
-        if not CFG.offline_data_method in [
+        if CFG.offline_data_method == "geo_and_vlm":
+            atom_dataset_from_grammar, candidates_from_grammar = \
+                self._generate_atom_dataset_via_grammar(dataset)
+            atom_dataset_from_vlm, candidates_from_vlm = \
+                self._parse_atom_dataset_from_annotated_dataset(dataset)
+            merged_atom_dataset = utils.merge_ground_atom_datasets(
+                atom_dataset_from_grammar, atom_dataset_from_vlm)
+        elif not CFG.offline_data_method in [
                 "demo+labelled_atoms", "saved_vlm_img_demos_folder",
                 "demo_with_vlm_imgs"
         ]:
             atom_dataset, candidates = self._generate_atom_dataset_via_grammar(
                 dataset)
-        elif CFG.offline_data_method == "geo_and_vlm":
-            atom_dataset, candidates = self._generate_atom_dataset_via_grammar(
-                dataset)
-            import pdb; pdb.set_trace()
         else:
             # In this case, we're inventing over already-labelled atoms.
             atom_dataset, candidates = \

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -1002,6 +1002,8 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
         ]:
             atom_dataset, candidates = self._generate_atom_dataset_via_grammar(
                 dataset)
+        elif CFG.offline_data_method == "geo_and_vlm":
+            pass
         else:
             # In this case, we're inventing over already-labelled atoms.
             atom_dataset, candidates = \

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -996,7 +996,10 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
         return (atom_dataset, candidates)
 
     def learn_from_offline_dataset(self, dataset: Dataset) -> None:
-        if CFG.offline_data_method == "geo_and_vlm":
+        if CFG.offline_data_method in [
+                "geo_and_demo_with_vlm_imgs", "geo_and_demo+labelled_atoms",
+                "geo_and_saved_vlm_img_demos_folder"
+        ]:
             atom_dataset_from_grammar, candidates_from_grammar = \
                 self._generate_atom_dataset_via_grammar(dataset)
             atom_dataset_from_vlm, candidates_from_vlm = \

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -790,7 +790,7 @@ class _PrunedGrammar(_DataBasedPredicateGrammar):
             for traj in self.dataset.trajectories:
                 # The init_atoms and final_atoms are not used.
                 seg_traj = segment_trajectory(traj, predicates=set())
-                state_seq = utils.segment_trajectory_to_start_end_state_sequence(
+                state_seq = utils.segment_trajectory_to_start_end_state_sequence(  # pylint:disable=line-too-long
                     seg_traj)
                 self._state_sequences.append(state_seq)
 

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -790,7 +790,7 @@ class _PrunedGrammar(_DataBasedPredicateGrammar):
             for traj in self.dataset.trajectories:
                 # The init_atoms and final_atoms are not used.
                 seg_traj = segment_trajectory(traj, predicates=set())
-                state_seq = utils.segment_trajectory_to_state_sequence(
+                state_seq = utils.segment_trajectory_to_start_end_state_sequence(
                     seg_traj)
                 self._state_sequences.append(state_seq)
 
@@ -1001,8 +1001,9 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
                 self._generate_atom_dataset_via_grammar(dataset)
             atom_dataset_from_vlm, candidates_from_vlm = \
                 self._parse_atom_dataset_from_annotated_dataset(dataset)
-            merged_atom_dataset = utils.merge_ground_atom_datasets(
+            atom_dataset = utils.merge_ground_atom_datasets(
                 atom_dataset_from_grammar, atom_dataset_from_vlm)
+            candidates = candidates_from_grammar | candidates_from_vlm
         elif not CFG.offline_data_method in [
                 "demo+labelled_atoms", "saved_vlm_img_demos_folder",
                 "demo_with_vlm_imgs"

--- a/predicators/datasets/__init__.py
+++ b/predicators/datasets/__init__.py
@@ -47,7 +47,7 @@ def create_dataset(env: BaseEnv, train_tasks: List[Task],
         return create_ground_atom_data(env, base_dataset, excluded_preds, n)
     if CFG.offline_data_method in [
             "demo_with_vlm_imgs", "geo_and_demo_with_vlm_imgs"
-    ]:
+    ]:  # pragma: no cover.
         # NOTE: this below method is tested separately; it's just that testing
         # it by calling the above function is painful because a VLM is
         # instantiated and called from inside this method, but when testing,
@@ -80,7 +80,7 @@ def create_dataset(env: BaseEnv, train_tasks: List[Task],
             env, train_tasks, known_options)
     if CFG.offline_data_method in [
             "saved_vlm_img_demos_folder", "geo_and_saved_vlm_img_demos_folder"
-    ]:
+    ]:  # pragma: no cover.
         # NOTE: this below method is tested separately; it's just that testing
         # it by calling the above function is painful because a VLM is
         # instantiated and called from inside this method, but when testing,

--- a/predicators/datasets/__init__.py
+++ b/predicators/datasets/__init__.py
@@ -45,7 +45,9 @@ def create_dataset(env: BaseEnv, train_tasks: List[Task],
         n = int(CFG.teacher_dataset_num_examples)
         assert n >= 1, "Must have at least 1 example of each predicate"
         return create_ground_atom_data(env, base_dataset, excluded_preds, n)
-    if CFG.offline_data_method in ["demo_with_vlm_imgs", "geo_and_vlm"]:  # pragma: no cover  # pylint:disable=line-too-long
+    if CFG.offline_data_method in [
+            "demo_with_vlm_imgs", "geo_and_demo_with_vlm_imgs"
+    ]:
         # NOTE: this below method is tested separately; it's just that testing
         # it by calling the above function is painful because a VLM is
         # instantiated and called from inside this method, but when testing,
@@ -71,10 +73,14 @@ def create_dataset(env: BaseEnv, train_tasks: List[Task],
         # a VLM.
         return create_ground_atom_data_from_generated_demos(
             demo_data, env, known_predicates, train_tasks)
-    if CFG.offline_data_method == "demo+labelled_atoms":
+    if CFG.offline_data_method in [
+            "demo+labelled_atoms", "geo_and_demo+labelled_atoms"
+    ]:
         return create_ground_atom_data_from_labelled_txt(
             env, train_tasks, known_options)
-    if CFG.offline_data_method == "saved_vlm_img_demos_folder":  # pragma: no cover  # pylint:disable=line-too-long
+    if CFG.offline_data_method in [
+            "saved_vlm_img_demos_folder", "geo_and_saved_vlm_img_demos_folder"
+    ]:
         # NOTE: this below method is tested separately; it's just that testing
         # it by calling the above function is painful because a VLM is
         # instantiated and called from inside this method, but when testing,

--- a/predicators/datasets/__init__.py
+++ b/predicators/datasets/__init__.py
@@ -45,7 +45,7 @@ def create_dataset(env: BaseEnv, train_tasks: List[Task],
         n = int(CFG.teacher_dataset_num_examples)
         assert n >= 1, "Must have at least 1 example of each predicate"
         return create_ground_atom_data(env, base_dataset, excluded_preds, n)
-    if CFG.offline_data_method == "demo_with_vlm_imgs":  # pragma: no cover  # pylint:disable=line-too-long
+    if CFG.offline_data_method in ["demo_with_vlm_imgs", "geo_and_vlm"]:  # pragma: no cover  # pylint:disable=line-too-long
         # NOTE: this below method is tested separately; it's just that testing
         # it by calling the above function is painful because a VLM is
         # instantiated and called from inside this method, but when testing,

--- a/predicators/envs/base_env.py
+++ b/predicators/envs/base_env.py
@@ -77,6 +77,16 @@ class BaseEnv(abc.ABC):
         raise NotImplementedError("Override me!")
 
     @property
+    def agent_goal_predicates(self) -> Set[Predicate]:
+        """Get the goal predicates that we want the agent to use, which may be
+        different than the ones the demonstrator uses.
+
+        This is used when inventing VLM predicates. Unless overridden, these are
+        the same as the original goal predicates.
+        """
+        return self.goal_predicates
+
+    @property
     @abc.abstractmethod
     def types(self) -> Set[Type]:
         """Get the set of types that are given with this environment."""

--- a/predicators/envs/base_env.py
+++ b/predicators/envs/base_env.py
@@ -81,8 +81,8 @@ class BaseEnv(abc.ABC):
         """Get the goal predicates that we want the agent to use, which may be
         different than the ones the demonstrator uses.
 
-        This is used when inventing VLM predicates. Unless overridden, these are
-        the same as the original goal predicates.
+        This is used when inventing VLM predicates. Unless overridden,
+        these are the same as the original goal predicates.
         """
         return self.goal_predicates
 

--- a/predicators/envs/burger.py
+++ b/predicators/envs/burger.py
@@ -349,6 +349,10 @@ class BurgerEnv(BaseEnv):
         # return {self._On, self._GoalHack}
 
     @property
+    def agent_goal_predicates(self) -> Set[Predicate]:
+        return {self._On, self._GoalHack}
+
+    @property
     def action_space(self) -> Box:
         # dx (column), dy (row), direction, cut/cook, pick/place
         # We expect dx and dy to be one of -1, 0, or 1.

--- a/predicators/main.py
+++ b/predicators/main.py
@@ -95,14 +95,16 @@ def main() -> None:
     # is often created during env __init__().
     env.action_space.seed(CFG.seed)
     assert env.goal_predicates.issubset(env.predicates)
-    preds, _ = utils.parse_config_excluded_predicates(env)
+    included_preds, excluded_preds = utils.parse_config_excluded_predicates(
+        env)
     # The known predicates are passed into the approach and into dataset
     # creation. In some cases, like when inventing geometric and VLM predicates,
     # we want to hide certain goal predicates from the agent by replacing them
     # with agent-specific goal predicates that the environment defines.
     # Note that inside dataset creation, the known predicates are only used to
     # create a VLM dataset, so we can just overwrite the variable `preds`.
-    preds = utils.replace_goals_with_agent_specific_goals(preds, env)
+    preds = utils.replace_goals_with_agent_specific_goals(
+        included_preds, excluded_preds, env)
     # Create the train tasks.
     env_train_tasks = env.get_train_tasks()
     # We assume that a train Task can be constructed from a EnvironmentTask.

--- a/predicators/main.py
+++ b/predicators/main.py
@@ -96,6 +96,13 @@ def main() -> None:
     env.action_space.seed(CFG.seed)
     assert env.goal_predicates.issubset(env.predicates)
     preds, _ = utils.parse_config_excluded_predicates(env)
+    # The known predicates are passed into the approach and into dataset
+    # creation. In some cases, like when inventing geometric and VLM predicates,
+    # we want to hide certain goal predicates from the agent by replacing them
+    # with agent-specific goal predicates that the environment defines.
+    # Note that inside dataset creation, the known predicates are only used to
+    # create a VLM dataset, so we can just overwrite the variable `preds`.
+    preds = utils.replace_goals_with_agent_specific_goals(preds, env)
     # Create the train tasks.
     env_train_tasks = env.get_train_tasks()
     # We assume that a train Task can be constructed from a EnvironmentTask.

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -350,6 +350,7 @@ class GlobalSettings:
     # burger env parameters
     gridworld_num_rows = 4
     gridworld_num_cols = 4
+    allow_state_allclose_comparison_with_simulator_state = True
 
     # parameters for random options approach
     random_options_max_tries = 100

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -51,6 +51,9 @@ class GlobalSettings:
     # used by VLM predicate invention, where we want to invent goal predicates
     # and different task goals are provided to the agent and the demonstrator.
     allow_exclude_goal_predicates = False
+    # Normally, State.allclose() raises an error if the simulator state of
+    # either of its arguments is not None.
+    allow_state_allclose_comparison_despite_simulator_state = False
 
     # cover_multistep_options env parameters
     cover_multistep_action_limits = [-np.inf, np.inf]
@@ -350,7 +353,6 @@ class GlobalSettings:
     # burger env parameters
     gridworld_num_rows = 4
     gridworld_num_cols = 4
-    allow_state_allclose_comparison_despite_simulator_state = True
 
     # parameters for random options approach
     random_options_max_tries = 100

--- a/predicators/settings.py
+++ b/predicators/settings.py
@@ -350,7 +350,7 @@ class GlobalSettings:
     # burger env parameters
     gridworld_num_rows = 4
     gridworld_num_cols = 4
-    allow_state_allclose_comparison_with_simulator_state = True
+    allow_state_allclose_comparison_despite_simulator_state = True
 
     # parameters for random options approach
     random_options_max_tries = 100

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -170,11 +170,13 @@ class State:
     def allclose(self, other: State) -> bool:
         """Return whether this state is close enough to another one, i.e., its
         objects are the same, and the features are close."""
-        if not CFG.allow_state_allclose_comparison_with_simulator_state:
-            if self.simulator_state is not None or \
-               other.simulator_state is not None:
+        if self.simulator_state is not None or other.simulator_state is not None:
+            if not CFG.allow_state_allclose_comparison_despite_simulator_state:
                 raise NotImplementedError("Cannot use allclose when "
                                           "simulator_state is not None.")
+            else:
+                if self.simulator_state != other.simulator_state:
+                    return False
         if not sorted(self.data) == sorted(other.data):
             return False
         for obj in self.data:

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -170,13 +170,13 @@ class State:
     def allclose(self, other: State) -> bool:
         """Return whether this state is close enough to another one, i.e., its
         objects are the same, and the features are close."""
-        if self.simulator_state is not None or other.simulator_state is not None:
+        if self.simulator_state is not None or \
+            other.simulator_state is not None:
             if not CFG.allow_state_allclose_comparison_despite_simulator_state:
                 raise NotImplementedError("Cannot use allclose when "
                                           "simulator_state is not None.")
-            else:
-                if self.simulator_state != other.simulator_state:
-                    return False
+            if self.simulator_state != other.simulator_state:
+                return False
         if not sorted(self.data) == sorted(other.data):
             return False
         for obj in self.data:

--- a/predicators/structs.py
+++ b/predicators/structs.py
@@ -170,10 +170,11 @@ class State:
     def allclose(self, other: State) -> bool:
         """Return whether this state is close enough to another one, i.e., its
         objects are the same, and the features are close."""
-        if self.simulator_state is not None or \
-           other.simulator_state is not None:
-            raise NotImplementedError("Cannot use allclose when "
-                                      "simulator_state is not None.")
+        if not CFG.allow_state_allclose_comparison_with_simulator_state:
+            if self.simulator_state is not None or \
+               other.simulator_state is not None:
+                raise NotImplementedError("Cannot use allclose when "
+                                          "simulator_state is not None.")
         if not sorted(self.data) == sorted(other.data):
             return False
         for obj in self.data:

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -149,7 +149,7 @@ def count_branching_factor(strips_ops: List[STRIPSOperator],
     return total_branching_factor
 
 
-def segment_trajectory_to_state_sequence(
+def segment_trajectory_to_start_end_state_sequence(
         seg_traj: List[Segment]) -> List[State]:
     """Convert a trajectory of segments into a trajectory of states, made up of
     only the initial/final states of the segments.

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -2723,11 +2723,11 @@ def merge_ground_atom_datasets(
     assert len(gad1) == len(
         gad2), "Ground atom datasets must be of the same length to merge them."
     merged_ground_atom_dataset = []
-    for i, gats in enumerate(zip(gad1, gad2)):
-        gat1, gat2 = gats  # ground atom trajectories
-        ll_traj1, ga_list1 = gat1
-        ll_traj2, ga_list2 = gat2
-        assert ll_traj1 == ll_traj2, "Ground atom trajectories must share the same low-level trajectory in order to merge them."
+    for ground_atom_traj1, ground_atom_traj2 in zip(gad1, gad2):
+        ll_traj1, ga_list1 = ground_atom_traj1
+        ll_traj2, ga_list2 = ground_atom_traj2
+        assert ll_traj1 == ll_traj2, "Ground atom trajectories must share " \
+            "the same low-level trajectory to be able to merge them."
         merged_ga_list = [ga1 | ga2 for ga1, ga2 in zip(ga_list1, ga_list2)]
         merged_ground_atom_dataset.append((ll_traj1, merged_ga_list))
     return merged_ground_atom_dataset

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -3529,11 +3529,14 @@ def parse_config_excluded_predicates(
     return included, excluded
 
 
-def replace_goals_with_agent_specific_goals(predicates: Set[Predicate],
-                                            env: BaseEnv) -> Set[Predicate]:
+def replace_goals_with_agent_specific_goals(
+        included_predicates: Set[Predicate],
+        excluded_predicates: Set[Predicate], env: BaseEnv) -> Set[Predicate]:
     """Replace original goal predicates with agent-specific goal predicates if
     the environment defines them."""
-    return predicates - env.goal_predicates | env.agent_goal_predicates
+    preds = included_predicates - env.goal_predicates \
+        | env.agent_goal_predicates - excluded_predicates
+    return preds
 
 
 def null_sampler(state: State, goal: Set[GroundAtom], rng: np.random.Generator,

--- a/predicators/utils.py
+++ b/predicators/utils.py
@@ -2715,11 +2715,13 @@ def save_ground_atom_dataset(ground_atom_dataset: List[GroundAtomTrajectory],
         pkl.dump(ground_atom_dataset_to_pkl, f)
 
 
-def merge_ground_atom_datasets(gad1: List[GroundAtomTrajectory], gad2: List[GroundAtomTrajectory]) -> List[GroundAtomTrajectory]:
+def merge_ground_atom_datasets(
+        gad1: List[GroundAtomTrajectory],
+        gad2: List[GroundAtomTrajectory]) -> List[GroundAtomTrajectory]:
     """Merges two ground atom datasets sharing the same underlying low-level
-    trajectory via the union of ground atoms at each state.
-    """
-    assert len(gad1) == len(gad2), "Ground atom datasets must be of the same length to merge them."
+    trajectory via the union of ground atoms at each state."""
+    assert len(gad1) == len(
+        gad2), "Ground atom datasets must be of the same length to merge them."
     merged_ground_atom_dataset = []
     for i, gats in enumerate(zip(gad1, gad2)):
         gat1, gat2 = gats  # ground atom trajectories
@@ -3526,11 +3528,13 @@ def parse_config_excluded_predicates(
     excluded = {pred for pred in env.predicates if pred.name in excluded_names}
     return included, excluded
 
-def replace_goals_with_agent_specific_goals(predicates: Set[Predicate], env: BaseEnv) -> Set[Predicate]:
+
+def replace_goals_with_agent_specific_goals(predicates: Set[Predicate],
+                                            env: BaseEnv) -> Set[Predicate]:
     """Replace original goal predicates with agent-specific goal predicates if
-    the environment defines them.
-    """
+    the environment defines them."""
     return predicates - env.goal_predicates | env.agent_goal_predicates
+
 
 def null_sampler(state: State, goal: Set[GroundAtom], rng: np.random.Generator,
                  objs: Sequence[Object]) -> Array:

--- a/tests/approaches/test_grammar_search_invention_approach.py
+++ b/tests/approaches/test_grammar_search_invention_approach.py
@@ -201,6 +201,46 @@ def test_invention_from_txt_file():
     assert approach._get_current_predicates() == env.goal_predicates  # pylint:disable=protected-access
 
 
+def test_geo_and_vlm_invention():
+    """Test constructing an atom dataset with both geo and vlm predicates."""
+    utils.reset_config({
+        "env":
+        "ice_tea_making",
+        "num_train_tasks":
+        1,
+        "num_test_tasks":
+        0,
+        "offline_data_method":
+        "geo_and_demo+labelled_atoms",
+        "data_dir":
+        "tests/datasets/mock_vlm_datasets",
+        "handmade_demo_filename":
+        "ice_tea_making__demo+labelled_atoms__manual__1.txt"
+    })
+    env = IceTeaMakingEnv()
+    train_tasks = env.get_train_tasks()
+    predicates, _ = utils.parse_config_excluded_predicates(env)
+    loaded_dataset = create_dataset(env, train_tasks,
+                                    get_gt_options(env.get_name()), predicates)
+    approach = GrammarSearchInventionApproach(env.goal_predicates,
+                                              get_gt_options(env.get_name()),
+                                              env.types, env.action_space,
+                                              train_tasks)
+    approach.learn_from_offline_dataset(loaded_dataset)
+    # The ice_tea_making__demo+labelled_atoms__manual__1.txt happens to
+    # set all atoms to True at all timesteps, and so we expect predicate
+    # invention to not select any of the predicates (only select the goal)
+    # predicates.
+    # If you investigate the atom_dataset created inside
+    # learn_from_offline_dataset() you'll see some grammar-based predicates
+    # invented that are based on the DummyGoal, but they don't get selected.
+    # A better test would alter the dataset such that some grammar-based
+    # predicates actually get selected, so we can verify that geo + vlm
+    # predicate invention works more explicitly.
+    assert len(approach._get_current_predicates()) == 1  # pylint:disable=protected-access
+    assert approach._get_current_predicates() == env.goal_predicates  # pylint:disable=protected-access
+
+
 def test_euclidean_grammar():
     """Tests for the EuclideanGrammar."""
     utils.reset_config({"env": "stick_button_move"})

--- a/tests/envs/test_burger.py
+++ b/tests/envs/test_burger.py
@@ -32,6 +32,7 @@ def test_burger():
             assert len(obj.type.feature_names) == len(task.init[obj])
     assert len(env.predicates) == 12
     assert len(env.goal_predicates) == 3
+    assert len(env.agent_goal_predicates) == 2
     assert env.get_name() == "burger"
     assert len(env.types) == 11
     options = get_gt_options(env.get_name())

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -184,6 +184,16 @@ obj9                11       12       13
     state_with_sim = State({}, "simulator_state")
     assert state_with_sim.simulator_state == "simulator_state"
     assert state.simulator_state is None
+
+    # Can use allclose with non-None simulator_state if explicitly allowed via
+    # settings.
+    utils.reset_config(
+        {"allow_state_allclose_comparison_despite_simulator_state": "True"})
+    state5 = state4.copy()
+    assert state4.allclose(state5)
+    state5.simulator_state = "not dummy"
+    assert not state4.allclose(state5)
+
     return state
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -103,7 +103,7 @@ def test_count_positives_for_ops(max_groundings, exp_num_true, exp_num_false):
 
 
 def test_segment_trajectory_to_state_and_atoms_sequence():
-    """Tests for segment_trajectory_to_state_sequence() and
+    """Tests for segment_trajectory_to_start_end_state_sequence() and
     segment_trajectory_to_atoms_sequence()."""
     # Set up the segments.
     cup_type = Type("cup_type", ["feat1"])
@@ -125,21 +125,21 @@ def test_segment_trajectory_to_state_and_atoms_sequence():
     final_atoms = {not_on([cup, plate])}
     segment1 = Segment(traj1, init_atoms, final_atoms)
     segment2 = Segment(traj2, final_atoms, init_atoms)
-    # Test segment_trajectory_to_state_sequence().
-    state_seq = utils.segment_trajectory_to_state_sequence([segment1])
+    # Test segment_trajectory_to_start_end_state_sequence().
+    state_seq = utils.segment_trajectory_to_start_end_state_sequence([segment1])
     assert state_seq == [state0, state2]
-    state_seq = utils.segment_trajectory_to_state_sequence(
+    state_seq = utils.segment_trajectory_to_start_end_state_sequence(
         [segment1, segment2])
     assert state_seq == [state0, state2, state0]
-    state_seq = utils.segment_trajectory_to_state_sequence(
+    state_seq = utils.segment_trajectory_to_start_end_state_sequence(
         [segment1, segment2, segment1, segment2])
     assert state_seq == [state0, state2, state0, state2, state0]
     with pytest.raises(AssertionError):
         # Need at least one segment in the trajectory.
-        utils.segment_trajectory_to_state_sequence([])
+        utils.segment_trajectory_to_start_end_state_sequence([])
     with pytest.raises(AssertionError):
         # Segments don't chain together correctly.
-        utils.segment_trajectory_to_state_sequence([segment1, segment1])
+        utils.segment_trajectory_to_start_end_state_sequence([segment1, segment1])
     # Test segment_trajectory_to_atoms_sequence().
     atoms_seq = utils.segment_trajectory_to_atoms_sequence([segment1])
     assert atoms_seq == [init_atoms, final_atoms]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -126,7 +126,8 @@ def test_segment_trajectory_to_state_and_atoms_sequence():
     segment1 = Segment(traj1, init_atoms, final_atoms)
     segment2 = Segment(traj2, final_atoms, init_atoms)
     # Test segment_trajectory_to_start_end_state_sequence().
-    state_seq = utils.segment_trajectory_to_start_end_state_sequence([segment1])
+    state_seq = utils.segment_trajectory_to_start_end_state_sequence(
+        [segment1])
     assert state_seq == [state0, state2]
     state_seq = utils.segment_trajectory_to_start_end_state_sequence(
         [segment1, segment2])
@@ -139,7 +140,8 @@ def test_segment_trajectory_to_state_and_atoms_sequence():
         utils.segment_trajectory_to_start_end_state_sequence([])
     with pytest.raises(AssertionError):
         # Segments don't chain together correctly.
-        utils.segment_trajectory_to_start_end_state_sequence([segment1, segment1])
+        utils.segment_trajectory_to_start_end_state_sequence(
+            [segment1, segment1])
     # Test segment_trajectory_to_atoms_sequence().
     atoms_seq = utils.segment_trajectory_to_atoms_sequence([segment1])
     assert atoms_seq == [init_atoms, final_atoms]


### PR DESCRIPTION
### Summary
This basically just calls both the method to generate predicates from a grammar and the method to generate predicates from a VLM and then combines the atom datasets produced by both. 

This does not yet work "well" in BurgerEnv yet because we don't get the predicates we want in the grammar (we'll have to tweak the grammar a bit, and also be careful about what predicates we include/exclude). But the pipeline works in that the atom datasets are combined properly into something with both geometric and VLM ground atoms.

An important change in this is that we now make it possible to replace goal predicates (e.g. goal predicates that we might expect the demonstrator to use) with agent-specific goal predicates -- which is relevant when we want the agent to invent the corresponding goal predicate that the demonstrator used. Before, this was partially done by making it so that tasks' goals could be reframed in terms of alternative goal predicates, but this PR also makes this happen for the predicates that get passed into an approach's initial/known predicates. 

### Tests
At the time of this writing, (2024-06-14), there is no coverage for `offline_data_method="demo_with_vlm_imgs"` and `offline_data_method="saved_vlm_img_demos_folder"` because a VLM would need to be instantiated and called and that would be slow (there's already a comment in the code about this) -- the current code tests this separately and ignores the coverage issue? 