### PR TITLE
Added CallPlanner action to RL_Bridge_Policy

### DIFF
--- a/predicators/approaches/bridge_policy_approach.py
+++ b/predicators/approaches/bridge_policy_approach.py
@@ -56,7 +56,7 @@ from predicators.nsrt_learning.segmentation import segment_trajectory
 from predicators.option_model import _OptionModelBase
 from predicators.settings import CFG
 from predicators.structs import NSRT, Action, Array, BridgeDataset, \
-    DefaultState, DemonstrationQuery, DemonstrationResponse, GroundAtom, \
+    DefaultState, DemonstrationQuery, DemonstrationResponse, \
     InteractionRequest, InteractionResult, LiftedAtom, LowLevelTrajectory, \
     Object, ParameterizedOption, Predicate, Query, State, Task, Type, \
     Variable, _GroundNSRT, _Option

--- a/predicators/approaches/bridge_policy_approach.py
+++ b/predicators/approaches/bridge_policy_approach.py
@@ -549,8 +549,6 @@ class RLBridgePolicyApproach(BridgePolicyApproach):
         # for efficiency.
         if not results:
             return None
-        all_states = []
-        all_actions = []
         policy_logs = self._policy_logs
         for i in range(len(results)):
             result = results[i]
@@ -568,8 +566,6 @@ class RLBridgePolicyApproach(BridgePolicyApproach):
             mapleq_states.append(result.states[-1])
             new_traj = LowLevelTrajectory(mapleq_states, mapleq_actions)
             self._trajs.append(new_traj)
-            all_states.extend(mapleq_states)
-            all_actions.extend(mapleq_actions)
             policy_logs = policy_logs[len(result.states) - 1:]
 
         self.mapleq.get_interaction_requests()

--- a/predicators/approaches/bridge_policy_approach.py
+++ b/predicators/approaches/bridge_policy_approach.py
@@ -375,7 +375,7 @@ class RLBridgePolicyApproach(BridgePolicyApproach):
             "CallPlanner",
             types=None,
             policy=self.call_planner_policy,
-            params_space=Box(0, len(train_tasks), (1, )),
+            params_space=Box(low=np.array([]), high=np.array([]), shape=(0,)),
         )
         initial_options.add(self.CallPlanner)
         self._initial_options = initial_options
@@ -405,7 +405,7 @@ class RLBridgePolicyApproach(BridgePolicyApproach):
         """policy for CallPlanner option."""
         self._current_control = "planner"
         # create a new task where the init state is our current state
-        current_task = Task(state, self._train_tasks[int(params[0])].goal)
+        current_task = Task(state, self._train_tasks[0].goal)
         option_policy = self._get_option_policy_by_planning(
             current_task, CFG.timeout)
         self._current_policy = utils.option_policy_to_policy(

--- a/predicators/approaches/bridge_policy_approach.py
+++ b/predicators/approaches/bridge_policy_approach.py
@@ -375,7 +375,7 @@ class RLBridgePolicyApproach(BridgePolicyApproach):
             "CallPlanner",
             types=None,
             policy=self.call_planner_policy,
-            params_space=Box(low=np.array([]), high=np.array([]), shape=(0,)),
+            params_space=Box(low=np.array([]), high=np.array([]), shape=(0, )),
         )
         initial_options.add(self.CallPlanner)
         self._initial_options = initial_options
@@ -401,7 +401,7 @@ class RLBridgePolicyApproach(BridgePolicyApproach):
         return False
 
     def call_planner_policy(self, state: State, _: Dict, __: Sequence[Object],
-                            params: Array) -> Action:
+                            ___: Array) -> Action:
         """policy for CallPlanner option."""
         self._current_control = "planner"
         # create a new task where the init state is our current state
@@ -498,8 +498,7 @@ class RLBridgePolicyApproach(BridgePolicyApproach):
                     self._policy_logs.append(self._current_control)
                 return action
             except utils.OptionExecutionFailure:
-                print("failed", self._current_control)
-
+                logging.debug(f"Failed control: {self._current_control}")
             # Switch control from planner to bridge.
             assert self._current_control == "planner"
             self._current_control = "bridge"

--- a/predicators/approaches/bridge_policy_approach.py
+++ b/predicators/approaches/bridge_policy_approach.py
@@ -553,6 +553,9 @@ class RLBridgePolicyApproach(BridgePolicyApproach):
         for i in range(len(results)):
             result = results[i]
             policy_log = policy_logs[:len(result.states[:-1])]
+            # We index max(j - 1, 0) to count for the case when CallPlanner
+            # is used, since "planner" is added to the corresponding policy_log.
+            # When j = 0, planner is always in control
             mapleq_states = [
                 state for j, state in enumerate(result.states[:-1])
                 if policy_log[j] == "bridge"

--- a/predicators/approaches/bridge_policy_approach.py
+++ b/predicators/approaches/bridge_policy_approach.py
@@ -42,8 +42,9 @@ Learned bridge policy in stick button:
 
 import logging
 import time
-from typing import Callable, List, Optional, Sequence, Set
+from typing import Callable, Dict, List, Optional, Sequence, Set
 
+import numpy as np
 from gym.spaces import Box
 
 from predicators import utils
@@ -54,11 +55,11 @@ from predicators.bridge_policies import BridgePolicyDone, create_bridge_policy
 from predicators.nsrt_learning.segmentation import segment_trajectory
 from predicators.option_model import _OptionModelBase
 from predicators.settings import CFG
-from predicators.structs import NSRT, Action, BridgeDataset, DefaultState, \
-    DemonstrationQuery, DemonstrationResponse, InteractionRequest, \
-    InteractionResult, LowLevelTrajectory, ParameterizedOption, Predicate, \
-    Query, State, Task, Type, _GroundNSRT, _Option
-from predicators.utils import OptionExecutionFailure
+from predicators.structs import NSRT, Action, Array, BridgeDataset, \
+    DefaultState, DemonstrationQuery, DemonstrationResponse, GroundAtom, \
+    InteractionRequest, InteractionResult, LiftedAtom, LowLevelTrajectory, \
+    Object, ParameterizedOption, Predicate, Query, State, Task, Type, \
+    Variable, _GroundNSRT, _Option
 
 
 class BridgePolicyApproach(OracleApproach):
@@ -129,7 +130,7 @@ class BridgePolicyApproach(OracleApproach):
             except BridgePolicyDone:
                 assert current_control == "bridge"
                 failed_option = None  # not used, but satisfy linting
-            except OptionExecutionFailure as e:
+            except utils.OptionExecutionFailure as e:
                 failed_option = e.info["last_failed_option"]
                 if failed_option is not None:
                     all_failed_options.append(failed_option)
@@ -180,7 +181,7 @@ class BridgePolicyApproach(OracleApproach):
             )
             try:
                 return current_policy(s)
-            except OptionExecutionFailure as e:
+            except utils.OptionExecutionFailure as e:
                 all_failed_options.append(e.info["last_failed_option"])
                 raise ApproachFailure(
                     e.args[0], info={"all_failed_options": all_failed_options})
@@ -239,7 +240,7 @@ class BridgePolicyApproach(OracleApproach):
                 reached_stuck_state = True
                 all_failed_options = e.info["all_failed_options"]
                 # Approach failures not caught in interaction loop.
-                raise OptionExecutionFailure(e.args[0], e.info)
+                raise utils.OptionExecutionFailure(e.args[0], e.info)
 
         def _termination_fn(s: State) -> bool:
             return reached_stuck_state or task.goal_holds(s)
@@ -365,10 +366,79 @@ class RLBridgePolicyApproach(BridgePolicyApproach):
                          action_space, train_tasks, task_planning_heuristic,
                          max_skeletons_optimized)
         self._maple_initialized = False
+        if task_planning_heuristic == "default":
+            task_planning_heuristic = CFG.sesame_task_planning_heuristic
+        self._task_planning_heuristic = task_planning_heuristic
         self._trajs: List[LowLevelTrajectory] = []
+        self.CanPlan = Predicate("CanPlan", [], self._Can_plan)
+        self.CallPlanner = utils.SingletonParameterizedOption(
+            "CallPlanner",
+            types=None,
+            policy=self.call_planner_policy,
+            params_space=Box(0, len(train_tasks), (1, )),
+        )
+        initial_options.add(self.CallPlanner)
+        self._initial_options = initial_options
         self.mapleq=MapleQApproach(self._get_current_predicates(), \
                                    self._initial_options, self._types, \
                                     self._action_space, self._train_tasks)
+        self._current_control = ""
+        option_policy = self._get_option_policy_by_planning(
+            self._train_tasks[0], CFG.timeout)
+        self._current_policy = utils.option_policy_to_policy(
+            option_policy,
+            max_option_steps=CFG.max_num_steps_option_rollout,
+            raise_error_on_repeated_state=True,
+        )
+        self._bridge_called_state = State(data={})
+        self._policy_logs: List[str] = []
+
+    def _Can_plan(self, state: State, _: Sequence[Object]) -> bool:
+        if (self.mapleq._q_function._vectorize_state(state) !=  # pylint: disable=protected-access
+                self.mapleq._q_function._vectorize_state(  # pylint: disable=protected-access
+                    self._bridge_called_state)).any():  # pylint: disable=protected-access
+            return True
+        return False
+
+    def call_planner_policy(self, state: State, _: Dict, __: Sequence[Object],
+                            params: Array) -> Action:
+        """policy for CallPlanner option."""
+        self._current_control = "planner"
+        # create a new task where the init state is our current state
+        current_task = Task(state, self._train_tasks[int(params[0])].goal)
+        option_policy = self._get_option_policy_by_planning(
+            current_task, CFG.timeout)
+        self._current_policy = utils.option_policy_to_policy(
+            option_policy,
+            max_option_steps=CFG.max_num_steps_option_rollout,
+            raise_error_on_repeated_state=True,
+        )
+
+        return Action(np.array([0.0, 0.0, 0.0], dtype=np.float32))
+
+    def call_planner_nsrt(self) -> NSRT:
+        """CallPlanner NSRT."""
+        parameters: Sequence[Variable] = []
+        option_vars = parameters
+        option = self.CallPlanner
+        preconditions = {LiftedAtom(self.CanPlan, [])}
+        add_effects: Set[LiftedAtom] = set()
+        delete_effects: Set[LiftedAtom] = set()
+
+        ignore_effects: Set[Predicate] = set()
+        call_planner_nsrt = NSRT("CallPlanner", parameters, preconditions,
+                                 add_effects, delete_effects, ignore_effects,
+                                 option, option_vars, self.planner_sampler)
+        return call_planner_nsrt
+
+    def planner_sampler(self, state: State, goal: Set[GroundAtom],
+                        rng: np.random.Generator,
+                        objs: Sequence[Object]) -> Array:
+        """sampler for CallPlanner Option."""
+        del state, goal, objs  # unused
+        # Note: just return a random value from -1 to 1
+        return np.array([rng.uniform(0, len(self._train_tasks))],
+                        dtype=np.float32)
 
     @classmethod
     def get_name(cls) -> str:
@@ -381,6 +451,8 @@ class RLBridgePolicyApproach(BridgePolicyApproach):
     def _init_nsrts(self) -> None:
         """Initializing nsrts for MAPLE Q."""
         nsrts = self._get_current_nsrts()
+        callplanner_nsrt = self.call_planner_nsrt()
+        nsrts.add(callplanner_nsrt)
         predicates = self._get_current_predicates()
         all_ground_nsrts: Set[_GroundNSRT] = set()
         if CFG.sesame_grounder == "naive":
@@ -410,6 +482,15 @@ class RLBridgePolicyApproach(BridgePolicyApproach):
                task: Task,
                timeout: int,
                train_or_test: str = "test") -> Callable[[State], Action]:
+        # Start by planning. Note that we cannot start with the bridge policy
+        # because the bridge policy takes as input the last failed NSRT.
+        self._current_control = "planner"
+        option_policy = self._get_option_policy_by_planning(task, timeout)
+        self._current_policy = utils.option_policy_to_policy(
+            option_policy,
+            max_option_steps=CFG.max_num_steps_option_rollout,
+            raise_error_on_repeated_state=True,
+        )
         if not self._maple_initialized:
             self.mapleq = MapleQApproach(self._get_current_predicates(),
                                          self._initial_options, self._types,
@@ -417,41 +498,33 @@ class RLBridgePolicyApproach(BridgePolicyApproach):
             self._maple_initialized = True
             self._init_nsrts()
 
-        # Start by planning. Note that we cannot start with the bridge policy
-        # because the bridge policy takes as input the last failed NSRT.
-        current_control = "planner"
-        option_policy = self._get_option_policy_by_planning(task, timeout)
-        current_policy = utils.option_policy_to_policy(
-            option_policy,
-            max_option_steps=CFG.max_num_steps_option_rollout,
-            raise_error_on_repeated_state=True,
-        )
-        all_failed_options: List[_Option] = []
-
         # Prevent infinite loops by detecting if the bridge policy is called
         # twice with the same state.
         last_bridge_policy_state = DefaultState
 
         def _policy(s: State) -> Action:
-            nonlocal current_control, current_policy, last_bridge_policy_state
+            nonlocal last_bridge_policy_state
 
             # Normal execution. Either keep executing the current option, or
             # switch to the next option if it has terminated.
             try:
-                action = current_policy(s)
+                action = self._current_policy(s)
+                if train_or_test == "train":
+                    self._policy_logs.append(self._current_control)
                 return action
-            except OptionExecutionFailure as e:
-                failed_option = e.info["last_failed_option"]
-                if failed_option is not None:
-                    all_failed_options.append(failed_option)
+            except utils.OptionExecutionFailure:
+                print("failed", self._current_control)
 
             # Switch control from planner to bridge.
-            assert current_control == "planner"
-            current_control = "bridge"
-
-            current_policy = self.mapleq._solve(  # pylint: disable=protected-access
+            assert self._current_control == "planner"
+            self._current_control = "bridge"
+            if train_or_test == "train":
+                self._policy_logs.append(self._current_control)
+            self._bridge_called_state = s
+            self._current_policy = self.mapleq._solve(  # pylint: disable=protected-access
                 task, timeout, train_or_test)
-            action = current_policy(s)
+            action = self._current_policy(s)
+
             return action
 
         return _policy
@@ -460,12 +533,20 @@ class RLBridgePolicyApproach(BridgePolicyApproach):
                                     train_task_idx: int) -> InteractionRequest:
         task = self._train_tasks[train_task_idx]
         policy = self._solve(task, timeout=CFG.timeout, train_or_test="train")
-
-        reached_stuck_state = False
-        all_failed_options = None
+        just_starting = True
 
         def _act_policy(s: State) -> Action:
-            nonlocal reached_stuck_state, all_failed_options
+            nonlocal just_starting
+            if just_starting:
+                self._current_control = "planner"
+                option_policy = self._get_option_policy_by_planning(
+                    task, CFG.timeout)
+                self._current_policy = utils.option_policy_to_policy(
+                    option_policy,
+                    max_option_steps=CFG.max_num_steps_option_rollout,
+                    raise_error_on_repeated_state=True,
+                )
+                just_starting = False
             return policy(s)
 
         def _termination_fn(s: State) -> bool:
@@ -486,13 +567,28 @@ class RLBridgePolicyApproach(BridgePolicyApproach):
             return None
         all_states = []
         all_actions = []
-
-        for result in results:
-            new_traj = LowLevelTrajectory(result.states, result.actions)
+        policy_logs = self._policy_logs
+        for i in range(len(results)):
+            result = results[i]
+            policy_log = policy_logs[:len(result.states[:-1])]
+            mapleq_states = [
+                state for j, state in enumerate(result.states[:-1])
+                if policy_log[j] == "bridge"
+                or policy_log[max(j - 1, 0)] == "bridge"
+            ]
+            mapleq_actions = [
+                action for j, action in enumerate(result.actions)
+                if policy_log[j] == "bridge"
+                or policy_log[max(j - 1, 0)] == "bridge"
+            ]
+            mapleq_states.append(result.states[-1])
+            new_traj = LowLevelTrajectory(mapleq_states, mapleq_actions)
             self._trajs.append(new_traj)
-            all_states.extend(result.states)
-            all_actions.extend(result.actions)
+            all_states.extend(mapleq_states)
+            all_actions.extend(mapleq_actions)
+            policy_logs = policy_logs[len(result.states) - 1:]
 
         self.mapleq.get_interaction_requests()
         self.mapleq._learn_nsrts(self._trajs, 0, [] * len(self._trajs))  # pylint: disable=protected-access
+        self._policy_logs = []
         return None

--- a/predicators/approaches/maple_q_approach.py
+++ b/predicators/approaches/maple_q_approach.py
@@ -124,6 +124,8 @@ class MapleQApproach(OnlineNSRTLearningApproach):
                 assert nsrt.option_vars == nsrt.parameters  # pragma: no cover.
         # On the first cycle, we need to register the ground NSRTs, goals, and
         # objects in the Q function so that it can define its inputs.
+        # Do not set grounding for rl_bridge_policy since it was set already
+        # in init_nsrts
         if not online_learning_cycle and CFG.approach != "rl_bridge_policy":
             all_ground_nsrts: Set[_GroundNSRT] = set()
             if CFG.sesame_grounder == "naive":

--- a/predicators/approaches/maple_q_approach.py
+++ b/predicators/approaches/maple_q_approach.py
@@ -124,35 +124,35 @@ class MapleQApproach(OnlineNSRTLearningApproach):
                 assert nsrt.option_vars == nsrt.parameters  # pragma: no cover.
         # On the first cycle, we need to register the ground NSRTs, goals, and
         # objects in the Q function so that it can define its inputs.
-        if not online_learning_cycle:
-            all_ground_nsrts: Set[_GroundNSRT] = set()
-            if CFG.sesame_grounder == "naive":
-                for nsrt in self._nsrts:
-                    all_objects = {
-                        o
-                        for t in self._train_tasks for o in t.init
-                    }
-                    all_ground_nsrts.update(
-                        utils.all_ground_nsrts(nsrt, all_objects))
-            elif CFG.sesame_grounder == "fd_translator":  # pragma: no cover
-                all_objects = set()
-                for t in self._train_tasks:
-                    curr_task_objects = set(t.init)
-                    curr_task_types = {o.type for o in t.init}
-                    curr_init_atoms = utils.abstract(
-                        t.init, self._get_current_predicates())
-                    all_ground_nsrts.update(
-                        utils.all_ground_nsrts_fd_translator(
-                            self._nsrts, curr_task_objects,
-                            self._get_current_predicates(), curr_task_types,
-                            curr_init_atoms, t.goal))
-                    all_objects.update(curr_task_objects)
-            else:  # pragma: no cover
-                raise ValueError(
-                    f"Unrecognized sesame_grounder: {CFG.sesame_grounder}")
-            goals = [t.goal for t in self._train_tasks]
-            self._q_function.set_grounding(all_objects, goals,
-                                           all_ground_nsrts)
+            if not online_learning_cycle:
+                all_ground_nsrts: Set[_GroundNSRT] = set()
+                if CFG.sesame_grounder == "naive":
+                    for nsrt in self._nsrts:
+                        all_objects = {
+                            o
+                            for t in self._train_tasks for o in t.init
+                        }
+                        all_ground_nsrts.update(
+                            utils.all_ground_nsrts(nsrt, all_objects))
+                elif CFG.sesame_grounder == "fd_translator":  # pragma: no cover
+                    all_objects = set()
+                    for t in self._train_tasks:
+                        curr_task_objects = set(t.init)
+                        curr_task_types = {o.type for o in t.init}
+                        curr_init_atoms = utils.abstract(
+                            t.init, self._get_current_predicates())
+                        all_ground_nsrts.update(
+                            utils.all_ground_nsrts_fd_translator(
+                                self._nsrts, curr_task_objects,
+                                self._get_current_predicates(), curr_task_types,
+                                curr_init_atoms, t.goal))
+                        all_objects.update(curr_task_objects)
+                else:  # pragma: no cover
+                    raise ValueError(
+                        f"Unrecognized sesame_grounder: {CFG.sesame_grounder}")
+                goals = [t.goal for t in self._train_tasks]
+                self._q_function.set_grounding(all_objects, goals,
+                                            all_ground_nsrts)
         # Update the data using the updated self._segmented_trajs.
         self._update_maple_data()
         # Re-learn Q function.

--- a/predicators/approaches/maple_q_approach.py
+++ b/predicators/approaches/maple_q_approach.py
@@ -113,7 +113,7 @@ class MapleQApproach(OnlineNSRTLearningApproach):
                      annotations: Optional[List[Any]]) -> None:
         # Start by learning NSRTs in the usual way.
         super()._learn_nsrts(trajectories, online_learning_cycle, annotations)
-        if CFG.approach == "active_sampler_learning":
+        if not online_learning_cycle and CFG.approach != "rl_bridge_policy":
             # Check the assumption that operators and options are 1:1.
             # This is just an implementation convenience.
             assert len({

--- a/predicators/approaches/maple_q_approach.py
+++ b/predicators/approaches/maple_q_approach.py
@@ -113,7 +113,7 @@ class MapleQApproach(OnlineNSRTLearningApproach):
                      annotations: Optional[List[Any]]) -> None:
         # Start by learning NSRTs in the usual way.
         super()._learn_nsrts(trajectories, online_learning_cycle, annotations)
-        if not online_learning_cycle and CFG.approach != "rl_bridge_policy":
+        if CFG.approach == "active_sampler_learning":
             # Check the assumption that operators and options are 1:1.
             # This is just an implementation convenience.
             assert len({
@@ -124,35 +124,35 @@ class MapleQApproach(OnlineNSRTLearningApproach):
                 assert nsrt.option_vars == nsrt.parameters  # pragma: no cover.
         # On the first cycle, we need to register the ground NSRTs, goals, and
         # objects in the Q function so that it can define its inputs.
-            if not online_learning_cycle:
-                all_ground_nsrts: Set[_GroundNSRT] = set()
-                if CFG.sesame_grounder == "naive":
-                    for nsrt in self._nsrts:
-                        all_objects = {
-                            o
-                            for t in self._train_tasks for o in t.init
-                        }
-                        all_ground_nsrts.update(
-                            utils.all_ground_nsrts(nsrt, all_objects))
-                elif CFG.sesame_grounder == "fd_translator":  # pragma: no cover
-                    all_objects = set()
-                    for t in self._train_tasks:
-                        curr_task_objects = set(t.init)
-                        curr_task_types = {o.type for o in t.init}
-                        curr_init_atoms = utils.abstract(
-                            t.init, self._get_current_predicates())
-                        all_ground_nsrts.update(
-                            utils.all_ground_nsrts_fd_translator(
-                                self._nsrts, curr_task_objects,
-                                self._get_current_predicates(), curr_task_types,
-                                curr_init_atoms, t.goal))
-                        all_objects.update(curr_task_objects)
-                else:  # pragma: no cover
-                    raise ValueError(
-                        f"Unrecognized sesame_grounder: {CFG.sesame_grounder}")
-                goals = [t.goal for t in self._train_tasks]
-                self._q_function.set_grounding(all_objects, goals,
-                                            all_ground_nsrts)
+        if not online_learning_cycle and CFG.approach != "rl_bridge_policy":
+            all_ground_nsrts: Set[_GroundNSRT] = set()
+            if CFG.sesame_grounder == "naive":
+                for nsrt in self._nsrts:
+                    all_objects = {
+                        o
+                        for t in self._train_tasks for o in t.init
+                    }
+                    all_ground_nsrts.update(
+                        utils.all_ground_nsrts(nsrt, all_objects))
+            elif CFG.sesame_grounder == "fd_translator":  # pragma: no cover
+                all_objects = set()
+                for t in self._train_tasks:
+                    curr_task_objects = set(t.init)
+                    curr_task_types = {o.type for o in t.init}
+                    curr_init_atoms = utils.abstract(
+                        t.init, self._get_current_predicates())
+                    all_ground_nsrts.update(
+                        utils.all_ground_nsrts_fd_translator(
+                            self._nsrts, curr_task_objects,
+                            self._get_current_predicates(), curr_task_types,
+                            curr_init_atoms, t.goal))
+                    all_objects.update(curr_task_objects)
+            else:  # pragma: no cover
+                raise ValueError(
+                    f"Unrecognized sesame_grounder: {CFG.sesame_grounder}")
+            goals = [t.goal for t in self._train_tasks]
+            self._q_function.set_grounding(all_objects, goals,
+                                        all_ground_nsrts)
         # Update the data using the updated self._segmented_trajs.
         self._update_maple_data()
         # Re-learn Q function.

--- a/predicators/approaches/maple_q_approach.py
+++ b/predicators/approaches/maple_q_approach.py
@@ -152,7 +152,7 @@ class MapleQApproach(OnlineNSRTLearningApproach):
                     f"Unrecognized sesame_grounder: {CFG.sesame_grounder}")
             goals = [t.goal for t in self._train_tasks]
             self._q_function.set_grounding(all_objects, goals,
-                                        all_ground_nsrts)
+                                           all_ground_nsrts)
         # Update the data using the updated self._segmented_trajs.
         self._update_maple_data()
         # Re-learn Q function.

--- a/predicators/explorers/maple_q_explorer.py
+++ b/predicators/explorers/maple_q_explorer.py
@@ -38,12 +38,12 @@ class MapleQExplorer(BaseExplorer):
     def _get_exploration_strategy(self, train_task_idx: int,
                                   timeout: int) -> ExplorationStrategy:
 
-        eps = CFG.active_sampler_learning_exploration_epsilon
         num_samples = CFG.active_sampler_learning_num_samples
         goal = self._train_tasks[train_task_idx].goal
 
         def _option_policy(state: State) -> _Option:
-            return self._q_function.get_option(state, goal, num_samples, eps)
+            return self._q_function.get_option(state, \
+                                               goal, num_samples, "train")
 
         policy = utils.option_policy_to_policy(
             _option_policy, max_option_steps=CFG.max_num_steps_option_rollout)

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -1542,7 +1542,6 @@ class MapleQFunction(MLPRegressor):
             and tuple(n.objects) == tuple(option.objects)
         ]
         assert len(matches) == 1
-
         # Create discrete part.
         discrete_vec = np.zeros(self._num_ground_nsrts)
         discrete_vec[matches[0]] = 1.0

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -1541,10 +1541,12 @@ class MapleQFunction(MLPRegressor):
             if n.option == option.parent
             and tuple(n.objects) == tuple(option.objects)
         ]
-        assert len(matches) == 1
+        # assert len(matches) == 1
+
         # Create discrete part.
         discrete_vec = np.zeros(self._num_ground_nsrts)
-        discrete_vec[matches[0]] = 1.0
+        if matches:
+            discrete_vec[matches[0]] = 1.0
         # Create continuous part.
         continuous_vec = np.zeros(self._max_num_params)
         continuous_vec[:len(option.params)] = option.params

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -1392,6 +1392,8 @@ class MapleQFunction(MLPRegressor):
                 state, num_samples_per_applicable_nsrt=1)
             # Note that this assumes that the output of sampling is completely
             # random, including in the order of ground NSRTs.
+            if self._use_epsilon_annealing:
+                self.decay_epsilon()
             return options[0]
         # Return the best option (approx argmax.)
         options = self._sample_applicable_options_from_state(

--- a/predicators/ml_models.py
+++ b/predicators/ml_models.py
@@ -1541,12 +1541,11 @@ class MapleQFunction(MLPRegressor):
             if n.option == option.parent
             and tuple(n.objects) == tuple(option.objects)
         ]
-        # assert len(matches) == 1
+        assert len(matches) == 1
 
         # Create discrete part.
         discrete_vec = np.zeros(self._num_ground_nsrts)
-        if matches:
-            discrete_vec[matches[0]] = 1.0
+        discrete_vec[matches[0]] = 1.0
         # Create continuous part.
         continuous_vec = np.zeros(self._max_num_params)
         continuous_vec[:len(option.params)] = option.params


### PR DESCRIPTION
A CallPlanner NSRT was added to RLBridgePolicyApproach, which does not change the low-level environment state but transfers control back to the planner. Bridge policy can use this NSRT to call the planner, allowing the method to resume online bilevel planning after the bridge policy is executed.