### PR TITLE
Fix burger agent goals towards getting an 'end-to-end' result

### DIFF
--- a/predicators/envs/burger.py
+++ b/predicators/envs/burger.py
@@ -1503,14 +1503,14 @@ class BurgerNoMoveEnv(BurgerEnv):
     @property
     def agent_goal_predicates(self) -> Set[Predicate]:
         preds_by_task_type = {
-            "more_stacks": {self._On, self._OnGround, self._GoalHack2},
+            "more_stacks": {self._On, self._OnGround, self._GoalHack2, self._Clear, self._Holding},
             "fatter_burger": {
                 self._On, self._OnGround, self._GoalHack2, self._GoalHack5,
-                self._GoalHack6, self._GoalHack7
+                self._GoalHack6, self._GoalHack7, self._Clear, self._Holding,
             },
             "combo_burger": {
                 self._On, self._OnGround, self._GoalHack2, self._GoalHack3,
-                self._GoalHack4
+                self._GoalHack4, self._Clear, self._Holding
             }
         }
         return preds_by_task_type[CFG.burger_no_move_task_type]

--- a/predicators/envs/burger.py
+++ b/predicators/envs/burger.py
@@ -1501,10 +1501,6 @@ class BurgerNoMoveEnv(BurgerEnv):
         }
 
     @property
-    def goal_predicates(self) -> Set[Predicate]:
-        return {self._On, self._OnGround, self._IsCooked, self._IsSliced}
-
-    @property
     def agent_goal_predicates(self) -> Set[Predicate]:
         preds_by_task_type = {
             "more_stacks": {self._On, self._OnGround, self._GoalHack2},
@@ -1518,6 +1514,10 @@ class BurgerNoMoveEnv(BurgerEnv):
             }
         }
         return preds_by_task_type[CFG.burger_no_move_task_type]
+    
+    @property
+    def goal_predicates(self) -> Set[Predicate]:
+        return self.agent_goal_predicates
 
     def get_vlm_debug_atom_strs(self,
                                 train_tasks: List[Task]) -> List[List[str]]:

--- a/predicators/envs/burger.py
+++ b/predicators/envs/burger.py
@@ -1503,10 +1503,19 @@ class BurgerNoMoveEnv(BurgerEnv):
     @property
     def agent_goal_predicates(self) -> Set[Predicate]:
         preds_by_task_type = {
-            "more_stacks": {self._On, self._OnGround, self._GoalHack2, self._Clear, self._Holding},
+            "more_stacks": {
+                self._On, self._OnGround, self._GoalHack2, self._Clear,
+                self._Holding
+            },
             "fatter_burger": {
-                self._On, self._OnGround, self._GoalHack2, self._GoalHack5,
-                self._GoalHack6, self._GoalHack7, self._Clear, self._Holding,
+                self._On,
+                self._OnGround,
+                self._GoalHack2,
+                self._GoalHack5,
+                self._GoalHack6,
+                self._GoalHack7,
+                self._Clear,
+                self._Holding,
             },
             "combo_burger": {
                 self._On, self._OnGround, self._GoalHack2, self._GoalHack3,
@@ -1514,7 +1523,7 @@ class BurgerNoMoveEnv(BurgerEnv):
             }
         }
         return preds_by_task_type[CFG.burger_no_move_task_type]
-    
+
     @property
     def goal_predicates(self) -> Set[Predicate]:
         return self.agent_goal_predicates

--- a/tests/envs/test_burger.py
+++ b/tests/envs/test_burger.py
@@ -304,8 +304,8 @@ def test_burger_no_move():
     env = BurgerNoMoveEnv()
     task = env.get_test_tasks()[0]
     assert len(env.predicates) == 13
-    assert len(env.goal_predicates) == 4
-    assert len(env.agent_goal_predicates) == 5
+    assert len(env.goal_predicates) == 7
+    assert len(env.agent_goal_predicates) == 7
     assert len(env.get_vlm_debug_atom_strs([])) == 3
     rng = np.random.default_rng(0)
     assert len(env.get_edge_cells_for_object_placement(


### PR DESCRIPTION
Modifies agent goals, etc. such that we have an 'end-to-end' result in burger for the first time!

```
python predicators/main.py --env burger_no_move --approach grammar_search_invention --seed 0 --num_train_tasks 8 --num_test_tasks 3 --bilevel_plan_without_sim True --offline_data_method geo_and_demo_with_vlm_imgs --vlm_model_name gpt-4o --segmenter option_changes --grammar_search_vlm_atom_proposal_prompt_type options_labels_whole_traj_diverse --grammar_search_vlm_atom_label_prompt_type img_option_diffs_label_history_burger --grammar_search_task_planning_timeout 10.0 --sesame_max_skeletons_optimized 200 --disable_harmlessness_check True --sesame_task_planner fdopt --excluded_predicates all --option_model_terminate_on_repeat False --grammar_search_vlm_atom_proposal_use_debug False --allow_exclude_goal_predicates True --grammar_search_prune_redundant_preds True --grammar_search_predicate_cost_upper_bound 7 --allow_state_allclose_comparison_despite_simulator_state True --grammar_search_max_predicates 200 --grammar_search_parallelize_vlm_labeling True --grammar_search_use_handcoded_debug_grammar False --grammar_search_select_all_debug False --bilevel_plan_without_sim True --cluster_and_intersect_soft_intersection_for_preconditions True --vlm_include_cropped_images True --timeout 80 --grammar_search_vlm_atom_proposal_use_debug False --burger_no_move_task_type "more_stacks" --grammar_search_grammar_includes_givens False  --cluster_and_intersect_prune_low_data_pnads True --cluster_and_intersect_min_datastore_fraction 0.2
```