### PR TITLE
Gets `--load_approach` to work for grammar search invention

### DIFF
--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -13,6 +13,7 @@ from operator import le
 from typing import Any, Callable, Dict, FrozenSet, Iterator, List, Optional, \
     Sequence, Set, Tuple
 
+import dill as pkl
 import numpy as np
 from gym.spaces import Box
 from scipy.stats import kstest
@@ -943,6 +944,12 @@ class GrammarSearchInventionApproach(NSRTLearningApproach):
     @classmethod
     def get_name(cls) -> str:
         return "grammar_search_invention"
+
+    def load(self, online_learning_cycle: Optional[int]) -> None:
+        super().load(online_learning_cycle)
+        preds, _ = utils.extract_preds_and_types(self._nsrts)
+        self._learned_predicates = set(
+            preds.values()) - self._initial_predicates
 
     def _get_current_predicates(self) -> Set[Predicate]:
         return self._initial_predicates | self._learned_predicates

--- a/predicators/approaches/grammar_search_invention_approach.py
+++ b/predicators/approaches/grammar_search_invention_approach.py
@@ -13,7 +13,6 @@ from operator import le
 from typing import Any, Callable, Dict, FrozenSet, Iterator, List, Optional, \
     Sequence, Set, Tuple
 
-import dill as pkl
 import numpy as np
 from gym.spaces import Box
 from scipy.stats import kstest


### PR DESCRIPTION
Previously, the `--load_approach` flag was broken for grammar search invention. This is because the `_learned_predicates` was not being set: we just needed to do that.