### PR TITLE
Bowen gnn

### DIFF
--- a/predicators/approaches/gnn_option_policy_approach.py
+++ b/predicators/approaches/gnn_option_policy_approach.py
@@ -201,10 +201,10 @@ class GNNOptionPolicyApproach(GNNApproach):
         # Keep trying until the timeout.
         tries: int = 0
         all_num_act: int = 0
+        total_num_act: int = 0
         while time.perf_counter() - start_time < timeout:
             tries += 1
-            if tries > 2:
-                all_num_act += total_num_act
+            all_num_act += total_num_act
             total_num_act = 0
             state = task.init
             plan: List[_Option] = []
@@ -248,12 +248,13 @@ class GNNOptionPolicyApproach(GNNApproach):
                     break
                 # If num_act is zero, that means that the option is stuck in
                 # the state, so we should break to avoid infinite loops.
-                if num_act == 0:
-                    break
-                total_num_act += num_act
                 # Break early if we have timed out.
+                total_num_act += num_act
                 if time.perf_counter() - start_time > timeout:
                     break
+                if num_act == 0:
+                    break
+        all_num_act += total_num_act
         print(f"Shooting: {all_num_act} actions with {tries} tries in \
               {time.perf_counter() - start_time} seconds")
         raise ApproachTimeout("Shooting timed out!")

--- a/predicators/approaches/gnn_option_policy_approach.py
+++ b/predicators/approaches/gnn_option_policy_approach.py
@@ -199,7 +199,12 @@ class GNNOptionPolicyApproach(GNNApproach):
         start_time = time.perf_counter()
         memory: Dict = {}  # optionally updated by predict()
         # Keep trying until the timeout.
+        tries = 0
+        all_num_act = 0
         while time.perf_counter() - start_time < timeout:
+            tries += 1
+            if tries > 2:
+                all_num_act += total_num_act
             total_num_act = 0
             state = task.init
             plan: List[_Option] = []
@@ -247,6 +252,7 @@ class GNNOptionPolicyApproach(GNNApproach):
                     break
                 total_num_act += num_act
                 # Break early if we have timed out.
-                if time.perf_counter() - start_time < timeout:
+                if time.perf_counter() - start_time > timeout:
                     break
+        print(f"Shooting: {all_num_act} actions with {tries} tries in {time.perf_counter() - start_time} seconds")
         raise ApproachTimeout("Shooting timed out!")

--- a/predicators/approaches/gnn_option_policy_approach.py
+++ b/predicators/approaches/gnn_option_policy_approach.py
@@ -199,8 +199,8 @@ class GNNOptionPolicyApproach(GNNApproach):
         start_time = time.perf_counter()
         memory: Dict = {}  # optionally updated by predict()
         # Keep trying until the timeout.
-        tries = 0
-        all_num_act = 0
+        tries: int = 0
+        all_num_act: int = 0
         while time.perf_counter() - start_time < timeout:
             tries += 1
             if tries > 2:

--- a/predicators/approaches/gnn_option_policy_approach.py
+++ b/predicators/approaches/gnn_option_policy_approach.py
@@ -254,5 +254,6 @@ class GNNOptionPolicyApproach(GNNApproach):
                 # Break early if we have timed out.
                 if time.perf_counter() - start_time > timeout:
                     break
-        print(f"Shooting: {all_num_act} actions with {tries} tries in {time.perf_counter() - start_time} seconds")
+        print(f"Shooting: {all_num_act} actions with {tries} tries in \
+              {time.perf_counter() - start_time} seconds")
         raise ApproachTimeout("Shooting timed out!")


### PR DESCRIPTION
Hi Tom and Nishanth,
Following your suggestions, This PR only changes:
- The GNN-shooting methods, `predicators/approaches/gnn_option_policy_approach.py`, in every try of shooting, we break when the time `>` timeout. Previously it was `<`, so that only the last try is effective, all previous tries will only shoot one action.

Another small note is that:
```
                if time.perf_counter() - start_time > timeout:
                    break
```
Needs to happen before:
```
                if num_act == 0:
                    break
```
Otherwise, the `test_gnn_option_policy_approach_special_cases()` won't cover the timeout break.

Please review, thanks.
I'll proceed with the satellite-markov env once this is passed and merged.